### PR TITLE
fix(web): project card redirect picks the newest run, not the oldest

### DIFF
--- a/src/aise/web/static/app.js
+++ b/src/aise/web/static/app.js
@@ -476,10 +476,24 @@ function setupProjectReact() {
 
     const [view, setView] = window.React.useState("default");
 
+    // Backend returns runs in insertion (chronological) order, so ``runs[0]``
+    // is the OLDEST run. Sort by started_at descending and pick the newest
+    // as the "latest run" target for the auto-redirect. Without this,
+    // clicking a project card could bounce the user to a run from days ago
+    // (e.g. an old failed dispatch) instead of whatever was just started.
+    function pickLatestRun(list) {
+      if (!list || list.length === 0) return null;
+      return [...list].sort((a, b) => {
+        const ta = Date.parse(a && a.started_at) || 0;
+        const tb = Date.parse(b && b.started_at) || 0;
+        return tb - ta;
+      })[0];
+    }
+
     // Auto-redirect to latest run if available
     window.React.useEffect(() => {
-      if (runs.length > 0) {
-        const latestRun = runs[0];
+      const latestRun = pickLatestRun(runs);
+      if (latestRun && latestRun.run_id) {
         window.location.href = `/projects/${encodeURIComponent(projectId)}/runs/${encodeURIComponent(latestRun.run_id)}`;
       }
     }, []); // only on initial load

--- a/src/aise/web/templates/layout.html
+++ b/src/aise/web/templates/layout.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&family=Manrope:wght@500;600;700;800&family=Noto+Sans+SC:wght@400;500;700&display=swap">
-  <link rel="stylesheet" href="/static/main.css?v=20260418a">
+  <link rel="stylesheet" href="/static/main.css?v=20260418b">
 </head>
 <body>
   <div class="app-shell">
@@ -72,7 +72,7 @@
   </template>
   <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
-  <script src="/static/app.js?v=20260418a"></script>
+  <script src="/static/app.js?v=20260418b"></script>
   {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/tests/test_web/test_app.py
+++ b/tests/test_web/test_app.py
@@ -255,6 +255,31 @@ class TestWebPersistence:
         assert len(project_payload["requirements"]) == 1
         assert len(project_payload["runs"]) == 1
 
+    def test_get_project_returns_runs_in_insertion_order(self, monkeypatch, tmp_path):
+        """Regression guard: the frontend's "jump to latest run" logic
+        depends on understanding the order ``get_project`` returns runs
+        in. Backend returns them in insertion (chronological) order, so
+        ``runs[0]`` is the oldest. The frontend therefore must sort by
+        ``started_at`` before picking a target; previously it used
+        ``runs[0]`` and redirected users to a days-old failed run when
+        they clicked the project card.
+        """
+        monkeypatch.chdir(tmp_path)
+        service = WebProjectService()
+        monkeypatch.setattr(service.project_manager, "run_project_workflow", _mock_workflow_result)
+        project_id = service.create_project("OrderCheck", "local")
+        service.run_requirement(project_id, "first")
+        service.run_requirement(project_id, "second")
+        service.run_requirement(project_id, "third")
+        payload = service.get_project(project_id)
+        assert payload is not None
+        runs = payload["runs"]
+        assert len(runs) == 3
+        # Insertion order: earliest first. The sort stability matters
+        # because the frontend sort in ``pickLatestRun`` flips this.
+        times = [r["started_at"] for r in runs]
+        assert times == sorted(times), "Expected insertion (chronological) order; frontend depends on this contract."
+
     def test_zombie_running_run_is_reaped_on_startup(self, monkeypatch, tmp_path):
         """Runs stored as running/pending when the server starts have no live
         worker thread (``_active_workflow_runs`` is not persisted). Without


### PR DESCRIPTION
## Problem

Clicking a project card navigated to a stale run (e.g. ``project_3`` → ``run_4f3abcce6a``, an Apr 13 failure) instead of whatever ran most recently.

## Root cause

``ProjectApp`` in ``src/aise/web/static/app.js`` used ``runs[0]`` as "latest":

```javascript
window.React.useEffect(() => {
  if (runs.length > 0) {
    const latestRun = runs[0];
    window.location.href = `/projects/.../runs/${latestRun.run_id}`;
  }
}, []);
```

But ``WebProjectService.get_project`` returns ``runs`` in **insertion order** (``_runs_by_project[pid].append(run)`` is FIFO), so ``runs[0]`` is the **oldest** run. The ``// Auto-redirect to latest run if available`` comment was aspirational — the code never matched it.

## Fix

New ``pickLatestRun(list)`` helper sorts a shallow copy by ``started_at`` descending and returns the newest. ``useEffect`` redirect uses it.

Backend ordering unchanged — kept as insertion order because the run-history list view on the project page consumes it for chronological display. Added ``test_get_project_returns_runs_in_insertion_order`` to lock in that contract, so if someone later changes the backend's sort order, both this fix and the run-history view will break loudly rather than silently.

## Test plan

- [x] ``ruff check`` + ``ruff format --check``
- [x] New test ``test_get_project_returns_runs_in_insertion_order`` passes
- [x] JS syntax (``node --check``) passes
- [ ] Manual: click a project card with multiple runs; should land on the most recent one.

Cache-buster: ``?v=20260417b`` → ``?v=20260418b``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)