### PR TITLE
fix: stop leaking AISE paths in prompt + symmetric escape handling

### DIFF
--- a/src/aise/runtime/agent_runtime.py
+++ b/src/aise/runtime/agent_runtime.py
@@ -31,7 +31,7 @@ from ..utils.logging import get_logger
 from .agent_card import build_agent_card
 from .agent_md_parser import parse_agent_md
 from .models import AgentCard, AgentDefinition, AgentState
-from .skill_loader import get_skill_source_paths, load_skills_from_directory
+from .skill_loader import load_skills_from_directory
 
 logger = get_logger(__name__)
 
@@ -96,6 +96,92 @@ if create_deep_agent is not None:
     _install_summarization_max_arg_length_patch()
 
 
+# Appended to every agent's system prompt. Anchors the LLM's mental model
+# of the filesystem WITHOUT revealing the absolute host location of the
+# project directory. Without this, the LLM treats ``/home/…/AISE/…``
+# paths as valid because other parts of the deepagents-injected prompt
+# (``"All file paths must start with a /"``) leave the root ambiguous.
+#
+# The rules here are enforced by :mod:`policy_backend` — absolute host
+# paths starting with ``/home``, ``/etc``, ``/tmp``, ``/opt``, etc. are
+# rejected by ``norm_write`` / ``norm_edit`` / ``norm_read`` and will
+# soon also be rejected by ``norm_ls`` / ``norm_glob`` / ``norm_grep``.
+_PATH_POLICY_PROMPT = """
+## File Path Policy
+
+All file I/O happens inside your project's sandbox. You do NOT have access
+to the host filesystem and must never assume absolute host paths. Use ONE
+of these two equivalent forms:
+
+- **Relative path** — ``tests/test_foo.py``, ``docs/bar.md``, ``src/mod/x.py``
+- **Virtual-root path** (leading ``/``) — ``/tests/test_foo.py``, ``/docs/bar.md``
+
+Both forms resolve inside the project sandbox.
+
+**Forbidden** — any absolute host path, including but not limited to:
+- ``/home/...`` (user home directories)
+- ``/etc/...``, ``/tmp/...``, ``/var/...``, ``/opt/...``, ``/usr/...`` (system)
+
+These are outside the sandbox and will be rejected by ``write_file``,
+``edit_file``, ``read_file``, ``ls``, ``glob``, and ``grep`` with a
+``"Path is outside this project's root"`` error. Do not attempt them —
+if you think you need a path outside the sandbox, you are confused about
+where your project lives.
+
+If a tool ever returns that error, rewrite the call with a relative path
+(``docs/foo.md``) or a virtual-root path (``/docs/foo.md``). Never try
+to guess the host location.
+""".strip()
+
+
+def _load_inline_skill_content(skills_dir: Path) -> list[tuple[str, str]]:
+    """Read every ``*/SKILL.md`` from ``skills_dir`` and return its content.
+
+    Returns a list of ``(skill_name, skill_body)`` pairs. Uses a simple
+    directory scan (no deepagents involvement) so no absolute host paths
+    appear anywhere. The content is inlined into the agent's system
+    prompt by :func:`_compose_system_prompt`.
+    """
+    results: list[tuple[str, str]] = []
+    if not skills_dir.is_dir():
+        return results
+    for skill_md in sorted(skills_dir.glob("*/SKILL.md")):
+        try:
+            body = skill_md.read_text(encoding="utf-8")
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Failed to read skill %s: %s", skill_md.parent.name, exc)
+            continue
+        results.append((skill_md.parent.name, body))
+    return results
+
+
+def _compose_system_prompt(
+    agent_prompt: str,
+    inline_skills: list[tuple[str, str]],
+) -> str:
+    """Append inline skill bodies + the path policy to the agent prompt.
+
+    Structure (top to bottom):
+        <agent .md system prompt>
+        [## Available Skills — inline]
+          <SKILL.md body for each skill>
+        ## File Path Policy
+    """
+    parts: list[str] = []
+    if agent_prompt.strip():
+        parts.append(agent_prompt.rstrip())
+    if inline_skills:
+        skill_section = ["## Available Skills", ""]
+        for name, body in inline_skills:
+            skill_section.append(f"### {name}")
+            skill_section.append("")
+            skill_section.append(body.strip())
+            skill_section.append("")
+        parts.append("\n".join(skill_section).rstrip())
+    parts.append(_PATH_POLICY_PROMPT)
+    return "\n\n".join(parts)
+
+
 class AgentRuntime:
     """Agent runtime built on the deepagents framework.
 
@@ -157,13 +243,32 @@ class AgentRuntime:
         self._tools = tools
         self._extra_skill_infos = extra_skill_infos
 
-        # 3. Build the deep agent
-        skill_sources = get_skill_source_paths(self._skills_dir)
+        # 3. Assemble the final system prompt
+        #
+        # Deepagents' ``SkillsMiddleware`` accepts ``skills=[abs_path]`` and
+        # injects those absolute host paths into the agent's system prompt
+        # verbatim (e.g. ``skills at /home/user/workspace/AISE/src/aise/
+        # agents/_runtime_skills``). That prompt then teaches the LLM that
+        # ``/home/.../AISE/...`` is a valid working area, so it confidently
+        # writes files to ``/home/.../AISE/src/aise/docs/...`` etc., which
+        # our ``policy_backend`` rejects with ``Path escapes project root``
+        # (hundreds of WARN entries per run).
+        #
+        # We bypass the mechanism entirely: instead of passing ``skills=``
+        # to ``create_deep_agent``, we read the skill content ourselves and
+        # inline it into the agent's system prompt. The LLM sees the skill
+        # knowledge but never sees any absolute host path.
+        inlined_skills = _load_inline_skill_content(self._skills_dir)
+        system_prompt = _compose_system_prompt(
+            self._definition.system_prompt or "",
+            inlined_skills,
+        )
+
+        # 4. Build the deep agent
         create_kwargs: dict[str, Any] = {
             "model": model,
             "tools": tools or None,
-            "system_prompt": self._definition.system_prompt or None,
-            "skills": skill_sources or None,
+            "system_prompt": system_prompt or None,
             "name": self._definition.name,
             "checkpointer": checkpointer,
         }
@@ -171,10 +276,10 @@ class AgentRuntime:
             create_kwargs["backend"] = backend
         self._agent: CompiledStateGraph = create_deep_agent(**create_kwargs)
         logger.info(
-            "Deep agent created: name=%s tools=%d skill_sources=%d",
+            "Deep agent created: name=%s tools=%d inline_skills=%d",
             self._definition.name,
             len(tools),
-            len(skill_sources),
+            len(inlined_skills),
         )
 
         # 4. Generate A2A agent card

--- a/src/aise/runtime/policy_backend.py
+++ b/src/aise/runtime/policy_backend.py
@@ -377,27 +377,33 @@ def make_policy_backend(
     def norm_ls(path: str) -> Any:
         normalized = _normalize(path)
         if normalized is None:
-            # ls has no error channel on its Info result — log and return
-            # an empty listing so the LLM sees "no such path" rather than
-            # accidentally scanning outside the project.
-            logger.warning("ls on non-project path rejected: %r", path)
-            return _orig_ls("/")
+            # Raise, rather than silently remap to project root. The old
+            # fallback returned the project root's contents for any
+            # escape path, which fooled the LLM into believing that
+            # ``ls /home/.../AISE/src`` worked — it built a false model
+            # of the filesystem and then tried ``write_file`` on the
+            # same escape path. Deepagents' tool wrapper converts this
+            # exception to a ToolMessage the LLM can see and learn from.
+            raise PermissionError(_escape_error(path))
         return _orig_ls(normalized)
 
     def norm_glob(pattern: str, path: str = "/") -> Any:
+        # Only treat ``pattern`` as a path when it looks like one. A
+        # leading-``/`` pattern (``/src/**/*.py``) is a virtual-root
+        # pattern and passes through normalize; bare patterns
+        # (``**/*.py``) are globs relative to ``path``.
         p_norm = _normalize(pattern) if pattern and pattern.startswith("/") else pattern
         base_norm = _normalize(path)
         if p_norm is None or base_norm is None:
-            logger.warning("glob on non-project path rejected: pattern=%r path=%r", pattern, path)
-            return _orig_glob(pattern if p_norm is None else p_norm, "/")
+            bad = path if base_norm is None else pattern
+            raise PermissionError(_escape_error(bad))
         return _orig_glob(p_norm, base_norm)
 
     def norm_grep(pattern: str, path: str | None = None, glob: str | None = None) -> Any:
         if path:
             normalized = _normalize(path)
             if normalized is None:
-                logger.warning("grep on non-project path rejected: %r", path)
-                normalized = "/"
+                raise PermissionError(_escape_error(path))
         else:
             normalized = path
         return _orig_grep(pattern, normalized, glob)

--- a/tests/test_runtime/test_agent_runtime.py
+++ b/tests/test_runtime/test_agent_runtime.py
@@ -300,6 +300,67 @@ class TestSummarizationPatch:
         assert "max_length" in truncate
 
 
+class TestSystemPromptAssembly:
+    """The final system_prompt passed to ``create_deep_agent`` must:
+
+    - append a path-policy block telling the LLM not to use absolute host paths
+    - inline every SKILL.md body (so we can stop passing ``skills=`` to
+      ``create_deep_agent`` and prevent deepagents' SkillsMiddleware from
+      leaking AISE's absolute source-tree paths into the prompt)
+    - NOT contain any absolute host path (``/home/``, ``/etc/``, etc.)
+    """
+
+    def test_system_prompt_includes_path_policy(self, agent_md_file, skills_dir, mock_create_deep_agent):
+        mock_factory, _ = mock_create_deep_agent
+        AgentRuntime(agent_md=agent_md_file, skills_dir=skills_dir, model="openai:gpt-4o")
+        _, kwargs = mock_factory.call_args
+        prompt = kwargs.get("system_prompt", "")
+        assert "File Path Policy" in prompt
+        assert "relative path" in prompt.lower()
+        assert "/home" in prompt  # appears inside a "Forbidden" list, not a skill path
+        # But "/home/ntstaker" — the concrete AISE absolute — must NOT appear:
+        assert "/home/ntstaker/workspace/AISE" not in prompt
+        assert "/home/ntstaker" not in prompt
+
+    def test_system_prompt_does_not_pass_skills_kwarg(self, agent_md_file, skills_dir, mock_create_deep_agent):
+        """Regression: ``create_deep_agent`` must NOT be called with
+        ``skills=``. Passing skills would re-activate deepagents'
+        SkillsMiddleware, which re-injects the absolute source-tree
+        path into the system prompt."""
+        mock_factory, _ = mock_create_deep_agent
+        AgentRuntime(agent_md=agent_md_file, skills_dir=skills_dir, model="openai:gpt-4o")
+        _, kwargs = mock_factory.call_args
+        assert "skills" not in kwargs or kwargs["skills"] is None
+
+    def test_system_prompt_inlines_skill_bodies(self, agent_md_file, skills_dir, mock_create_deep_agent):
+        """Skills in ``skills_dir/*/SKILL.md`` are inlined into the
+        system prompt (so the LLM gets the skill content without having
+        to ``read_file`` a host-absolute skill path)."""
+        skill_dir = skills_dir / "sample_skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("# sample_skill\n\nThis is a MAGIC_SKILL_MARKER body.\n")
+        mock_factory, _ = mock_create_deep_agent
+        AgentRuntime(agent_md=agent_md_file, skills_dir=skills_dir, model="openai:gpt-4o")
+        _, kwargs = mock_factory.call_args
+        prompt = kwargs.get("system_prompt", "")
+        assert "## Available Skills" in prompt
+        assert "### sample_skill" in prompt
+        assert "MAGIC_SKILL_MARKER" in prompt
+
+    def test_system_prompt_no_absolute_aise_paths_with_skills(self, agent_md_file, skills_dir, mock_create_deep_agent):
+        """Even with a skill present, the resulting prompt should have
+        zero references to ``/home/*/AISE`` — the skill body is inlined
+        by filename (``### sample``) not path."""
+        skill_dir = skills_dir / "sample"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("# sample\ncontent\n")
+        mock_factory, _ = mock_create_deep_agent
+        AgentRuntime(agent_md=agent_md_file, skills_dir=skills_dir, model="openai:gpt-4o")
+        _, kwargs = mock_factory.call_args
+        prompt = kwargs.get("system_prompt", "")
+        assert str(skills_dir) not in prompt, f"skills_dir absolute path leaked into prompt: {skills_dir}"
+
+
 class TestAgentRuntimeCard:
     def test_agent_card_generated(self, agent_md_file, skills_dir, mock_create_deep_agent):
         runtime = AgentRuntime(agent_md=agent_md_file, skills_dir=skills_dir, model="openai:gpt-4o")

--- a/tests/test_runtime/test_policy_backend.py
+++ b/tests/test_runtime/test_policy_backend.py
@@ -293,6 +293,18 @@ class TestLsInfo:
         paths = [e["path"] for e in entries]
         assert any("src" in p for p in paths)
 
+    def test_ls_rejects_escape_path(self, backend):
+        """Symmetric with write/edit/read: escape paths now raise instead
+        of silently returning the project root's contents. The old
+        fallback fooled LLMs into believing ``ls /home/.../AISE/src``
+        worked, after which they'd confidently ``write_file`` to the
+        same escape path.
+        """
+        with pytest.raises(PermissionError, match="outside this project's root"):
+            backend.ls_info("/home/ntstaker/workspace/AISE/src")
+        with pytest.raises(PermissionError, match="outside this project's root"):
+            backend.ls_info("/etc/passwd")
+
 
 # -- glob_info -------------------------------------------------------------
 
@@ -315,6 +327,10 @@ class TestGlobInfo:
         paths = [r["path"] for r in results]
         assert any("a.py" in p for p in paths)
 
+    def test_glob_rejects_escape_path(self, backend):
+        with pytest.raises(PermissionError, match="outside this project's root"):
+            backend.glob_info("*.py", path="/home/ntstaker/workspace/AISE")
+
 
 # -- grep_raw --------------------------------------------------------------
 
@@ -332,6 +348,10 @@ class TestGrepRaw:
         backend.write("/src/main.py", "findme\n")
         results = backend.grep_raw("findme", path="/src")
         assert not isinstance(results, str)
+
+    def test_grep_rejects_escape_path(self, backend):
+        with pytest.raises(PermissionError, match="outside this project's root"):
+            backend.grep_raw("needle", path="/home/ntstaker/workspace/AISE")
 
     def test_grep_with_glob_kwarg(self, backend):
         """Regression: norm_grep must accept glob keyword argument."""


### PR DESCRIPTION
**Stacked on #100.** Diff will contain the #99 and #100 commits until those merge; after that GitHub auto-trims.

## Problem

Worker agents routinely tried to write to paths like ``/home/ntstaker/workspace/AISE/src/aise/docs/requirement.md`` (PM trace ``3b81d9448a6a``), generating hundreds of ``Path escapes project root`` WARN entries per run and creating contaminated files inside the project (``a/``, ``projects/``, ``_run_tests.py``, etc.).

The LLM wasn't hallucinating — our infrastructure was **literally telling it** those paths were valid:

1. **Skill path leak** — ``AgentRuntime`` passed ``skills=[abs_path]`` to ``create_deep_agent``, which activated deepagents' ``SkillsMiddleware``. The middleware writes the absolute source-tree path into the agent's system prompt verbatim:
   ```
   **_runtime_skills Skills**: `/home/ntstaker/workspace/AISE/src/aise/agents/_runtime_skills`
   (No skills available yet. You can create skills in /home/.../AISE/...)
   ```
2. **Asymmetric escape handling** — ``write_file`` / ``edit_file`` / ``read_file`` returned a clear error on escape paths, but ``ls`` / ``glob`` / ``grep`` silently fell back to the **project root's listing**. Running ``ls('/home/.../AISE/src')`` returned a directory that looked real to the LLM, so it confidently did ``write_file('/home/.../AISE/src/something.py')`` — which then got rejected. Each round produced two WARN lines per escape attempt.
3. **No anchoring** — the prompt never told the LLM that absolute host paths were off-limits; deepagents' own phrasing ("All file paths must start with a /") made every absolute path look valid.

## Fix

### 1. Inline skill bodies instead of passing ``skills=``  `94bff45`
- New helpers ``_load_inline_skill_content`` / ``_compose_system_prompt`` read every ``*/SKILL.md`` and splice their bodies into the agent's system prompt under ``## Available Skills`` / ``### <name>``.
- ``create_deep_agent`` is now called **without** ``skills=`` — ``SkillsMiddleware`` stays dormant and no absolute host path is ever injected.

### 2. Raise instead of silent fallback in ls/glob/grep  `ff5ecc8`
- ``norm_ls`` / ``norm_glob`` / ``norm_grep`` now raise ``PermissionError`` with the same message text ``norm_write`` / ``norm_edit`` already use. Deepagents' tool wrappers propagate it to a ``ToolMessage`` the LLM sees. Symmetric across all filesystem tools.
- Side effect: log WARN volume drops roughly 2× (was emitting one WARN per normalize-reject **and** one per caller-fallback; now only the normalize WARN).

### 3. Anchor project root without exposing the host path
- Every agent's system prompt now ends with a ``## File Path Policy`` block stating the rules (use relative or virtual-root paths; absolute host paths like ``/home``, ``/etc``, ``/tmp``, ``/opt``, ``/usr`` are rejected).
- The block only describes rules. Per your requirement it **does not name** ``/home/.../projects/<project_id>`` or otherwise reveal AISE's on-disk layout.

## Test plan

- [x] ``ruff check src tests`` + ``ruff format --check``
- [x] ``pytest tests/test_runtime tests/test_agents tests/test_core tests/test_web tests/test_skills`` — **721 passed / 26 skipped**
- [x] New regression tests:
  - ``test_ls_rejects_escape_path`` / ``test_glob_rejects_escape_path`` / ``test_grep_rejects_escape_path``
  - ``test_system_prompt_includes_path_policy`` — path policy appended
  - ``test_system_prompt_does_not_pass_skills_kwarg`` — ``skills=`` never reaches ``create_deep_agent``
  - ``test_system_prompt_inlines_skill_bodies`` — SKILL.md bodies inlined
  - ``test_system_prompt_no_absolute_aise_paths_with_skills`` — even with skills present, ``skills_dir`` absolute path must not appear in the prompt
- [ ] **After merge**: re-run a snake-game project; expected improvements:
  - Worker agents stop attempting ``/home/.../AISE/...`` writes
  - Log WARN count drops from ~400 per run to single digits
  - No contamination files (``a/``, ``projects/``, top-level ``run_test*.py``) appear in the project root

## Risks

- The ``## Available Skills`` section is larger now (inlined bodies instead of progressive disclosure). Our only skill (``tdd``) is 95 lines — acceptable. If more skills are added later, consider progressive disclosure with virtual-root paths.
- ``SkillsMiddleware``'s internal skill-source tracking no longer fires. We don't rely on any of its other behaviors (skill metadata, source-path-based reads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)