### PR TITLE
Add per-agent LLM configuration support

### DIFF
--- a/src/aise/agents/architect.py
+++ b/src/aise/agents/architect.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from ..config import ModelConfig
 from ..core.agent import Agent, AgentRole
 from ..core.artifact import ArtifactStore
 from ..core.message import MessageBus
@@ -16,12 +17,18 @@ from ..skills.architect import (
 class ArchitectAgent(Agent):
     """Agent responsible for system architecture, API design, and technical review."""
 
-    def __init__(self, message_bus: MessageBus, artifact_store: ArtifactStore) -> None:
+    def __init__(
+        self,
+        message_bus: MessageBus,
+        artifact_store: ArtifactStore,
+        model_config: ModelConfig | None = None,
+    ) -> None:
         super().__init__(
             name="architect",
             role=AgentRole.ARCHITECT,
             message_bus=message_bus,
             artifact_store=artifact_store,
+            model_config=model_config,
         )
         self.register_skill(SystemDesignSkill())
         self.register_skill(APIDesignSkill())

--- a/src/aise/agents/developer.py
+++ b/src/aise/agents/developer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from ..config import ModelConfig
 from ..core.agent import Agent, AgentRole
 from ..core.artifact import ArtifactStore
 from ..core.message import MessageBus
@@ -16,12 +17,18 @@ from ..skills.developer import (
 class DeveloperAgent(Agent):
     """Agent responsible for code implementation, testing, and bug fixing."""
 
-    def __init__(self, message_bus: MessageBus, artifact_store: ArtifactStore) -> None:
+    def __init__(
+        self,
+        message_bus: MessageBus,
+        artifact_store: ArtifactStore,
+        model_config: ModelConfig | None = None,
+    ) -> None:
         super().__init__(
             name="developer",
             role=AgentRole.DEVELOPER,
             message_bus=message_bus,
             artifact_store=artifact_store,
+            model_config=model_config,
         )
         self.register_skill(CodeGenerationSkill())
         self.register_skill(UnitTestWritingSkill())

--- a/src/aise/agents/product_manager.py
+++ b/src/aise/agents/product_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from ..config import ModelConfig
 from ..core.agent import Agent, AgentRole
 from ..core.artifact import ArtifactStore
 from ..core.message import MessageBus
@@ -16,12 +17,18 @@ from ..skills.pm import (
 class ProductManagerAgent(Agent):
     """Agent responsible for requirements analysis and product design."""
 
-    def __init__(self, message_bus: MessageBus, artifact_store: ArtifactStore) -> None:
+    def __init__(
+        self,
+        message_bus: MessageBus,
+        artifact_store: ArtifactStore,
+        model_config: ModelConfig | None = None,
+    ) -> None:
         super().__init__(
             name="product_manager",
             role=AgentRole.PRODUCT_MANAGER,
             message_bus=message_bus,
             artifact_store=artifact_store,
+            model_config=model_config,
         )
         self.register_skill(RequirementAnalysisSkill())
         self.register_skill(UserStoryWritingSkill())

--- a/src/aise/agents/qa_engineer.py
+++ b/src/aise/agents/qa_engineer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from ..config import ModelConfig
 from ..core.agent import Agent, AgentRole
 from ..core.artifact import ArtifactStore
 from ..core.message import MessageBus
@@ -16,12 +17,18 @@ from ..skills.qa import (
 class QAEngineerAgent(Agent):
     """Agent responsible for test planning, design, and automation."""
 
-    def __init__(self, message_bus: MessageBus, artifact_store: ArtifactStore) -> None:
+    def __init__(
+        self,
+        message_bus: MessageBus,
+        artifact_store: ArtifactStore,
+        model_config: ModelConfig | None = None,
+    ) -> None:
         super().__init__(
             name="qa_engineer",
             role=AgentRole.QA_ENGINEER,
             message_bus=message_bus,
             artifact_store=artifact_store,
+            model_config=model_config,
         )
         self.register_skill(TestPlanDesignSkill())
         self.register_skill(TestCaseDesignSkill())

--- a/src/aise/agents/team_lead.py
+++ b/src/aise/agents/team_lead.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from ..config import ModelConfig
 from ..core.agent import Agent, AgentRole
 from ..core.artifact import ArtifactStore
 from ..core.message import MessageBus
@@ -16,12 +17,18 @@ from ..skills.lead import (
 class TeamLeadAgent(Agent):
     """Agent responsible for workflow coordination, task assignment, and progress tracking."""
 
-    def __init__(self, message_bus: MessageBus, artifact_store: ArtifactStore) -> None:
+    def __init__(
+        self,
+        message_bus: MessageBus,
+        artifact_store: ArtifactStore,
+        model_config: ModelConfig | None = None,
+    ) -> None:
         super().__init__(
             name="team_lead",
             role=AgentRole.TEAM_LEAD,
             message_bus=message_bus,
             artifact_store=artifact_store,
+            model_config=model_config,
         )
         self.register_skill(TaskDecompositionSkill())
         self.register_skill(TaskAssignmentSkill())

--- a/src/aise/config.py
+++ b/src/aise/config.py
@@ -6,11 +6,30 @@ from dataclasses import dataclass, field
 
 
 @dataclass
+class ModelConfig:
+    """Configuration for an LLM provider and model.
+
+    Each agent can have its own provider, model, and tuning parameters,
+    allowing heterogeneous setups (e.g. GPT-4o for the architect,
+    Claude for the developer, a local Ollama model for QA).
+    """
+
+    provider: str = "openai"
+    model: str = "gpt-4o"
+    api_key: str = ""
+    base_url: str = ""
+    temperature: float = 0.7
+    max_tokens: int = 4096
+    extra: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass
 class AgentConfig:
     """Configuration for an individual agent."""
 
     name: str
     enabled: bool = True
+    model: ModelConfig = field(default_factory=ModelConfig)
 
 
 @dataclass
@@ -26,6 +45,7 @@ class ProjectConfig:
     """Top-level project configuration."""
 
     project_name: str = "Untitled Project"
+    default_model: ModelConfig = field(default_factory=ModelConfig)
     agents: dict[str, AgentConfig] = field(default_factory=lambda: {
         "product_manager": AgentConfig(name="product_manager"),
         "architect": AgentConfig(name="architect"),
@@ -34,3 +54,14 @@ class ProjectConfig:
         "team_lead": AgentConfig(name="team_lead"),
     })
     workflow: WorkflowConfig = field(default_factory=WorkflowConfig)
+
+    def get_model_config(self, agent_name: str) -> ModelConfig:
+        """Return the effective model config for an agent.
+
+        Uses the agent-specific config if it was explicitly set (differs
+        from defaults), otherwise falls back to the project-level default.
+        """
+        agent_cfg = self.agents.get(agent_name)
+        if agent_cfg is not None and agent_cfg.model != ModelConfig():
+            return agent_cfg.model
+        return self.default_model

--- a/src/aise/core/__init__.py
+++ b/src/aise/core/__init__.py
@@ -2,6 +2,7 @@
 
 from .agent import Agent, AgentRole
 from .artifact import Artifact, ArtifactType, ArtifactStore
+from .llm import LLMClient
 from .message import Message, MessageBus, MessageType
 from .skill import Skill
 from .workflow import Phase, Workflow, WorkflowEngine
@@ -12,6 +13,7 @@ __all__ = [
     "Artifact",
     "ArtifactStore",
     "ArtifactType",
+    "LLMClient",
     "Message",
     "MessageBus",
     "MessageType",

--- a/src/aise/core/llm.py
+++ b/src/aise/core/llm.py
@@ -1,0 +1,50 @@
+"""LLM client abstraction for provider-agnostic model access."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..config import ModelConfig
+
+
+class LLMClient:
+    """Thin wrapper that normalises access to different LLM providers.
+
+    This is intentionally *not* tied to any SDK so the core framework
+    stays dependency-free.  Concrete provider integrations can subclass
+    this or be injected via a factory.
+
+    The base implementation stores the resolved :class:`ModelConfig` and
+    exposes a :meth:`complete` method that subclasses override to call
+    the real API.
+    """
+
+    def __init__(self, config: ModelConfig) -> None:
+        self.config = config
+
+    @property
+    def provider(self) -> str:
+        return self.config.provider
+
+    @property
+    def model(self) -> str:
+        return self.config.model
+
+    def complete(
+        self,
+        messages: list[dict[str, str]],
+        **kwargs: Any,
+    ) -> str:
+        """Send a chat-completion request and return the assistant text.
+
+        Override in subclasses to call the real provider API.  The base
+        implementation returns a placeholder so the deterministic skills
+        keep working without an API key.
+        """
+        return ""
+
+    def __repr__(self) -> str:
+        return (
+            f"LLMClient(provider={self.config.provider!r}, "
+            f"model={self.config.model!r})"
+        )

--- a/src/aise/core/skill.py
+++ b/src/aise/core/skill.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .artifact import Artifact, ArtifactStore
+
+if TYPE_CHECKING:
+    from ..config import ModelConfig
+    from .llm import LLMClient
 
 
 @dataclass
@@ -16,6 +20,8 @@ class SkillContext:
     artifact_store: ArtifactStore
     project_name: str = ""
     parameters: dict[str, Any] = field(default_factory=dict)
+    model_config: ModelConfig | None = None
+    llm_client: LLMClient | None = None
 
 
 class Skill(ABC):
@@ -47,7 +53,7 @@ class Skill(ABC):
 
         Args:
             input_data: Input payload (e.g., raw requirements text, code to review).
-            context: Runtime context with access to artifact store and config.
+            context: Runtime context with access to artifact store, config, and LLM client.
 
         Returns:
             The produced artifact.

--- a/src/aise/main.py
+++ b/src/aise/main.py
@@ -30,11 +30,11 @@ def create_team(config: ProjectConfig | None = None) -> Orchestrator:
     store = orchestrator.artifact_store
 
     agents = [
-        ProductManagerAgent(bus, store),
-        ArchitectAgent(bus, store),
-        DeveloperAgent(bus, store),
-        QAEngineerAgent(bus, store),
-        TeamLeadAgent(bus, store),
+        ProductManagerAgent(bus, store, config.get_model_config("product_manager")),
+        ArchitectAgent(bus, store, config.get_model_config("architect")),
+        DeveloperAgent(bus, store, config.get_model_config("developer")),
+        QAEngineerAgent(bus, store, config.get_model_config("qa_engineer")),
+        TeamLeadAgent(bus, store, config.get_model_config("team_lead")),
     ]
 
     for agent in agents:

--- a/tests/test_core/test_model_config.py
+++ b/tests/test_core/test_model_config.py
@@ -1,0 +1,259 @@
+"""Tests for model configuration and per-agent LLM setup."""
+
+from typing import Any
+
+from aise.config import AgentConfig, ModelConfig, ProjectConfig
+from aise.core.agent import Agent, AgentRole
+from aise.core.artifact import Artifact, ArtifactStore, ArtifactType
+from aise.core.llm import LLMClient
+from aise.core.message import MessageBus
+from aise.core.skill import Skill, SkillContext
+from aise.agents import (
+    ArchitectAgent,
+    DeveloperAgent,
+    ProductManagerAgent,
+    QAEngineerAgent,
+    TeamLeadAgent,
+)
+from aise.main import create_team
+
+
+class EchoSkill(Skill):
+    @property
+    def name(self) -> str:
+        return "echo"
+
+    @property
+    def description(self) -> str:
+        return "Echoes input and records model info"
+
+    def execute(self, input_data: dict[str, Any], context: SkillContext) -> Artifact:
+        return Artifact(
+            artifact_type=ArtifactType.REQUIREMENTS,
+            content={
+                "input": input_data,
+                "has_model_config": context.model_config is not None,
+                "has_llm_client": context.llm_client is not None,
+                "provider": context.model_config.provider if context.model_config else None,
+                "model": context.model_config.model if context.model_config else None,
+            },
+            producer="test",
+        )
+
+
+class TestModelConfig:
+    def test_default_values(self):
+        cfg = ModelConfig()
+        assert cfg.provider == "openai"
+        assert cfg.model == "gpt-4o"
+        assert cfg.api_key == ""
+        assert cfg.base_url == ""
+        assert cfg.temperature == 0.7
+        assert cfg.max_tokens == 4096
+
+    def test_custom_values(self):
+        cfg = ModelConfig(
+            provider="anthropic",
+            model="claude-sonnet-4-20250514",
+            api_key="sk-test",
+            base_url="https://api.anthropic.com",
+            temperature=0.3,
+            max_tokens=8192,
+        )
+        assert cfg.provider == "anthropic"
+        assert cfg.model == "claude-sonnet-4-20250514"
+        assert cfg.api_key == "sk-test"
+        assert cfg.max_tokens == 8192
+
+    def test_extra_field(self):
+        cfg = ModelConfig(extra={"top_p": 0.9, "seed": 42})
+        assert cfg.extra["top_p"] == 0.9
+        assert cfg.extra["seed"] == 42
+
+    def test_equality(self):
+        a = ModelConfig()
+        b = ModelConfig()
+        assert a == b
+        c = ModelConfig(provider="anthropic")
+        assert a != c
+
+
+class TestAgentConfigWithModel:
+    def test_default_model(self):
+        cfg = AgentConfig(name="test")
+        assert cfg.model == ModelConfig()
+
+    def test_custom_model(self):
+        mc = ModelConfig(provider="anthropic", model="claude-sonnet-4-20250514")
+        cfg = AgentConfig(name="test", model=mc)
+        assert cfg.model.provider == "anthropic"
+
+
+class TestProjectConfigModelResolution:
+    def test_default_model_fallback(self):
+        default = ModelConfig(provider="anthropic", model="claude-sonnet-4-20250514")
+        config = ProjectConfig(default_model=default)
+        resolved = config.get_model_config("product_manager")
+        assert resolved.provider == "anthropic"
+        assert resolved.model == "claude-sonnet-4-20250514"
+
+    def test_agent_specific_override(self):
+        default = ModelConfig(provider="openai", model="gpt-4o")
+        agent_model = ModelConfig(provider="anthropic", model="claude-opus-4-20250514")
+        config = ProjectConfig(
+            default_model=default,
+            agents={
+                "developer": AgentConfig(name="developer", model=agent_model),
+                "architect": AgentConfig(name="architect"),
+            },
+        )
+        assert config.get_model_config("developer").provider == "anthropic"
+        assert config.get_model_config("architect").provider == "openai"
+
+    def test_unknown_agent_returns_default(self):
+        default = ModelConfig(provider="ollama", model="llama3")
+        config = ProjectConfig(default_model=default)
+        resolved = config.get_model_config("nonexistent")
+        assert resolved.provider == "ollama"
+
+
+class TestLLMClient:
+    def test_creation(self):
+        cfg = ModelConfig(provider="anthropic", model="claude-sonnet-4-20250514")
+        client = LLMClient(cfg)
+        assert client.provider == "anthropic"
+        assert client.model == "claude-sonnet-4-20250514"
+        assert client.config is cfg
+
+    def test_complete_returns_empty_string(self):
+        client = LLMClient(ModelConfig())
+        result = client.complete([{"role": "user", "content": "hello"}])
+        assert result == ""
+
+    def test_repr(self):
+        client = LLMClient(ModelConfig(provider="openai", model="gpt-4o"))
+        r = repr(client)
+        assert "openai" in r
+        assert "gpt-4o" in r
+
+
+class TestAgentWithModelConfig:
+    def test_agent_gets_default_config(self):
+        bus = MessageBus()
+        store = ArtifactStore()
+        agent = Agent("test", AgentRole.DEVELOPER, bus, store)
+        assert agent.model_config.provider == "openai"
+        assert agent.llm_client is not None
+
+    def test_agent_with_custom_config(self):
+        bus = MessageBus()
+        store = ArtifactStore()
+        cfg = ModelConfig(provider="anthropic", model="claude-sonnet-4-20250514")
+        agent = Agent("test", AgentRole.DEVELOPER, bus, store, model_config=cfg)
+        assert agent.model_config.provider == "anthropic"
+        assert agent.llm_client.provider == "anthropic"
+
+    def test_model_config_passed_to_skill_context(self):
+        bus = MessageBus()
+        store = ArtifactStore()
+        cfg = ModelConfig(provider="anthropic", model="claude-opus-4-20250514")
+        agent = Agent("test", AgentRole.DEVELOPER, bus, store, model_config=cfg)
+        agent.register_skill(EchoSkill())
+
+        artifact = agent.execute_skill("echo", {"x": 1})
+        assert artifact.content["has_model_config"] is True
+        assert artifact.content["has_llm_client"] is True
+        assert artifact.content["provider"] == "anthropic"
+        assert artifact.content["model"] == "claude-opus-4-20250514"
+
+    def test_repr_includes_model(self):
+        bus = MessageBus()
+        store = ArtifactStore()
+        cfg = ModelConfig(provider="ollama", model="llama3")
+        agent = Agent("test", AgentRole.DEVELOPER, bus, store, model_config=cfg)
+        r = repr(agent)
+        assert "ollama/llama3" in r
+
+
+class TestConcreteAgentsWithModelConfig:
+    def _bus_store(self):
+        bus = MessageBus()
+        store = ArtifactStore()
+        return bus, store
+
+    def test_product_manager_accepts_config(self):
+        bus, store = self._bus_store()
+        cfg = ModelConfig(provider="anthropic", model="claude-sonnet-4-20250514")
+        agent = ProductManagerAgent(bus, store, model_config=cfg)
+        assert agent.model_config.provider == "anthropic"
+
+    def test_architect_accepts_config(self):
+        bus, store = self._bus_store()
+        cfg = ModelConfig(provider="ollama", model="codellama")
+        agent = ArchitectAgent(bus, store, model_config=cfg)
+        assert agent.model_config.provider == "ollama"
+
+    def test_developer_accepts_config(self):
+        bus, store = self._bus_store()
+        cfg = ModelConfig(provider="openai", model="o1-preview")
+        agent = DeveloperAgent(bus, store, model_config=cfg)
+        assert agent.model_config.model == "o1-preview"
+
+    def test_qa_engineer_accepts_config(self):
+        bus, store = self._bus_store()
+        cfg = ModelConfig(provider="google", model="gemini-pro")
+        agent = QAEngineerAgent(bus, store, model_config=cfg)
+        assert agent.model_config.provider == "google"
+
+    def test_team_lead_accepts_config(self):
+        bus, store = self._bus_store()
+        cfg = ModelConfig(provider="mistral", model="mistral-large")
+        agent = TeamLeadAgent(bus, store, model_config=cfg)
+        assert agent.model_config.provider == "mistral"
+
+    def test_backward_compatible_without_config(self):
+        bus, store = self._bus_store()
+        agent = ProductManagerAgent(bus, store)
+        assert agent.model_config == ModelConfig()
+        assert len(agent.skill_names) == 4
+
+
+class TestCreateTeamWithModelConfig:
+    def test_create_team_default(self):
+        orchestrator = create_team()
+        for agent in orchestrator.agents.values():
+            assert agent.model_config == ModelConfig()
+
+    def test_create_team_with_project_default(self):
+        cfg = ProjectConfig(
+            default_model=ModelConfig(provider="anthropic", model="claude-sonnet-4-20250514"),
+        )
+        orchestrator = create_team(cfg)
+        for agent in orchestrator.agents.values():
+            assert agent.model_config.provider == "anthropic"
+
+    def test_create_team_mixed_providers(self):
+        cfg = ProjectConfig(
+            default_model=ModelConfig(provider="openai", model="gpt-4o"),
+            agents={
+                "product_manager": AgentConfig(name="product_manager"),
+                "architect": AgentConfig(
+                    name="architect",
+                    model=ModelConfig(provider="anthropic", model="claude-opus-4-20250514"),
+                ),
+                "developer": AgentConfig(
+                    name="developer",
+                    model=ModelConfig(provider="ollama", model="codellama"),
+                ),
+                "qa_engineer": AgentConfig(name="qa_engineer"),
+                "team_lead": AgentConfig(name="team_lead"),
+            },
+        )
+        orchestrator = create_team(cfg)
+        agents = orchestrator.agents
+
+        assert agents["product_manager"].model_config.provider == "openai"
+        assert agents["architect"].model_config.provider == "anthropic"
+        assert agents["developer"].model_config.provider == "ollama"
+        assert agents["qa_engineer"].model_config.provider == "openai"
+        assert agents["team_lead"].model_config.provider == "openai"


### PR DESCRIPTION
## Summary
This PR introduces flexible, per-agent LLM provider and model configuration, allowing heterogeneous setups where different agents can use different LLM providers and models (e.g., GPT-4o for the architect, Claude for the developer, a local Ollama model for QA).

## Key Changes

- **New `ModelConfig` dataclass** (`src/aise/config.py`): Encapsulates LLM provider settings including provider name, model identifier, API credentials, temperature, max tokens, and extra parameters.

- **Updated `AgentConfig`**: Now includes an optional `model` field to allow per-agent model overrides.

- **Updated `ProjectConfig`**: 
  - Added `default_model` field for project-wide LLM defaults
  - Added `get_model_config()` method that resolves the effective model config for an agent (agent-specific override takes precedence over project default)

- **New `LLMClient` class** (`src/aise/core/llm.py`): Provider-agnostic LLM client abstraction that stores resolved `ModelConfig` and exposes a `complete()` method for chat completions. Base implementation returns empty string to keep the framework dependency-free; concrete provider integrations can subclass or be injected.

- **Updated `Agent` base class**:
  - Constructor now accepts optional `model_config` parameter
  - Instantiates `LLMClient` from the provided config
  - Passes both `model_config` and `llm_client` to skill contexts
  - Updated `__repr__` to include provider/model information

- **Updated `SkillContext`**: Added `model_config` and `llm_client` fields so skills can access LLM capabilities.

- **Updated all concrete agent classes** (ProductManager, Architect, Developer, QA, TeamLead): Constructor signatures now accept optional `model_config` parameter and pass it to parent.

- **Updated `create_team()`** (`src/aise/main.py`): Agents are now instantiated with model configs resolved from the project configuration.

- **Comprehensive test suite** (`tests/test_core/test_model_config.py`): 259 lines of tests covering model config defaults, custom values, agent-specific overrides, LLM client creation, skill context injection, and end-to-end team creation scenarios.

## Implementation Details

- **Backward compatible**: All `model_config` parameters default to `None`, which triggers creation of a default `ModelConfig()`. Existing code without explicit config continues to work.
- **Dependency-free core**: The `LLMClient` base class has no external dependencies; provider-specific implementations are expected to be added separately.
- **Configuration precedence**: Agent-specific model configs override project defaults, which themselves override hardcoded defaults.
- **TYPE_CHECKING imports**: Used in `skill.py` to avoid circular imports while maintaining type hints.

https://claude.ai/code/session_01Hr5wxFC3pVxgQtVCDX1iKD