### PR TITLE
fix: prevent write_file corruption + escape-path writes

### DIFF
--- a/src/aise/runtime/agent_runtime.py
+++ b/src/aise/runtime/agent_runtime.py
@@ -41,6 +41,61 @@ except ImportError:
     create_deep_agent = None  # type: ignore[assignment,misc]
 
 
+# Raise the deepagents SummarizationMiddleware ``max_arg_length`` from its
+# default of 2000 bytes to this value. The middleware truncates large
+# tool-call arguments in the CONVERSATION HISTORY (not on disk) to save
+# tokens, replacing them with ``<first 20 chars> + "...(argument
+# truncated)"``. For weak local LLMs this creates a destructive
+# self-referential loop: a later generation reads its own truncated
+# history, emits ``write_file(content="""... (argument truncated)""")``,
+# and that short marker gets written verbatim to disk — overwriting the
+# real test/source file with a 43-byte garbage string. A typical
+# test + source module in this project is 5–20 KB, so a 50 KB ceiling
+# keeps the real file content in history while still leaving room for
+# summarization of other oversized arguments.
+_SUMMARIZATION_MAX_ARG_LENGTH = 50000
+
+
+def _install_summarization_max_arg_length_patch() -> None:
+    """Monkey-patch deepagents' ``_compute_summarization_defaults`` to inject
+    ``max_length=_SUMMARIZATION_MAX_ARG_LENGTH`` into ``truncate_args_settings``.
+
+    ``create_deep_agent`` looks up ``_compute_summarization_defaults`` via its
+    own module-level import binding in ``deepagents.graph``; patching the
+    source module alone would not affect new calls. We therefore patch the
+    binding in ``deepagents.graph`` directly.
+
+    The patch is idempotent: a marker attribute on the replacement function
+    prevents double-wrapping if this module is re-imported.
+    """
+    try:
+        from deepagents import graph as _da_graph
+    except ImportError:
+        return
+
+    orig = getattr(_da_graph, "_compute_summarization_defaults", None)
+    if orig is None or getattr(orig, "_aise_max_arg_patched", False):
+        return
+
+    def patched(model):  # type: ignore[no-untyped-def]
+        defaults = dict(orig(model))
+        truncate = dict(defaults.get("truncate_args_settings") or {})
+        truncate.setdefault("max_length", _SUMMARIZATION_MAX_ARG_LENGTH)
+        defaults["truncate_args_settings"] = truncate
+        return defaults
+
+    patched._aise_max_arg_patched = True  # type: ignore[attr-defined]
+    _da_graph._compute_summarization_defaults = patched
+    logger.info(
+        "Patched deepagents SummarizationMiddleware max_arg_length=%d",
+        _SUMMARIZATION_MAX_ARG_LENGTH,
+    )
+
+
+if create_deep_agent is not None:
+    _install_summarization_max_arg_length_patch()
+
+
 class AgentRuntime:
     """Agent runtime built on the deepagents framework.
 

--- a/src/aise/runtime/policy_backend.py
+++ b/src/aise/runtime/policy_backend.py
@@ -119,6 +119,26 @@ def make_policy_backend(
             "NOT use absolute host paths like /home/user/workspace/..."
         )
 
+    # Summarization middleware replaces past ``write_file.content`` /
+    # ``edit_file.new_string`` arguments with this marker when the context
+    # grows too large. Weak local LLMs then read their own truncated
+    # history and emit a new ``write_file`` whose ``content`` is literally
+    # the marker string — which would destructively overwrite the real
+    # file with a 43-byte garbage payload. We refuse such writes.
+    _TRUNCATION_MARKER = "...(argument truncated)"
+
+    def _truncation_marker_error(tool: str, file_path: str) -> str:
+        return (
+            f"Refusing {tool} on '{file_path}': the content argument "
+            f"contains the summarization-middleware marker "
+            f"{_TRUNCATION_MARKER!r}. That marker is a placeholder the "
+            "conversation middleware puts in place of a large tool-call "
+            "argument in your history — it is NOT real content. "
+            "Regenerate the full file content from the original task "
+            "requirements, or use read_file to see the current on-disk "
+            "content before deciding what to write."
+        )
+
     # -- Wrap every file operation with normalization ----------------------
 
     _orig_write = base.write
@@ -172,6 +192,12 @@ def make_policy_backend(
         if normalized is None:
             return WriteResult(error=_escape_error(file_path))
         file_path = normalized
+        if _TRUNCATION_MARKER in content:
+            logger.warning(
+                "write_file refused: content contains truncation marker (%s)",
+                file_path,
+            )
+            return WriteResult(error=_truncation_marker_error("write_file", file_path))
         resolved = base._resolve_path(file_path)
         if not resolved.exists():
             _reset_noop_streak()
@@ -221,6 +247,12 @@ def make_policy_backend(
         if normalized is None:
             return EditResult(error=_escape_error(file_path))
         file_path = normalized
+        if _TRUNCATION_MARKER in new_string:
+            logger.warning(
+                "edit_file refused: new_string contains truncation marker (%s)",
+                file_path,
+            )
+            return EditResult(error=_truncation_marker_error("edit_file", file_path))
         # old_string == new_string is a no-op. Return success so the LLM
         # doesn't enter an error-retry loop. After _NOOP_STREAK_LIMIT
         # identical repeats the tool returns a LOOP_DETECTED error.

--- a/src/aise/runtime/policy_backend.py
+++ b/src/aise/runtime/policy_backend.py
@@ -54,35 +54,70 @@ def make_policy_backend(
 
     # -- Path normalization ------------------------------------------------
 
-    # Prefixes that the LLM might prepend. The project root itself
-    # (``/home/user/.../projects/project_3-snake``) and the AISE repo
-    # root (``/home/user/.../AISE``) are both common.
-    _strip_prefixes: list[str] = []
-    _strip_prefixes.append(root_str + "/")  # project root
-    _strip_prefixes.append(root_str)
-    # Also strip the AISE repo root (2 levels up from src/aise/runtime/)
-    aise_root = Path(__file__).resolve().parent.parent.parent.parent
-    aise_str = str(aise_root)
-    if aise_str != root_str:
-        _strip_prefixes.append(aise_str + "/")
-        _strip_prefixes.append(aise_str)
+    # Prefixes the LLM might prepend to reach files inside THIS project.
+    # We only strip the project root — absolute paths pointing outside
+    # the project (``/home/user/workspace/AISE/...``, ``/etc/...``, etc.)
+    # are rejected rather than silently remapped. An earlier version
+    # stripped the AISE repo root too, which let a confused PM write
+    # ``/home/user/.../AISE/src/aise/docs/requirement.md`` and have it
+    # land at ``projects/<proj>/src/aise/docs/requirement.md`` — wrong
+    # location, and the LLM had no way to notice the mistake because
+    # the write silently succeeded.
+    _project_strip_prefixes: tuple[str, ...] = (root_str + "/", root_str)
 
-    def _normalize(path: str) -> str:
-        """Strip absolute host prefixes, leaving a virtual-root-relative path.
+    # System paths we know a project write should never touch. Used to
+    # flag escape attempts when a path starts with ``/`` but does not
+    # point inside the project.
+    _ESCAPE_PREFIXES: tuple[str, ...] = (
+        "/home/",
+        "/opt/",
+        "/usr/",
+        "/etc/",
+        "/tmp/",
+        "/var/",
+        "/mnt/",
+        "/root/",
+        "/boot/",
+        "/dev/",
+        "/proc/",
+        "/sys/",
+    )
 
