### PR TITLE
fix: remove invalid md_adapter parameter from AIPlanner.from_llm_client calls

### DIFF
--- a/src/aise/core/orchestrator.py
+++ b/src/aise/core/orchestrator.py
@@ -209,9 +209,9 @@ class Orchestrator:
         md_adapter = ProcessMdAdapter()
 
         if llm_client is not None:
-            planner = AIPlanner.from_llm_client(registry, llm_client, md_adapter=md_adapter)
+            planner = AIPlanner.from_llm_client(registry, llm_client)
         else:
-            planner = AIPlanner(registry=registry, md_adapter=md_adapter)
+            planner = AIPlanner(registry=registry)
 
         engine = DynamicEngine(registry, planner, self.artifact_store, project_root=self.project_root)
 

--- a/src/aise/core/orchestrator.py
+++ b/src/aise/core/orchestrator.py
@@ -197,16 +197,12 @@ class Orchestrator:
         """
         from .ai_planner import AIPlanner, PlannerContext
         from .dynamic_engine import DynamicEngine
-        from .process_md_adapter import ProcessMdAdapter
         from .process_registry import ProcessRegistry
 
         registry = ProcessRegistry.build_default()
 
         # Auto-discover skills from registered agents
         registry.auto_discover_from_agents(self._agents)
-
-        # Initialize MD adapter for process template support
-        md_adapter = ProcessMdAdapter()
 
         if llm_client is not None:
             planner = AIPlanner.from_llm_client(registry, llm_client)


### PR DESCRIPTION
Fixes TypeError when calling AIPlanner.from_llm_client with md_adapter parameter that doesn't exist in the method signature.