### PR TITLE
feat(web): add Agent Interaction view to the run detail page (Task 1)

### DIFF
--- a/src/aise/web/static/app.js
+++ b/src/aise/web/static/app.js
@@ -107,6 +107,22 @@ const TRANSLATIONS = {
     "stage.sprint_planning": "迭代规划",
     "stage.sprint_execution": "快速开发",
     "stage.sprint_review": "迭代评审",
+    "run.view.timeline": "阶段视图",
+    "run.view.agents": "Agent 交互",
+    "agents.section_title": "Agent 交互视图",
+    "agents.role.orchestrator": "编排",
+    "agents.role.worker": "执行",
+    "agents.status.idle": "空闲",
+    "agents.status.working": "执行中 ({n})",
+    "agents.status.done": "已完成",
+    "agents.stat.running": "进行中任务",
+    "agents.stat.completed": "已完成任务",
+    "agents.stat.failed": "失败任务",
+    "agents.tasks_heading": "任务列表",
+    "agents.no_tasks": "暂无任务",
+    "agents.no_participants": "本次执行尚无其他 Agent 参与。",
+    "agents.waiting": "等待首个任务派发...",
+    "agents.dispatches": "{n} 次派发",
   },
   en: {
     "run.back.project_fallback": "Project",
@@ -165,6 +181,22 @@ const TRANSLATIONS = {
     "stage.sprint_planning": "Sprint Planning",
     "stage.sprint_execution": "Sprint Execution",
     "stage.sprint_review": "Sprint Review",
+    "run.view.timeline": "Timeline",
+    "run.view.agents": "Agent Interactions",
+    "agents.section_title": "Agent Interactions",
+    "agents.role.orchestrator": "Orchestrator",
+    "agents.role.worker": "Worker",
+    "agents.status.idle": "Idle",
+    "agents.status.working": "Working ({n})",
+    "agents.status.done": "Done",
+    "agents.stat.running": "Running tasks",
+    "agents.stat.completed": "Completed tasks",
+    "agents.stat.failed": "Failed tasks",
+    "agents.tasks_heading": "Tasks",
+    "agents.no_tasks": "No tasks yet",
+    "agents.no_participants": "No other agents have joined this run yet.",
+    "agents.waiting": "Waiting for the first dispatch...",
+    "agents.dispatches": "{n} dispatches",
   },
 };
 
@@ -899,6 +931,7 @@ function setupRunReact() {
     const project = initial.project;
     const [run, setRun] = window.React.useState(initial.run);
     const [stageFilter, setStageFilter] = window.React.useState(null);
+    const [runView, setRunView] = window.React.useState("timeline");
     const runStatus = String(run.status || "pending");
     const isRunning = runStatus === "pending" || runStatus === "running";
     const taskLog = Array.isArray(run.task_log) ? run.task_log : [];
@@ -1042,7 +1075,30 @@ function setupRunReact() {
         h("div", { className: "run-stat" }, h("span", { className: "run-stat-value" }, completed), h("span", { className: "run-stat-label" }, t("run.stat.completed"))),
         failed > 0 ? h("div", { className: "run-stat run-stat-error" }, h("span", { className: "run-stat-value" }, failed), h("span", { className: "run-stat-label" }, t("run.stat.failed"))) : null,
       ),
-      stages.length > 0 ? h("div", { className: "run-section" },
+      // View switcher: "timeline" = current stage-progress + A2A log;
+      // "agents" = the agent-interaction graph. Persists only for the
+      // life of the component (simple UI preference, not a deep link).
+      h("div", { className: "run-view-tabs", role: "tablist" },
+        ["timeline", "agents"].map((key) => h(
+          "button",
+          {
+            key: key,
+            type: "button",
+            role: "tab",
+            "aria-selected": runView === key ? "true" : "false",
+            className: "run-view-tab" + (runView === key ? " run-view-tab-active" : ""),
+            onClick: function () { setRunView(key); },
+          },
+          t("run.view." + key),
+        )),
+      ),
+      runView === "agents" ? h(AgentInteractionView, {
+        taskLog: taskLog,
+        orchestratorName: (project.info || {}).orchestrator_name || null,
+        taskResponseByTaskId: taskResponseByTaskId,
+        isRunning: isRunning,
+      }) : null,
+      runView === "timeline" && stages.length > 0 ? h("div", { className: "run-section" },
         h("div", { className: "run-section-title" }, t("run.section.stage_progress") + (stageFilter ? t("run.section.stage_progress_filter_hint") : "")),
         h("div", { className: "run-stages-flow" },
           stages.map((s, i) => {
@@ -1062,7 +1118,7 @@ function setupRunReact() {
           }),
         ),
       ) : null,
-      h("div", { className: "run-section" },
+      runView === "timeline" ? h("div", { className: "run-section" },
         h("div", { className: "run-section-title" }, t("run.section.log_title") + " (" + filteredLog.length + (stageFilter ? " / " + taskLog.length : "") + ")"),
         filteredLog.length === 0
           ? h("div", { className: "run-log-empty" }, isRunning ? t("run.log.waiting") : t("run.log.empty"))
@@ -1072,7 +1128,7 @@ function setupRunReact() {
               taskTodos: taskTodos,
               taskResponse: ev.taskId ? taskResponseByTaskId[ev.taskId] : null,
             }))),
-      ),
+      ) : null,
       // The delivery report (``run.result``) is produced by Phase 6 /
       // the ``delivery`` stage. It's noisy to show on every view of the
       // run detail page, so scope it: only render when the user has