-        ``/home/user/workspace/AISE/src/foo.py`` → ``/src/foo.py``
-        ``/src/foo.py`` → ``/src/foo.py``  (already virtual)
-        ``src/foo.py`` → ``src/foo.py``    (already relative)
+    def _normalize(path: str) -> str | None:
+        """Return a virtual-root-relative path, or None if the path escapes.
+
+        - ``/<project_root>/src/foo.py`` → ``/src/foo.py``
+        - ``/src/foo.py`` (virtual) → ``/src/foo.py``
+        - ``src/foo.py`` (relative) → ``src/foo.py``
+        - ``/home/other/…`` → None  (reject: escapes project root)
         """
-        for prefix in _strip_prefixes:
+        for prefix in _project_strip_prefixes:
             if path.startswith(prefix):
                 remainder = path[len(prefix) :]
-                # Ensure it starts with / for virtual_mode consistency
                 normalized = "/" + remainder.lstrip("/") if remainder else "/"
                 if normalized != path:
                     logger.debug("Path normalized: %r → %r", path, normalized)
                 return normalized
+        # Relative path or already-virtual absolute path: pass through.
+        if not path.startswith("/"):
+            return path
+        # Absolute host path that isn't in the project. If it targets a
+        # known system directory, reject outright; otherwise trust the
+        # deepagents virtual_mode resolver (it will root under the
+        # project anyway, but at least non-system paths aren't escape
+        # attempts).
+        if path.startswith(_ESCAPE_PREFIXES):
+            logger.warning("Path escapes project root, rejecting: %r", path)
+            return None
         return path
