### PR TITLE
feat(web): gate delivery report on delivery stage; show task goal on rows

### DIFF
--- a/src/aise/web/static/app.js
+++ b/src/aise/web/static/app.js
@@ -926,10 +926,19 @@ function setupRunReact() {
               taskResponse: ev.taskId ? taskResponseByTaskId[ev.taskId] : null,
             }))),
       ),
-      run.result ? h("div", { className: "run-section" },
-        h("div", { className: "run-section-title" }, "\u4ea4\u4ed8\u62a5\u544a"),
-        h("pre", { className: "run-result-text" }, run.result),
-      ) : null,
+      // The delivery report (``run.result``) is produced by Phase 6 /
+      // the ``delivery`` stage. It's noisy to show on every view of the
+      // run detail page, so scope it: only render when the user has
+      // actively filtered the log to the delivery stage (by clicking
+      // the delivery chip). When no filter is applied or a different
+      // stage is selected, the report is hidden and the rest of the
+      // A2A log takes the space.
+      run.result && stageFilter && /deliver/i.test(stageFilter)
+        ? h("div", { className: "run-section" },
+            h("div", { className: "run-section-title" }, "\u4ea4\u4ed8\u62a5\u544a"),
+            h("pre", { className: "run-result-text" }, run.result),
+          )
+        : null,
       run.error ? h("div", { className: "run-section run-error-section" },
         h("div", { className: "run-section-title" }, "\u9519\u8bef"),
         h("pre", { className: "run-error-text" }, run.error),
@@ -982,7 +991,16 @@ function setupRunReact() {
     if (ev.type === "task_request") {
       var payload = ev.payload || {};
       var fullTask = payload.task || "";
-      var preview = fullTask.length > 120 ? fullTask.substring(0, 120) + "..." : fullTask;
+      // The task row shows the task's GOAL (what it is, not the full
+      // description text sent to the worker). Prefer ``payload.step``
+      // (e.g. "impl_config_loader", "phase_2_design") — it is the
+      // orchestrator's short identifier for what the task accomplishes.
+      // Fall back to the first line of the task description, which is
+      // typically a goal-like sentence.
+      var goalText =
+        payload.step ||
+        (fullTask ? fullTask.split("\n")[0].slice(0, 100) : "") ||
+        "任务";
       var response = taskResponse || null;
       var responsePayload = (response && response.payload) || {};
       var responseStatus = response ? response.status : null;
@@ -1009,7 +1027,7 @@ function setupRunReact() {
               ? (responseStatus === "completed" ? "✓ 已完成" : responseStatus === "failed" ? "✕ 失败" : responseStatus)
               : "● 进行中",
           ),
-          h("span", { className: "run-log-detail" }, expanded ? "" : preview),
+          h("span", { className: "run-log-detail" }, goalText),
           h("span", { className: "run-log-ts" }, ts),
         ),
         showTodos ? h(TaskTodoProgress, { todos: todosForTask }) : null,

--- a/src/aise/web/templates/layout.html
+++ b/src/aise/web/templates/layout.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&family=Manrope:wght@500;600;700;800&family=Noto+Sans+SC:wght@400;500;700&display=swap">
-  <link rel="stylesheet" href="/static/main.css?v=20260418b">
+  <link rel="stylesheet" href="/static/main.css?v=20260418c">
 </head>
 <body>
   <div class="app-shell">
@@ -72,7 +72,7 @@
   </template>
   <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
-  <script src="/static/app.js?v=20260418b"></script>
+  <script src="/static/app.js?v=20260418c"></script>
   {% block scripts %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary

Two small UI tweaks to the run-detail page per user request.

### 1. Delivery report only visible when delivery stage is selected

The ``交付报告`` block (``run.result``) was previously rendered unconditionally at the bottom of the page. Now it only shows when the user has filtered the stage flow to a ``deliver``-matching stage (click the chip). Other stages / no filter → hidden, A2A task log takes the space.

### 2. Task rows show task GOAL, not task input

Each ``task_request`` row's inline preview was the first ~120 chars of the multi-line ``payload.task`` description sent to the worker. That's the task's input, not what the task is. Row now prefers ``payload.step`` (orchestrator's identifier — e.g. ``impl_config_loader``, ``phase_2_design``, ``layer2_snake``) and falls back to first line of ``payload.task`` if no step is set. Full description still visible in the expanded ``任务描述`` subsection.

## Test plan

- [x] ``ruff check`` + ``ruff format --check`` + ``node --check`` JS syntax
- [x] ``pytest tests/test_web`` — no regressions
- [ ] Manual: load a completed run, confirm delivery report hides by default, click delivery stage → appears. Task rows show short goal labels instead of truncated prose.

Cache-buster: ``?v=20260418b`` → ``?v=20260418c``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)