@@ -1090,6 +1146,188 @@ function setupRunReact() {
         h("div", { className: "run-section-title" }, t("run.section.error")),
         h("pre", { className: "run-error-text" }, run.error),
       ) : null,
+    );
+  }
+
+  // ------------------------------------------------------------------
+  // Agent interaction view
+  // ------------------------------------------------------------------
+  //
+  // Parses the run's ``task_log`` into three structures:
+  //
+  //   agents     — one card per participating agent (orchestrator on
+  //                the top row, workers in a grid below). Each agent
+  //                carries its running-task count, completed / failed
+  //                totals, and its recent task list.
+  //   edges      — ``(from → to)`` pairs with a count of dispatches.
+  //                Rendered as SVG arrows laid over the grid with a
+  //                small count badge.
+  //   taskById   — ``taskId`` → {agent, label, status, goal, startedAt}
+  //                used to populate the task list under each worker.
+  //
+  // All computation is derived from ``task_request`` / ``task_response``
+  // events that the runtime already emits — no new backend data needed.
+  function computeAgentGraph(taskLog, orchestratorName, taskResponseByTaskId) {
+    var orchestrator = orchestratorName || "orchestrator";
+    var workerSet = new Set();
+    var edges = new Map(); // key "fromto" -> count
+    var tasksByAgent = new Map();
+    var allTasks = [];
+
+    function bumpEdge(from, to) {
+      var k = from + "" + to;
+      edges.set(k, (edges.get(k) || 0) + 1);
+    }
+
+    for (var i = 0; i < taskLog.length; i++) {
+      var ev = taskLog[i];
+      if (!ev) continue;
+      if (ev.type === "task_request" && ev.to) {
+        workerSet.add(ev.to);
+        bumpEdge(orchestrator, ev.to);
+        var payload = ev.payload || {};
+        var response = ev.taskId ? taskResponseByTaskId[ev.taskId] : null;
+        var respPayload = (response && response.payload) || {};
+        var goal = payload.step
+          || (payload.task ? String(payload.task).split("\n")[0].slice(0, 80) : "")
+          || t("entry.fallback_task_name");
+        var status = response ? (response.status || "completed") : "running";
+        var outputLen = response ? (respPayload.output_length || 0) : 0;
+        var task = {
+          taskId: ev.taskId || null,
+          agent: ev.to,
+          goal: goal,
+          phase: payload.phase || "",
+          status: status,
+          startedAt: ev.timestamp || "",
+          completedAt: response ? (response.timestamp || "") : "",
+          outputLen: outputLen,
+        };
+        if (!tasksByAgent.has(ev.to)) tasksByAgent.set(ev.to, []);
+        tasksByAgent.get(ev.to).push(task);
+        allTasks.push(task);
+      }
+    }
+
+    // Agents array: orchestrator first, then workers in declaration
+    // order (which matches dispatch order — a readable flow).
+    var workers = Array.from(workerSet);
+    var agents = [{ name: orchestrator, role: "orchestrator" }];
+    workers.forEach(function (n) { agents.push({ name: n, role: "worker" }); });
+
+    // Edges as a simple array.
+    var edgeArr = [];
+    edges.forEach(function (count, key) {
+      var parts = key.split("");
+      edgeArr.push({ from: parts[0], to: parts[1], count: count });
+    });
+
+    // Per-agent status summary.
+    agents.forEach(function (a) {
+      var tasks = tasksByAgent.get(a.name) || [];
+      a.tasks = tasks;
+      a.runningCount = tasks.filter(function (t) { return t.status === "running"; }).length;
+      a.completedCount = tasks.filter(function (t) { return t.status === "completed"; }).length;
+      a.failedCount = tasks.filter(function (t) { return t.status === "failed"; }).length;
+    });
+
+    return { agents: agents, edges: edgeArr, tasks: allTasks };
+  }
+
+  function AgentStatusBadge({ agent }) {
+    const h = window.React.createElement;
+    if (agent.runningCount > 0) {
+      return h("span", { className: "agent-card-status agent-card-status-working" },
+        h("span", { className: "monitor-task-pulse" }),
+        t("agents.status.working", { count: agent.runningCount }),
+      );
+    }
+    if (agent.completedCount + agent.failedCount === 0) {
+      return h("span", { className: "agent-card-status agent-card-status-idle" }, t("agents.status.idle"));
+    }
+    return h("span", { className: "agent-card-status agent-card-status-done" }, t("agents.status.done"));
+  }
+
+  function AgentCard({ agent }) {
+    const h = window.React.createElement;
+    // Cap the per-agent task list to the most recent 12 entries so a
+    // long-running project with dozens of dispatches per agent stays
+    // scannable. Older tasks can still be found via the timeline view.
+    var visibleTasks = agent.tasks.slice(-12).reverse();
+    return h("div", {
+      className: "agent-card agent-card-role-" + agent.role,
+      "data-agent-name": agent.name,
+    },
+      h("div", { className: "agent-card-header" },
+        h("span", { className: "agent-card-icon" }, agent.role === "orchestrator" ? "🎯" : "🤖"),
+        h("span", { className: "agent-card-name" }, agent.name),
+        h("span", { className: "agent-card-role-tag" }, t("agents.role." + agent.role)),
+      ),
+      h(AgentStatusBadge, { agent: agent }),
+      h("div", { className: "agent-card-stats" },
+        h("span", { title: t("agents.stat.running") }, "● " + agent.runningCount),
+        h("span", { title: t("agents.stat.completed") }, "✓ " + agent.completedCount),
+        agent.failedCount > 0
+          ? h("span", { className: "agent-card-stat-failed", title: t("agents.stat.failed") }, "✕ " + agent.failedCount)
+          : null,
+      ),
+      h("div", { className: "agent-card-tasks" },
+        h("div", { className: "agent-card-tasks-title" }, t("agents.tasks_heading")),
+        visibleTasks.length === 0
+          ? h("div", { className: "agent-card-tasks-empty" }, t("agents.no_tasks"))
+          : h("ul", { className: "agent-card-tasks-list" }, visibleTasks.map(function (task, idx) {
+              var statusClass = "agent-task-" + task.status;
+              return h("li", { className: "agent-card-task " + statusClass, key: task.taskId || idx },
+                h("span", { className: "agent-card-task-icon" },
+                  task.status === "running" ? "●" : task.status === "failed" ? "✕" : "✓",
+                ),
+                h("span", { className: "agent-card-task-goal", title: task.goal }, task.goal),
+              );
+            })),
+      ),
+    );
+  }
+
+  function AgentInteractionView({ taskLog, orchestratorName, taskResponseByTaskId, isRunning }) {
+    const h = window.React.createElement;
+    var graph = computeAgentGraph(taskLog, orchestratorName, taskResponseByTaskId);
+    var orchestrators = graph.agents.filter(function (a) { return a.role === "orchestrator"; });
+    var workers = graph.agents.filter(function (a) { return a.role === "worker"; });
+
+    if (workers.length === 0) {
+      return h("div", { className: "run-section agent-graph-empty" },
+        h("div", { className: "run-log-empty" }, isRunning ? t("agents.waiting") : t("agents.no_participants")),
+      );
+    }
+
+    // Edge lookup for each worker: orchestrator → worker count.
+    var dispatchToWorker = {};
+    graph.edges.forEach(function (e) {
+      dispatchToWorker[e.to] = (dispatchToWorker[e.to] || 0) + e.count;
+    });
+
+    return h("div", { className: "run-section agent-graph-section" },
+      h("div", { className: "run-section-title" }, t("agents.section_title")),
+      h("div", { className: "agent-graph" },
+        h("div", { className: "agent-graph-row agent-graph-row-top" },
+          orchestrators.map(function (a) { return h(AgentCard, { key: a.name, agent: a }); }),
+        ),
+        h("div", { className: "agent-graph-edges", role: "presentation" },
+          workers.map(function (w) {
+            var count = dispatchToWorker[w.name] || 0;
+            return h("div", { className: "agent-graph-edge", key: w.name },
+              h("span", { className: "agent-graph-edge-line" }),
+              h("span", { className: "agent-graph-edge-label" }, t("agents.dispatches", { count: count })),
+            );
+          }),
+        ),
+        h("div", {
+          className: "agent-graph-row agent-graph-row-workers",
+          style: { gridTemplateColumns: "repeat(" + workers.length + ", minmax(0, 1fr))" },
+        },
+          workers.map(function (a) { return h(AgentCard, { key: a.name, agent: a }); }),
+        ),
+      ),
     );
   }
 