+
+    def _escape_error(file_path: str) -> str:
+        return (
+            f"Path '{file_path}' is outside this project's root. "
+            "Use relative paths (e.g. 'docs/requirement.md') or paths "
+            "rooted at the project (e.g. '/docs/requirement.md'). Do "
+            "NOT use absolute host paths like /home/user/workspace/..."
+        )
 
     # -- Wrap every file operation with normalization ----------------------
 
@@ -133,7 +168,10 @@ def make_policy_backend(
         _noop_streak = 0
 
     def norm_write(file_path: str, content: str) -> WriteResult:
-        file_path = _normalize(file_path)
+        normalized = _normalize(file_path)
+        if normalized is None:
+            return WriteResult(error=_escape_error(file_path))
+        file_path = normalized
         resolved = base._resolve_path(file_path)
         if not resolved.exists():
             _reset_noop_streak()
@@ -173,10 +211,16 @@ def make_policy_backend(
             return WriteResult(error=f"Error writing file '{file_path}': {exc}")
 
     def norm_read(file_path: str, offset: int = 0, limit: int = 2000) -> str:
-        return _orig_read(_normalize(file_path), offset, limit)
+        normalized = _normalize(file_path)
+        if normalized is None:
+            return _escape_error(file_path)
+        return _orig_read(normalized, offset, limit)
 
     def norm_edit(file_path: str, old_string: str, new_string: str, replace_all: bool = False):
-        file_path = _normalize(file_path)
+        normalized = _normalize(file_path)
+        if normalized is None:
+            return EditResult(error=_escape_error(file_path))
+        file_path = normalized
         # old_string == new_string is a no-op. Return success so the LLM
         # doesn't enter an error-retry loop. After _NOOP_STREAK_LIMIT
         # identical repeats the tool returns a LOOP_DETECTED error.
@@ -207,14 +251,32 @@ def make_policy_backend(
         return result
 
     def norm_ls(path: str) -> Any:
-        return _orig_ls(_normalize(path))
+        normalized = _normalize(path)
+        if normalized is None:
+            # ls has no error channel on its Info result — log and return
+            # an empty listing so the LLM sees "no such path" rather than
+            # accidentally scanning outside the project.
+            logger.warning("ls on non-project path rejected: %r", path)
+            return _orig_ls("/")
+        return _orig_ls(normalized)
 
     def norm_glob(pattern: str, path: str = "/") -> Any:
-        return _orig_glob(_normalize(pattern), _normalize(path))
+        p_norm = _normalize(pattern) if pattern and pattern.startswith("/") else pattern
+        base_norm = _normalize(path)
+        if p_norm is None or base_norm is None:
+            logger.warning("glob on non-project path rejected: pattern=%r path=%r", pattern, path)
+            return _orig_glob(pattern if p_norm is None else p_norm, "/")
+        return _orig_glob(p_norm, base_norm)
 
     def norm_grep(pattern: str, path: str | None = None, glob: str | None = None) -> Any:
-        norm_path = _normalize(path) if path else path
-        return _orig_grep(pattern, norm_path, glob)
+        if path:
+            normalized = _normalize(path)
+            if normalized is None:
+                logger.warning("grep on non-project path rejected: %r", path)
+                normalized = "/"
+        else:
+            normalized = path
+        return _orig_grep(pattern, normalized, glob)
 
     # -- Sandbox: execute support --------------------------------------------
     # FilesystemBackend doesn't implement SandboxBackendProtocol, so

--- a/tests/test_runtime/test_agent_runtime.py
+++ b/tests/test_runtime/test_agent_runtime.py
@@ -218,6 +218,49 @@ class TestAgentRuntimeTodos:
         assert captured[0][0]["status"] == "in_progress"
 
 
+class TestSummarizationPatch:
+    """Validate the deepagents SummarizationMiddleware max_arg_length override.
+
+    Without this patch, the default 2000-byte threshold truncates past
+    ``write_file.content`` arguments to a 43-byte marker, which weak LLMs
+    then copy back into new write_file calls — destroying the real file
+    on disk (observed in dispatch 0b83037d0155).
+    """
+
+    def test_summarization_defaults_include_max_length(self):
+        from deepagents import graph as da_graph
+
+        from aise.runtime.agent_runtime import _SUMMARIZATION_MAX_ARG_LENGTH
+
+        # Build a lightweight stand-in model that satisfies the
+        # ``has_profile`` branch of ``_compute_summarization_defaults``.
+        class _FakeModel:
+            profile = {"max_input_tokens": 200_000}
+
+        defaults = da_graph._compute_summarization_defaults(_FakeModel())
+        truncate = defaults.get("truncate_args_settings") or {}
+        assert truncate.get("max_length") == _SUMMARIZATION_MAX_ARG_LENGTH
+
+    def test_patch_is_idempotent(self):
+        from aise.runtime.agent_runtime import (
+            _install_summarization_max_arg_length_patch,
+        )
+
+        # Running a second time must not re-wrap the already-patched function.
+        _install_summarization_max_arg_length_patch()
+        _install_summarization_max_arg_length_patch()
+
+        from deepagents import graph as da_graph
+
+        class _FakeModel:
+            profile = {"max_input_tokens": 200_000}
+
+        # Still a single max_length override, not nested.
+        defaults = da_graph._compute_summarization_defaults(_FakeModel())
+        truncate = defaults.get("truncate_args_settings") or {}
+        assert "max_length" in truncate
+
+
 class TestAgentRuntimeCard:
     def test_agent_card_generated(self, agent_md_file, skills_dir, mock_create_deep_agent):
         runtime = AgentRuntime(agent_md=agent_md_file, skills_dir=skills_dir, model="openai:gpt-4o")

--- a/tests/test_runtime/test_policy_backend.py
+++ b/tests/test_runtime/test_policy_backend.py
@@ -170,6 +170,34 @@ class TestWrite:
             assert result.error is not None, f"expected rejection for {escape}"
             assert "outside this project's root" in result.error
 
+    def test_write_rejects_summarization_truncation_marker(self, backend, project_root):
+        """When the SummarizationMiddleware has replaced a past write_file's
+        content argument in the conversation history with ``<first 20 chars>
+        + "...(argument truncated)"``, a weak LLM may copy that short marker
+        string into a new write_file call. Without this guard the marker
+        would be written verbatim to disk, destroying the real file.
+
+        Regression: dispatch 0b83037d0155 rewrote tests/test_entity.py down
+        to the 43-byte marker multiple times and hit recursion_limit=240.
+        """
+        content = '"""Comprehensive uni...(argument truncated)'
+        result = backend.write("/tests/test_foo.py", content)
+        assert result.error is not None
+        assert "truncation" in result.error.lower() or "truncated" in result.error.lower()
+        # File should NOT be written.
+        assert not (project_root / "tests" / "test_foo.py").exists()
+
+    def test_write_accepts_marker_substring_in_real_content(self, backend, project_root):
+        """Legitimate content that happens to MENTION the phrase ``argument
+        truncated`` (e.g. a test case about summarization) is fine. Only the
+        full marker ``"...(argument truncated)"`` is rejected."""
+        # Normal content mentioning the phrase without the full marker.
+        result = backend.write(
+            "/tests/test_foo.py",
+            "# this test checks argument handling — not the truncated marker",
+        )
+        assert result.error is None
+
 
 # -- Read ------------------------------------------------------------------
 
@@ -231,6 +259,20 @@ class TestEdit:
         result = backend.edit("/src/calc.py", "this does not exist", "new content")
         assert result.error is not None
         assert "write_file" in result.error
+
+    def test_edit_rejects_summarization_truncation_marker_in_new_string(self, backend):
+        """new_string containing the ``...(argument truncated)`` marker is a
+        copy-from-truncated-history bug; refuse the edit."""
+        backend.write("/src/calc.py", "x = 1")
+        result = backend.edit(
+            "/src/calc.py",
+            "x = 1",
+            '"""header...(argument truncated)',
+        )
+        assert result.error is not None
+        assert "truncation" in result.error.lower() or "truncated" in result.error.lower()
+        # File is not modified.
+        assert (backend._resolve_path("/src/calc.py")).read_text() == "x = 1"
 
 
 # -- ls_info ---------------------------------------------------------------

--- a/tests/test_runtime/test_policy_backend.py
+++ b/tests/test_runtime/test_policy_backend.py
@@ -139,14 +139,36 @@ class TestWrite:
         assert r.error is None
         assert (project_root / "src" / "main.py").read_text() == "v2"
 
-    def test_write_normalizes_absolute_host_path(self, backend, project_root):
-        # Simulate LLM using absolute AISE repo path
+    def test_write_normalizes_absolute_project_root_path(self, backend, project_root):
+        """Absolute paths pointing INTO this project are still accepted."""
+        result = backend.write(f"{project_root}/src/test.py", "x=1")
+        assert result.error is None
+        assert (project_root / "src" / "test.py").read_text() == "x=1"
+
+    def test_write_rejects_absolute_non_project_path(self, backend, project_root):
+        """Regression: a confused agent wrote to the AISE repo's own source
+        (``/home/.../AISE/src/aise/docs/requirement.md``) and the backend
+        silently remapped it into the project, leaving the file at
+        ``projects/<proj>/src/aise/docs/...``. We now reject such escape
+        paths with a clear error so the LLM retries with a relative path.
+        """
         import aise
 
         aise_root = str(Path(aise.__file__).resolve().parent.parent.parent)
-        result = backend.write(f"{aise_root}/src/test.py", "x=1")
-        assert result.error is None
-        assert (project_root / "src" / "test.py").read_text() == "x=1"
+        # This path is OUTSIDE the project_root tmp_path.
+        result = backend.write(f"{aise_root}/src/aise/docs/requirement.md", "x=1")
+        assert result.error is not None
+        assert "outside this project's root" in result.error
+        # Nothing should have been written inside the project either.
+        assert not (project_root / "src" / "aise" / "docs" / "requirement.md").exists()
+
+    def test_write_rejects_system_escape_paths(self, backend, project_root):
+        """Writes to /etc, /tmp, /var, etc. are rejected even if they don't
+        collide with the AISE repo."""
+        for escape in ("/etc/passwd", "/tmp/x.py", "/var/log/attack.sh"):
+            result = backend.write(escape, "pwn")
+            assert result.error is not None, f"expected rejection for {escape}"
+            assert "outside this project's root" in result.error
 
 
 # -- Read ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three reliability fixes for the developer/QA dispatch path, all regressions observed on recent snake-game runs against a local 30B-class LLM. Each commit is independently revertible.

### 1. Reject absolute paths that escape the project root  `a0b6f69`

The `product_manager` for project_2 wrote `/home/…/AISE/src/aise/docs/requirement.md` (the AISE dev-tool's own source tree). The old `_normalize` had the AISE repo root as a strip prefix, so the path was silently remapped into the project as `projects/project_2-snake-commercial/src/aise/docs/requirement.md` — wrong location, no error, subsequent agents couldn't find the doc. Now such paths (and `/etc`, `/tmp`, `/var`, `/usr`, …) return a clear "outside this project's root" error. Originally opened against PR #98 before that PR merged.

### 2. Raise SummarizationMiddleware `max_arg_length` to 50000  `0048406`

Root cause of dispatch `0b83037d0155`'s recursion-limit failure. Deepagents truncates past `write_file.content` args in history to a 43-byte marker at 85% of the model's token budget; weak LLMs copy the marker back into a new `write_file` call, overwriting the real file with garbage. The old 2000-byte threshold fires on every ~10 KB test file. 50000 bytes keeps typical test/source modules intact while still trimming pathological oversized args (`execute` stdout, etc.).

Patched via `deepagents.graph._compute_summarization_defaults` because that is the binding `create_deep_agent` actually uses; patching the source module would be invisible to the graph's already-resolved import. Idempotent (sentinel attribute prevents double-wrap).

### 3. Refuse writes containing the truncation marker  `588344f`

Defense-in-depth for #2. Even with the larger threshold, a very long-running dispatch can still trip truncation. `norm_write` / `norm_edit` now reject any `content` / `new_string` containing the literal marker `"...(argument truncated)"` with an explicit error telling the LLM the marker is a history placeholder — not real content.

Substring matching: the full marker is required, so legitimate content that merely mentions the phrase `argument truncated` (e.g. a test docstring) still writes.

## Test plan

- [x] `ruff check src tests`
- [x] `ruff format --check src tests`
- [x] `pytest tests/test_runtime tests/test_agents tests/test_core tests/test_web tests/test_skills` — 708 passed / 26 skipped locally
- [ ] CI runs both lint + pytest on PR
- [ ] After merge: re-run a snake-game project and confirm (a) no `src/aise/docs/…` appears under any project, (b) `0b83037d0155`-style "write_file to 43-byte marker" doesn't recur even on long dispatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)