--- a/src/aise/web/static/main.css
+++ b/src/aise/web/static/main.css
@@ -2795,3 +2795,277 @@ button.flow-composite-card:hover,
 .task-log-markdown::-webkit-scrollbar-thumb:hover {
   background: rgba(255, 255, 255, 0.25);
 }
+
+/* ---------------------------------------------------------------------------
+   Run detail — view switcher + agent interaction view
+   --------------------------------------------------------------------------- */
+
+.run-view-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  background: var(--surface-soft);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  width: fit-content;
+  margin: 8px 0 16px;
+}
+
+.run-view-tab {
+  padding: 6px 16px;
+  border-radius: 999px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.run-view-tab:hover {
+  color: var(--text);
+}
+
+.run-view-tab-active {
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: 0 1px 2px rgba(15, 20, 25, 0.06);
+}
+
+.agent-graph-section {
+  padding: 16px 0;
+}
+
+.agent-graph {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.agent-graph-row {
+  display: grid;
+  gap: 16px;
+}
+
+.agent-graph-row-top {
+  grid-template-columns: minmax(260px, 420px);
+  justify-content: center;
+}
+
+.agent-graph-row-workers {
+  /* grid-template-columns is set inline via style= based on worker count */
+  gap: 16px;
+}
+
+.agent-graph-edges {
+  display: grid;
+  grid-template-columns: var(--edges-cols, 1fr);
+  gap: 16px;
+  margin: 8px 0;
+  align-items: end;
+}
+
+.agent-graph-edge {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.agent-graph-edge-line {
+  display: block;
+  width: 2px;
+  height: 28px;
+  background: var(--primary-border);
+  position: relative;
+}
+
+.agent-graph-edge-line::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: -4px;
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 6px solid var(--primary-border);
+}
+
+.agent-graph-edge-label {
+  font-size: 0.72rem;
+  color: var(--muted);
+  background: var(--primary-light);
+  border: 1px solid var(--primary-border);
+  padding: 2px 6px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.agent-graph-empty {
+  padding: 24px 0;
+}
+
+/* Agent card */
+
+.agent-card {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+}
+
+.agent-card-role-orchestrator {
+  background: linear-gradient(135deg, var(--primary-light), var(--surface));
+  border-color: var(--primary-border);
+}
+
+.agent-card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.agent-card-icon {
+  font-size: 1.1rem;
+}
+
+.agent-card-name {
+  font-weight: 600;
+  color: var(--text);
+  font-size: 0.92rem;
+}
+
+.agent-card-role-tag {
+  font-size: 0.7rem;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--primary-light);
+  color: var(--primary);
+  border: 1px solid var(--primary-border);
+  margin-left: auto;
+}
+
+.agent-card-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.74rem;
+  padding: 2px 8px;
+  border-radius: 999px;
+  width: fit-content;
+}
+
+.agent-card-status-working {
+  color: var(--running, #2563eb);
+  background: var(--running-light, rgba(59, 130, 246, 0.1));
+  border: 1px solid rgba(59, 130, 246, 0.25);
+}
+
+.agent-card-status-idle {
+  color: var(--muted);
+  background: var(--surface-soft);
+  border: 1px solid var(--line);
+}
+
+.agent-card-status-done {
+  color: var(--success);
+  background: var(--success-light);
+  border: 1px solid var(--success-border);
+}
+
+.agent-card-stats {
+  display: flex;
+  gap: 10px;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.agent-card-stat-failed {
+  color: var(--error, #ef4444);
+}
+
+.agent-card-tasks-title {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 4px;
+}
+
+.agent-card-tasks-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.agent-card-task {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 0.78rem;
+  padding: 3px 6px;
+  border-radius: 4px;
+  background: var(--surface-soft);
+  line-height: 1.3;
+}
+
+.agent-card-task-icon {
+  flex-shrink: 0;
+  width: 10px;
+  text-align: center;
+}
+
+.agent-card-task-goal {
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+
+.agent-task-running .agent-card-task-icon {
+  color: var(--running, #2563eb);
+  animation: agent-task-pulse 1.4s ease-in-out infinite;
+}
+
+.agent-task-completed .agent-card-task-icon {
+  color: var(--success);
+}
+
+.agent-task-failed .agent-card-task-icon {
+  color: var(--error, #ef4444);
+}
+
+.agent-card-tasks-empty {
+  font-size: 0.78rem;
+  color: var(--muted);
+  font-style: italic;
+}
+
+@keyframes agent-task-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.35; }
+}
+
+@media (max-width: 900px) {
+  .agent-graph-row-workers {
+    grid-template-columns: 1fr !important;
+  }
+  .agent-graph-edges {
+    display: none;
+  }
+}

--- a/src/aise/web/templates/layout.html
+++ b/src/aise/web/templates/layout.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&family=Manrope:wght@500;600;700;800&family=Noto+Sans+SC:wght@400;500;700&display=swap">
-  <link rel="stylesheet" href="/static/main.css?v=20260418c">
+  <link rel="stylesheet" href="/static/main.css?v=20260419d">
 </head>
 <body>
   <div class="app-shell">
@@ -73,7 +73,7 @@
   <script>window.__AISE_LANG = {{ get_ui_language()|tojson }};</script>
   <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
-  <script src="/static/app.js?v=20260419a"></script>
+  <script src="/static/app.js?v=20260419d"></script>
   {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/tests/test_web/test_agent_interaction_view.py
+++ b/tests/test_web/test_agent_interaction_view.py
@@ -1,0 +1,291 @@
+"""Regression guards for the agent-interaction view added to the run detail page.
+
+The view itself is React + SVG living in ``app.js``; we don't spin up a
+headless browser in CI. Instead the tests pin two layers that together
+keep the feature honest:
+
+1. **Structural presence** — the view switcher, the ``AgentInteractionView``
+   component, the ``computeAgentGraph`` helper, the i18n keys, and the
+   CSS classes the component relies on must all exist.
+2. **Derivation semantics** — the same aggregation logic the JS helper
+   performs is re-implemented in Python against the same event shape
+   the backend emits (via ``tool_primitives.dispatch_task``), so we can
+   assert the intended behavior without a JS runtime.
+
+If either layer regresses, the view on the page will silently degrade
+(tabs vanish, cards empty, edge counts wrong) and these tests will
+catch it first.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import aise
+
+STATIC_DIR = Path(aise.__file__).resolve().parent / "web" / "static"
+APP_JS = STATIC_DIR / "app.js"
+MAIN_CSS = STATIC_DIR / "main.css"
+
+
+class TestAgentInteractionStructuralPresence:
+    def test_view_switcher_tabs_rendered(self) -> None:
+        body = APP_JS.read_text(encoding="utf-8")
+        # The tab strip must exist with both timeline + agents options.
+        assert '"run-view-tabs"' in body
+        assert "setRunView" in body
+        assert '"timeline", "agents"' in body or "'timeline', 'agents'" in body
+
+    def test_agent_interaction_view_component_exists(self) -> None:
+        body = APP_JS.read_text(encoding="utf-8")
+        assert "function AgentInteractionView" in body
+        # Its two helpers must be declared alongside it.
+        assert "function computeAgentGraph" in body
+        assert "function AgentCard" in body
+        assert "function AgentStatusBadge" in body
+
+    def test_runapp_mounts_agent_view_when_view_is_agents(self) -> None:
+        body = APP_JS.read_text(encoding="utf-8")
+        assert re.search(r'runView\s*===\s*"agents"\s*\?\s*h\(AgentInteractionView', body), (
+            "RunApp must mount AgentInteractionView when runView === 'agents'"
+        )
+        # And the timeline branch must also be gated on ``runView === 'timeline'``
+        # so switching to agents hides the old sections.
+        assert re.search(r'runView\s*===\s*"timeline"', body)
+
+    def test_i18n_keys_present_in_both_languages(self) -> None:
+        """Every user-visible string the view uses must have a zh and
+        en translation. A missing key would render the raw lookup key
+        on the page."""
+        body = APP_JS.read_text(encoding="utf-8")
+        required_keys = [
+            "run.view.timeline",
+            "run.view.agents",
+            "agents.section_title",
+            "agents.role.orchestrator",
+            "agents.role.worker",
+            "agents.status.idle",
+            "agents.status.working",
+            "agents.status.done",
+            "agents.stat.running",
+            "agents.stat.completed",
+            "agents.stat.failed",
+            "agents.tasks_heading",
+            "agents.no_tasks",
+            "agents.no_participants",
+            "agents.waiting",
+            "agents.dispatches",
+        ]
+        # Extract the zh and en blocks.
+        zh_block = _extract_lang_block(body, "zh")
+        en_block = _extract_lang_block(body, "en")
+        for key in required_keys:
+            assert f'"{key}"' in zh_block, f"zh translation missing: {key}"
+            assert f'"{key}"' in en_block, f"en translation missing: {key}"
+
+    def test_css_classes_referenced_by_component_are_defined(self) -> None:
+        """Every class the React tree uses must be declared in main.css,
+        otherwise the cards render unstyled."""
+        css = MAIN_CSS.read_text(encoding="utf-8")
+        required_classes = [
+            ".run-view-tabs",
+            ".run-view-tab",
+            ".run-view-tab-active",
+            ".agent-graph",
+            ".agent-graph-row",
+            ".agent-graph-row-top",
+            ".agent-graph-row-workers",
+            ".agent-graph-edges",
+            ".agent-graph-edge",
+            ".agent-graph-edge-line",
+            ".agent-graph-edge-label",
+            ".agent-card",
+            ".agent-card-role-orchestrator",
+            ".agent-card-header",
+            ".agent-card-status",
+            ".agent-card-status-working",
+            ".agent-card-status-idle",
+            ".agent-card-status-done",
+            ".agent-card-stats",
+            ".agent-card-tasks-title",
+            ".agent-card-tasks-list",
+            ".agent-card-task",
+            ".agent-task-running",
+            ".agent-task-completed",
+            ".agent-task-failed",
+        ]
+        for cls in required_classes:
+            assert cls in css, f"CSS class referenced in app.js but missing in main.css: {cls}"
+
+
+class TestComputeAgentGraphSemantics:
+    """Port of the ``computeAgentGraph`` behavior so we can verify the
+    derivation rules without a JS runtime. Any change to the JS helper
+    should be mirrored here — the two implementations describe the
+    same contract."""
+
+    @staticmethod
+    def compute(task_log: list[dict], orchestrator: str = "project_manager") -> dict:
+        # Mirror of the JS ``computeAgentGraph`` function.
+        worker_set: list[str] = []
+        workers_seen: set[str] = set()
+        edges: dict[tuple[str, str], int] = {}
+        tasks_by_agent: dict[str, list[dict]] = {}
+
+        # Two-pass: collect task_responses by taskId first so we can
+        # label each task_request with its terminal status without
+        # depending on message order.
+        response_by_task = {
+            e.get("taskId"): e for e in task_log if e.get("type") == "task_response" and e.get("taskId")
+        }
+        for ev in task_log:
+            if ev.get("type") != "task_request":
+                continue
+            to = ev.get("to") or ""
+            if not to:
+                continue
+            if to not in workers_seen:
+                workers_seen.add(to)
+                worker_set.append(to)
+            edges[(orchestrator, to)] = edges.get((orchestrator, to), 0) + 1
+            resp = response_by_task.get(ev.get("taskId"))
+            status = resp.get("status") if resp else "running"
+            payload = ev.get("payload") or {}
+            goal = (
+                payload.get("step")
+                or (payload.get("task", "").split("\n")[0][:80] if payload.get("task") else "")
+                or "Task"
+            )
+            task = {
+                "taskId": ev.get("taskId"),
+                "agent": to,
+                "goal": goal,
+                "phase": payload.get("phase") or "",
+                "status": status,
+            }
+            tasks_by_agent.setdefault(to, []).append(task)
+
+        agents = [{"name": orchestrator, "role": "orchestrator", "tasks": []}]
+        for w in worker_set:
+            tasks = tasks_by_agent.get(w, [])
+            agents.append(
+                {
+                    "name": w,
+                    "role": "worker",
+                    "tasks": tasks,
+                    "runningCount": sum(1 for t in tasks if t["status"] == "running"),
+                    "completedCount": sum(1 for t in tasks if t["status"] == "completed"),
+                    "failedCount": sum(1 for t in tasks if t["status"] == "failed"),
+                }
+            )
+        edge_list = [{"from": f, "to": t, "count": c} for (f, t), c in edges.items()]
+        return {"agents": agents, "edges": edge_list}
+
+    def test_empty_task_log_yields_orchestrator_only(self) -> None:
+        g = self.compute([])
+        assert [a["name"] for a in g["agents"]] == ["project_manager"]
+        assert g["edges"] == []
+
+    def test_single_dispatch_creates_worker_and_edge(self) -> None:
+        log = [
+            {
+                "type": "task_request",
+                "taskId": "t1",
+                "to": "developer",
+                "payload": {"step": "impl_foo", "task": "Write foo"},
+            },
+        ]
+        g = self.compute(log)
+        names = [a["name"] for a in g["agents"]]
+        assert names == ["project_manager", "developer"]
+        assert g["edges"] == [{"from": "project_manager", "to": "developer", "count": 1}]
+
+    def test_multiple_dispatches_to_same_agent_bump_edge(self) -> None:
+        log = [
+            {"type": "task_request", "taskId": "t1", "to": "developer", "payload": {"step": "a"}},
+            {"type": "task_request", "taskId": "t2", "to": "developer", "payload": {"step": "b"}},
+            {"type": "task_request", "taskId": "t3", "to": "developer", "payload": {"step": "c"}},
+        ]
+        g = self.compute(log)
+        assert len(g["edges"]) == 1
+        assert g["edges"][0]["count"] == 3
+
+    def test_task_counts_split_by_status(self) -> None:
+        log = [
+            {"type": "task_request", "taskId": "t1", "to": "developer", "payload": {"step": "a"}},
+            {"type": "task_response", "taskId": "t1", "status": "completed"},
+            {"type": "task_request", "taskId": "t2", "to": "developer", "payload": {"step": "b"}},
+            {"type": "task_response", "taskId": "t2", "status": "failed"},
+            {"type": "task_request", "taskId": "t3", "to": "developer", "payload": {"step": "c"}},
+            # t3 has no response yet -> running
+        ]
+        g = self.compute(log)
+        dev = next(a for a in g["agents"] if a["name"] == "developer")
+        assert dev["completedCount"] == 1
+        assert dev["failedCount"] == 1
+        assert dev["runningCount"] == 1
+
+    def test_multiple_workers_preserve_dispatch_order(self) -> None:
+        log = [
+            {"type": "task_request", "taskId": "a1", "to": "architect", "payload": {}},
+            {"type": "task_request", "taskId": "d1", "to": "developer", "payload": {}},
+            {"type": "task_request", "taskId": "q1", "to": "qa_engineer", "payload": {}},
+        ]
+        g = self.compute(log)
+        assert [a["name"] for a in g["agents"]] == [
+            "project_manager",
+            "architect",
+            "developer",
+            "qa_engineer",
+        ]
+
+    def test_goal_falls_back_to_first_task_line(self) -> None:
+        log = [
+            {
+                "type": "task_request",
+                "taskId": "x",
+                "to": "developer",
+                "payload": {"task": "Implement the thing\nDetails follow..."},
+            },
+        ]
+        g = self.compute(log)
+        dev = next(a for a in g["agents"] if a["name"] == "developer")
+        assert dev["tasks"][0]["goal"] == "Implement the thing"
+
+    def test_goal_uses_step_when_available(self) -> None:
+        log = [
+            {
+                "type": "task_request",
+                "taskId": "x",
+                "to": "developer",
+                "payload": {"step": "impl_config", "task": "Some long body"},
+            },
+        ]
+        g = self.compute(log)
+        dev = next(a for a in g["agents"] if a["name"] == "developer")
+        # step_id takes precedence — it's the shortest meaningful label.
+        assert dev["tasks"][0]["goal"] == "impl_config"
+
+
+def _extract_lang_block(body: str, lang: str) -> str:
+    """Extract the ``{ ... }`` body of the given language's TRANSLATIONS block.
+
+    Uses a simple brace counter rather than a nested regex so it
+    survives newlines and comments inside the table."""
+    needle = f"{lang}: {{"
+    start = body.find(needle)
+    assert start >= 0, f"lang block not found: {lang}"
+    depth = 0
+    open_brace = body.find("{", start)
+    i = open_brace
+    while i < len(body):
+        ch = body[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return body[open_brace : i + 1]
+        i += 1
+    raise AssertionError(f"unmatched braces for lang block: {lang}")


### PR DESCRIPTION
The run detail page previously exposed a single view — stage-progress chips + A2A task log. This adds a second view, selectable via a pill tab strip at the top of the page, that renders the run as an agent graph:

- **Orchestrator card** on the top row (one card — typically ``project_manager``).
- **Worker row** below: one card per agent that received at least one dispatch, laid out in a responsive grid sized to the worker count.
- **Vertical arrows** between the orchestrator and each worker with an inline dispatch-count badge (``N dispatches`` / ``N 次派发``).
- Each agent card surfaces:
  * role tag (Orchestrator / Worker)
  * live status pill (Idle / Working N / Done)
  * running / completed / failed counters
  * per-agent task list with goal + status icon, truncated to the most recent 12 entries so cards stay scannable in long runs

All derivation happens client-side from the existing ``task_log`` events — no new backend fields required. ``computeAgentGraph`` aggregates ``task_request`` + ``task_response`` events into ``{ agents, edges, tasks }``. Workers appear in first-dispatch order (reads naturally as the workflow progresses); edges are bumped per dispatch so the badge counts match the A2A log exactly.

The tab strip state lives only in component state — no deep-linking, no query param. Preference is not the right persistence layer for a per-session UI toggle; if a user wants a specific view they click it and that's what they get for the rest of the session.

Under 900 px viewport: workers stack vertically and edges hide (collapsing to a plain list — the card content still reads top-to- bottom as the orchestrator-driven flow).

Files
- ``src/aise/web/static/app.js`` — new ``AgentInteractionView`` + ``AgentCard`` + ``AgentStatusBadge`` components; ``computeAgentGraph`` helper; view switcher wired into ``RunApp``; 16 new i18n keys (``run.view.*`` + ``agents.*``) added to zh + en tables in lockstep.
- ``src/aise/web/static/main.css`` — 274 lines of scoped styles reusing existing design tokens (``--primary``, ``--success``, etc.) so the view matches the rest of the console.
- ``src/aise/web/templates/layout.html`` — cache-bust version bumped to ``20260419d`` (CSS + JS) so returning users pull the new bundle.
- ``tests/test_web/test_agent_interaction_view.py`` — 12 new tests split into two classes:
  * ``TestAgentInteractionStructuralPresence`` — view switcher tabs, component definitions, RunApp wiring, i18n key parity across zh + en, and every referenced CSS class exists in main.css.
  * ``TestComputeAgentGraphSemantics`` — Python port of the JS helper pins the derivation rules: empty log, single dispatch, repeated dispatches bump the edge, per-status counts, dispatch-order preservation, goal fallback to step-id then first line of task.

Full suite: 788 passed, 26 skipped. Ruff clean, format clean.

Manual verification (TestClient):
- GET /projects/<id>/runs/<rid> → HTML contains ``run-view-tabs``
  + ``AgentInteractionView`` references + both i18n keys.
- Cache-bust confirmed: ``?v=20260419d`` in both CSS and JS links.