### PR TITLE
feat(web): stage-label resilience + i18next migration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ aise = "aise.main:main"
 where = ["src"]
 
 [tool.setuptools.package-data]
-"aise.web" = ["templates/*.html", "static/*.css", "static/*.js"]
+"aise.web" = ["templates/*.html", "static/*.css", "static/*.js", "static/*.ico", "static/*.png", "static/locales/*/*.json"]
 
 [tool.ruff]
 target-version = "py311"

--- a/src/aise/web/static/app.js
+++ b/src/aise/web/static/app.js
@@ -819,6 +819,19 @@ function setupRunReact() {
     return false;
   }
 
+  // Normalize a raw stage id down to its canonical "phase" id by
+  // stripping the counter suffix. ``implementation_layer1`` and
+  // ``implementation_layer2`` both normalize to ``implementation`` so
+  // the chip strip shows a single "开发实现 / Implementation" chip
+  // instead of one chip per layer. The expanded log entries still
+  // show the raw ``ev.stage`` value (``implementation_layer1``) so
+  // per-layer progress is not lost.
+  function normalizeStageId(stage) {
+    if (!stage) return stage;
+    var m = String(stage).match(STAGE_SUFFIX_RE);
+    return m ? m[1] : stage;
+  }
+
   function resolveStageLabel(stage) {
     if (!stage) return stage;
 
@@ -833,6 +846,17 @@ function setupRunReact() {
     }
 
     return humanizeStageId(stage);
+  }
+
+  // Chip-strip label: always uses the NORMALIZED stage id so
+  // ``implementation_layer2`` renders as just "Implementation" without
+  // a "#2" suffix. This keeps the phase progression readable when a
+  // phase has many sub-layers.
+  function resolveChipLabel(stage) {
+    if (!stage) return stage;
+    var normalized = normalizeStageId(stage);
+    if (stageKeyExists(normalized)) return t("stage." + normalized);
+    return humanizeStageId(normalized);
   }
 
   const EVENT_ICONS = {
@@ -898,17 +922,32 @@ function setupRunReact() {
       return () => { active = false; clearInterval(tid); };
     }, [project.info.project_id, run.run_id, isRunning]);
 
-    // Derive stages and tag each event with its stage
+    // Derive stages and tag each event with its stage.
+    //
+    // We track TWO things per event: the raw ``ev.stage`` (used in the
+    // expanded log entry so the per-layer detail stays visible) and
+    // the NORMALIZED stage id (e.g. ``implementation`` for
+    // ``implementation_layer1``). The chip strip only shows normalized
+    // ids, deduped, so multi-layer phases render as one chip.
     const stages = [];
-    const stageSet = new Set();
-    let curStage = null;
-    const evStages = taskLog.map((ev) => {
+    const normalizedSeen = new Set();
+    let curRawStage = null;
+    let curNormalizedStage = null;
+    const evStagesRaw = [];
+    const evStagesNormalized = [];
+    for (let i = 0; i < taskLog.length; i++) {
+      const ev = taskLog[i];
       if (ev.type === "stage_update" && ev.stage) {
-        curStage = ev.stage;
-        if (!stageSet.has(ev.stage)) { stageSet.add(ev.stage); stages.push(ev.stage); }
+        curRawStage = ev.stage;
+        curNormalizedStage = normalizeStageId(ev.stage);
+        if (!normalizedSeen.has(curNormalizedStage)) {
+          normalizedSeen.add(curNormalizedStage);
+          stages.push(curNormalizedStage);
+        }
       }
-      return curStage;
-    });
+      evStagesRaw.push(curRawStage);
+      evStagesNormalized.push(curNormalizedStage);
+    }
     const requests = taskLog.filter((e) => e.type === "task_request");
     const responses = taskLog.filter((e) => e.type === "task_response");
     const completed = responses.filter((e) => e.status === "completed").length;
@@ -984,8 +1023,11 @@ function setupRunReact() {
     const visibleLog = taskLog.filter(
       (e) => e.type !== "todos_update" && e.type !== "task_response",
     );
+    // Filter predicate uses the NORMALIZED stage so a single
+    // ``implementation`` chip matches every ``implementation_layer*``
+    // event, not just the one raw id the user clicked.
     const visibleStages = taskLog
-      .map((_, i) => evStages[i])
+      .map((_, i) => evStagesNormalized[i])
       .filter(
         (_, i) =>
           taskLog[i].type !== "todos_update" &&
@@ -1071,15 +1113,13 @@ function setupRunReact() {
             var lastStageIdx = stages.length - 1;
             var isDone = isRunning ? i < lastStageIdx : true;
             var isCurrent = isRunning && i === lastStageIdx;
-            var isCycle = /_cycle_\d+$/.test(s);
             var cls = "run-stage-chip run-stage-clickable"
-              + (isCycle ? " run-stage-cycle" : "")
               + (stageFilter === s ? " run-stage-selected" : "")
               + (isDone && !isCurrent ? " run-stage-done" : "")
               + (isCurrent ? " run-stage-active" : "");
             return h(window.React.Fragment, { key: s },
               i > 0 ? h("span", { className: "run-stage-arrow" + (isDone ? " run-stage-arrow-done" : "") }, "\u2192") : null,
-              h("span", { className: cls, onClick: function() { toggleStage(s); } }, resolveStageLabel(s) || s),
+              h("span", { className: cls, onClick: function() { toggleStage(s); } }, resolveChipLabel(s) || s),
             );
           }),
         ),

--- a/src/aise/web/static/app.js
+++ b/src/aise/web/static/app.js
@@ -33,216 +33,80 @@ function mountReact(rootId, componentFactory) {
 }
 
 // ---------------------------------------------------------------------------
-// i18n
+// i18n (i18next)
 // ---------------------------------------------------------------------------
 //
-// Every user-facing string on the run-detail and task-detail pages (the
-// pages the user spends the most time on) is routed through ``t(key)``.
-// The language is chosen by the user in Settings; the server emits it
-// as ``window.__AISE_LANG`` (see layout.html) before this file loads.
+// Translations are standard i18next JSON resource files served by
+// FastAPI's StaticFiles mount under ``/static/locales/<lng>/<ns>.json``.
+// Adding a new language = drop a new ``<code>/translation.json`` folder;
+// no code change required.
 //
-// Supported languages: ``zh`` (Simplified Chinese), ``en`` (English).
-// When a key is missing in the chosen language we fall back to English,
-// then to the raw key — loud so missing translations are visible during
-// development instead of silently showing "undefined".
+// The initial language is authoritative from the server (user's Settings)
+// and comes through the ``window.__AISE_LANG`` global seeded by layout.html.
+// i18next is loaded from CDN in layout.html alongside its http-backend
+// plugin, so by the time this file runs ``window.i18next`` exists.
 //
-// Keys use dotted namespaces (``run.section.stage_progress``). Plain
-// string values with ``{placeholder}`` tokens are substituted via the
-// second argument to ``t()``.
-const TRANSLATIONS = {
-  zh: {
-    "run.back.project_fallback": "Project",
-    "run.title": "执行详情",
-    "run.status.completed": "已完成",
-    "run.status.failed": "失败",
-    "run.status.running": "运行中",
-    "run.status.pending": "等待",
-    "run.mode.initial": "初始",
-    "run.mode.incremental": "增量",
-    "run.mode.incremental_hint": "基于已完成的项目基线追加的新需求。执行增量设计、增量开发、全量测试。",
-    "run.section.requirement": "需求",
-    "run.stat.stages": "阶段",
-    "run.stat.dispatches": "任务派发",
-    "run.stat.completed": "已完成",
-    "run.stat.failed": "失败",
-    "run.section.stage_progress": "阶段进度",
-    "run.section.stage_progress_filter_hint": " — 点击取消筛选",
-    "run.section.log_title": "A2A 任务日志",
-    "run.log.waiting": "等待任务派发...",
-    "run.log.empty": "无任务日志",
-    "run.section.delivery_report": "交付报告",
-    "run.section.error": "错误",
-    "entry.meta.stage": "阶段: ",
-    "entry.meta.status": "状态: ",
-    "entry.meta.task_id": "任务: ",
-    "entry.meta.step": "步骤: ",
-    "entry.meta.phase": "阶段: ",
-    "entry.meta.output": "输出: {n} 字符",
-    "entry.status.completed": "✓ 已完成",
-    "entry.status.failed": "✕ 失败",
-    "entry.status.running": "● 进行中",
-    "entry.task_description_title": "任务描述",
-    "entry.execution_result_title": "执行结果",
-    "entry.no_text_output": "(无文本输出 — agent 已直接写入文件)",
-    "entry.fallback_task_name": "任务",
-    "entry.summary_no_summary": "(无摘要)",
-    "entry.tool_fallback_name": "tool",
-    "todo.title": "任务步骤",
-    "todo.status.pending": "待处理",
-    "todo.status.in_progress": "进行中",
-    "todo.status.completed": "已完成",
-    "task.title": "任务详情",
-    "task.field.phase": "阶段",
-    "task.field.task_key": "任务",
-    "task.field.status": "状态",
-    "stage.process_selection": "流程选择",
-    "stage.team_assembly": "团队组建",
-    "stage.workflow_planning": "流程规划",
-    "stage.execution": "任务执行",
-    "stage.phase_1_requirement": "需求分析",
-    "stage.phase_2_design": "架构设计",
-    "stage.phase_3_implementation": "开发实现",
-    "stage.phase_4_verification": "测试验证",
-    // Phase names emitted by the orchestrator / PM at dispatch time
-    // (``phase=`` argument on ``dispatch_task``). These are the raw
-    // free-form strings the PM picks and they land verbatim in
-    // ``stage_update`` events. Keep the zh/en tables in lockstep.
-    "stage.requirement": "需求分析",
-    "stage.design": "架构设计",
-    "stage.implementation": "开发实现",
-    "stage.testing": "测试验证",
-    "stage.verification": "测试验证",
-    "stage.sprint_planning": "迭代规划",
-    "stage.sprint_design": "迭代设计",
-    "stage.sprint_execution": "快速开发",
-    "stage.sprint_main_entry": "入口验证",
-    "stage.sprint_review": "迭代评审",
-    "stage.sprint_retrospective": "迭代复盘",
-    "stage.delivery": "交付报告",
-    "stage.requirements": "需求分析",
-    "stage.architecture": "架构设计",
-    "stage.main_entry": "入口验证",
-    "stage.qa_testing": "集成测试",
-    "run.view.timeline": "阶段视图",
-    "run.view.agents": "Agent 交互",
-    "agents.section_title": "Agent 交互视图",
-    "agents.role.orchestrator": "编排",
-    "agents.role.worker": "执行",
-    "agents.status.idle": "空闲",
-    "agents.status.working": "执行中 ({n})",
-    "agents.status.done": "已完成",
-    "agents.stat.running": "进行中任务",
-    "agents.stat.completed": "已完成任务",
-    "agents.stat.failed": "失败任务",
-    "agents.tasks_heading": "任务列表",
-    "agents.no_tasks": "暂无任务",
-    "agents.no_participants": "本次执行尚无其他 Agent 参与。",
-    "agents.waiting": "等待首个任务派发...",
-    "agents.dispatches": "{n} 次派发",
-  },
-  en: {
-    "run.back.project_fallback": "Project",
-    "run.title": "Run Details",
-    "run.status.completed": "Completed",
-    "run.status.failed": "Failed",
-    "run.status.running": "Running",
-    "run.status.pending": "Pending",
-    "run.mode.initial": "Initial",
-    "run.mode.incremental": "Incremental",
-    "run.mode.incremental_hint": "New requirement layered on an existing baseline. Runs incremental design, incremental implementation, and FULL test suite.",
-    "run.section.requirement": "Requirement",
-    "run.stat.stages": "Stages",
-    "run.stat.dispatches": "Dispatches",
-    "run.stat.completed": "Completed",
-    "run.stat.failed": "Failed",
-    "run.section.stage_progress": "Stage Progress",
-    "run.section.stage_progress_filter_hint": " — click to clear filter",
-    "run.section.log_title": "A2A Task Log",
-    "run.log.waiting": "Waiting for dispatches...",
-    "run.log.empty": "No task log",
-    "run.section.delivery_report": "Delivery Report",
-    "run.section.error": "Error",
-    "entry.meta.stage": "Stage: ",
-    "entry.meta.status": "Status: ",
-    "entry.meta.task_id": "Task: ",
-    "entry.meta.step": "Step: ",
-    "entry.meta.phase": "Phase: ",
-    "entry.meta.output": "Output: {n} chars",
-    "entry.status.completed": "✓ Completed",
-    "entry.status.failed": "✕ Failed",
-    "entry.status.running": "● Running",
-    "entry.task_description_title": "Task description",
-    "entry.execution_result_title": "Execution result",
-    "entry.no_text_output": "(no text output — agent wrote files directly)",
-    "entry.fallback_task_name": "Task",
-    "entry.summary_no_summary": "(no summary)",
-    "entry.tool_fallback_name": "tool",
-    "todo.title": "Task Steps",
-    "todo.status.pending": "Pending",
-    "todo.status.in_progress": "In progress",
-    "todo.status.completed": "Completed",
-    "task.title": "Task Details",
-    "task.field.phase": "Phase",
-    "task.field.task_key": "Task",
-    "task.field.status": "Status",
-    "stage.process_selection": "Process Selection",
-    "stage.team_assembly": "Team Assembly",
-    "stage.workflow_planning": "Workflow Planning",
-    "stage.execution": "Execution",
-    "stage.phase_1_requirement": "Requirements",
-    "stage.phase_2_design": "Architecture",
-    "stage.phase_3_implementation": "Implementation",
-    "stage.phase_4_verification": "Verification",
-    "stage.requirement": "Requirements",
-    "stage.design": "Architecture",
-    "stage.implementation": "Implementation",
-    "stage.testing": "Testing",
-    "stage.verification": "Verification",
-    "stage.sprint_planning": "Sprint Planning",
-    "stage.sprint_design": "Sprint Design",
-    "stage.sprint_execution": "Sprint Execution",
-    "stage.sprint_main_entry": "Entry Point",
-    "stage.sprint_review": "Sprint Review",
-    "stage.sprint_retrospective": "Retrospective",
-    "stage.delivery": "Delivery",
-    "stage.requirements": "Requirements",
-    "stage.architecture": "Architecture",
-    "stage.main_entry": "Entry Point",
-    "stage.qa_testing": "Integration Testing",
-    "run.view.timeline": "Timeline",
-    "run.view.agents": "Agent Interactions",
-    "agents.section_title": "Agent Interactions",
-    "agents.role.orchestrator": "Orchestrator",
-    "agents.role.worker": "Worker",
-    "agents.status.idle": "Idle",
-    "agents.status.working": "Working ({n})",
-    "agents.status.done": "Done",
-    "agents.stat.running": "Running tasks",
-    "agents.stat.completed": "Completed tasks",
-    "agents.stat.failed": "Failed tasks",
-    "agents.tasks_heading": "Tasks",
-    "agents.no_tasks": "No tasks yet",
-    "agents.no_participants": "No other agents have joined this run yet.",
-    "agents.waiting": "Waiting for the first dispatch...",
-    "agents.dispatches": "{n} dispatches",
-  },
-};
+// Rendering is async: the bootstrap waits on ``i18next.init()`` before
+// mounting React. This avoids a flash-of-raw-key on first paint.
+//
+// ``t(key, params)`` below is a thin wrapper that delegates to
+// ``i18next.t``. Keep it around so existing callers don't care whether
+// i18next is loaded yet.
 
-function currentLang() {
-  const raw = (window.__AISE_LANG || "zh").toString().toLowerCase();
-  return TRANSLATIONS[raw] ? raw : "zh";
+const I18N_SUPPORTED_LANGS = ["zh", "en"];
+const I18N_DEFAULT_LANG = "zh";
+
+function resolveInitialLang() {
+  const raw = (window.__AISE_LANG || "").toString().toLowerCase();
+  return I18N_SUPPORTED_LANGS.indexOf(raw) >= 0 ? raw : I18N_DEFAULT_LANG;
+}
+
+// Bootstraps i18next once per page load. Subsequent calls return the
+// same promise so multiple page-specific setup functions (dashboard,
+// run, task, etc.) can all ``await`` the shared init.
+let _i18nReady = null;
+function initI18n() {
+  if (_i18nReady) return _i18nReady;
+  if (!window.i18next || !window.i18nextHttpBackend) {
+    // Vendor scripts didn't load (offline / CDN blocked). Resolve the
+    // promise so pages still mount; ``t()`` will fall through to the
+    // raw key and at least be legible in English-ish form.
+    _i18nReady = Promise.resolve(null);
+    return _i18nReady;
+  }
+  _i18nReady = window.i18next.use(window.i18nextHttpBackend).init({
+    lng: resolveInitialLang(),
+    fallbackLng: "en",
+    supportedLngs: I18N_SUPPORTED_LANGS,
+    defaultNS: "translation",
+    ns: ["translation"],
+    backend: {
+      loadPath: "/static/locales/{{lng}}/{{ns}}.json",
+    },
+    interpolation: {
+      // React escapes children already — don't double-escape.
+      escapeValue: false,
+    },
+    returnEmptyString: false,
+  });
+  return _i18nReady;
 }
 
 function t(key, params) {
-  const lang = currentLang();
-  const table = TRANSLATIONS[lang] || TRANSLATIONS.zh;
-  let template = table[key];
-  if (template === undefined) template = TRANSLATIONS.en[key];
-  if (template === undefined) template = key;
-  if (!params) return template;
-  return template.replace(/\{(\w+)\}/g, function (m, name) {
-    return Object.prototype.hasOwnProperty.call(params, name) ? params[name] : m;
-  });
+  if (window.i18next && window.i18next.isInitialized) {
+    return window.i18next.t(key, params);
+  }
+  // Pre-init fallback: return the key itself. Any code that renders
+  // before ``await initI18n()`` will show raw keys — which is louder
+  // than silent undefined and easy to spot in dev.
+  return key;
+}
+
+function currentLang() {
+  if (window.i18next && window.i18next.language) {
+    return String(window.i18next.language).toLowerCase();
+  }
+  return resolveInitialLang();
 }
 
 function formatLocalTime(ts) {
@@ -915,9 +779,9 @@ function setupRunReact() {
   const initial = readScriptJson("run-initial-data", { project: null, run: null });
   if (!initial.project || !initial.run) return;
 
-  // Stage names live in the top-level ``TRANSLATIONS`` table under the
-  // ``stage.<id>`` namespace — see the i18n block at the top of this
-  // file. Phase names are free-form strings the PM picks at dispatch
+  // Stage names live in the ``stage.<id>`` namespace of the i18next
+  // resource files under ``static/locales/<lng>/translation.json``.
+  // Phase names are free-form strings the PM picks at dispatch
   // time, so this resolver has to handle three cases:
   //
   //   1. Exact match on the full stage id  (``architecture`` → 架构设计)
@@ -929,8 +793,9 @@ function setupRunReact() {
   //      ``Impl Config Loader``) so the user never sees a raw
   //      snake_case identifier among Chinese labels.
   //
-  // ``t()`` returns the raw ``"stage.<id>"`` key when nothing matches,
-  // so we use string-equality with the probe key to detect a miss.
+  // Missing-key detection uses i18next's built-in ``exists`` so we
+  // don't depend on any string-equality trick between the probe key
+  // and the return value.
   function humanizeStageId(stage) {
     return String(stage)
       .split(/[_-]+/)
@@ -946,17 +811,24 @@ function setupRunReact() {
   // numeric N.
   var STAGE_SUFFIX_RE = /^(.+?)_(?:layer|cycle|part|iter|iteration|round|stage|v|step)_?(\d+)$/;
 
+  function stageKeyExists(stageId) {
+    var key = "stage." + stageId;
+    if (window.i18next && window.i18next.isInitialized) {
+      return window.i18next.exists(key);
+    }
+    return false;
+  }
+
   function resolveStageLabel(stage) {
     if (!stage) return stage;
-    var probe = "stage." + stage;
-    var translated = t(probe);
-    if (translated !== probe) return translated;
+
+    if (stageKeyExists(stage)) return t("stage." + stage);
 
     var suffix = stage.match(STAGE_SUFFIX_RE);
     if (suffix) {
-      var baseKey = "stage." + suffix[1];
-      var base = t(baseKey);
-      if (base === baseKey) base = humanizeStageId(suffix[1]);
+      var base = stageKeyExists(suffix[1])
+        ? t("stage." + suffix[1])
+        : humanizeStageId(suffix[1]);
       return base + " #" + suffix[2];
     }
 
@@ -972,7 +844,7 @@ function setupRunReact() {
   };
 
   // Todo status labels resolve via ``t()`` — see ``todo.status.*`` keys
-  // in the top-level TRANSLATIONS table.
+  // in the i18next locale resource files.
   function todoStatusLabel(status) {
     var key = "todo.status." + status;
     var translated = t(key);
@@ -1660,8 +1532,6 @@ function setupTaskReact() {
   function TaskApp() {
     const h = window.React.createElement;
     const task = initial.task || {};
-    const backLabel = currentLang() === "en" ? "\u2190 Back to Run Details" : "\u2190 返回执行详情";
-    const artifactLabel = currentLang() === "en" ? "Artifact ID" : "产物ID";
     return h(
       "section",
       { className: "card card-glow" },
@@ -1669,7 +1539,7 @@ function setupTaskReact() {
       h("p", null, `${t("task.field.phase")}: ${initial.phase_name}`),
       h("p", null, `${t("task.field.task_key")}: ${initial.task_key}`),
       h("p", null, `${t("task.field.status")}: ${task.status || ""}`),
-      task.artifact_id ? h("p", null, `${artifactLabel}: ${task.artifact_id}`) : null,
+      task.artifact_id ? h("p", null, `${t("task.field.artifact_id")}: ${task.artifact_id}`) : null,
       task.error ? h("pre", { className: "error" }, task.error) : null,
       h(
         "a",
@@ -1677,7 +1547,7 @@ function setupTaskReact() {
           className: "btn secondary",
           href: `/projects/${encodeURIComponent(initial.project_id)}/runs/${encodeURIComponent(initial.run_id)}`,
         },
-        backLabel,
+        t("task.back_to_run"),
       )
     );
   }
@@ -2210,11 +2080,16 @@ function setupMonitorReact() {
 }
 
 document.addEventListener("DOMContentLoaded", () => {
-  setupDashboardReact();
-  setupProjectReact();
-  setupRunReact();
-  setupTaskReact();
-  setupLoginReact();
-  setupModelsConfigPage();
-  setupMonitorReact();
+  // Wait for i18next to finish loading its resource files before
+  // mounting any React tree. First paint therefore has the correct
+  // translations — no flash of raw ``stage.xxx`` keys.
+  initI18n().finally(() => {
+    setupDashboardReact();
+    setupProjectReact();
+    setupRunReact();
+    setupTaskReact();
+    setupLoginReact();
+    setupModelsConfigPage();
+    setupMonitorReact();
+  });
 });

--- a/src/aise/web/static/app.js
+++ b/src/aise/web/static/app.js
@@ -103,10 +103,15 @@ const TRANSLATIONS = {
     "stage.phase_2_design": "架构设计",
     "stage.phase_3_implementation": "开发实现",
     "stage.phase_4_verification": "测试验证",
+    // Phase names emitted by the orchestrator / PM at dispatch time
+    // (``phase=`` argument on ``dispatch_task``). These are the raw
+    // free-form strings the PM picks and they land verbatim in
+    // ``stage_update`` events. Keep the zh/en tables in lockstep.
     "stage.requirement": "需求分析",
     "stage.design": "架构设计",
     "stage.implementation": "开发实现",
     "stage.testing": "测试验证",
+    "stage.verification": "测试验证",
     "stage.sprint_planning": "迭代规划",
     "stage.sprint_design": "迭代设计",
     "stage.sprint_execution": "快速开发",
@@ -192,6 +197,7 @@ const TRANSLATIONS = {
     "stage.design": "Architecture",
     "stage.implementation": "Implementation",
     "stage.testing": "Testing",
+    "stage.verification": "Verification",
     "stage.sprint_planning": "Sprint Planning",
     "stage.sprint_design": "Sprint Design",
     "stage.sprint_execution": "Sprint Execution",
@@ -911,19 +917,50 @@ function setupRunReact() {
 
   // Stage names live in the top-level ``TRANSLATIONS`` table under the
   // ``stage.<id>`` namespace — see the i18n block at the top of this
-  // file. Resolution below consults the active language via ``t()``.
-  // Dynamic stage label resolver (handles implementation_cycle_1, etc.)
+  // file. Phase names are free-form strings the PM picks at dispatch
+  // time, so this resolver has to handle three cases:
+  //
+  //   1. Exact match on the full stage id  (``architecture`` → 架构设计)
+  //   2. Known suffix patterns that carry a numeric counter —
+  //      ``implementation_layer1`` / ``implementation_cycle_3`` /
+  //      ``design_part_2`` etc. Strip the suffix, translate the base,
+  //      append ``#N``.
+  //   3. Unknown stage id: humanize it (``impl_config_loader`` →
+  //      ``Impl Config Loader``) so the user never sees a raw
+  //      snake_case identifier among Chinese labels.
+  //
+  // ``t()`` returns the raw ``"stage.<id>"`` key when nothing matches,
+  // so we use string-equality with the probe key to detect a miss.
+  function humanizeStageId(stage) {
+    return String(stage)
+      .split(/[_-]+/)
+      .filter(function (w) { return w.length > 0; })
+      .map(function (w) {
+        return w.charAt(0).toUpperCase() + w.slice(1);
+      })
+      .join(" ");
+  }
+
+  // Trailing counter suffix: ``_layer1`` / ``_layer_1`` / ``_cycle2`` /
+  // ``_part_3`` / ``_iter4`` / ``_round_5`` / ``_v2``. Captures base +
+  // numeric N.
+  var STAGE_SUFFIX_RE = /^(.+?)_(?:layer|cycle|part|iter|iteration|round|stage|v|step)_?(\d+)$/;
+
   function resolveStageLabel(stage) {
-    var translated = t("stage." + stage);
-    if (translated !== "stage." + stage) return translated;
-    var cycleMatch = stage.match(/^(.+)_cycle_(\d+)$/);
-    if (cycleMatch) {
-      var baseKey = "stage." + cycleMatch[1];
+    if (!stage) return stage;
+    var probe = "stage." + stage;
+    var translated = t(probe);
+    if (translated !== probe) return translated;
+
+    var suffix = stage.match(STAGE_SUFFIX_RE);
+    if (suffix) {
+      var baseKey = "stage." + suffix[1];
       var base = t(baseKey);
-      if (base === baseKey) base = cycleMatch[1];
-      return base + " #" + cycleMatch[2];
+      if (base === baseKey) base = humanizeStageId(suffix[1]);
+      return base + " #" + suffix[2];
     }
-    return stage;
+
+    return humanizeStageId(stage);
   }
 
   const EVENT_ICONS = {

--- a/src/aise/web/static/locales/en/translation.json
+++ b/src/aise/web/static/locales/en/translation.json
@@ -1,0 +1,128 @@
+{
+  "run": {
+    "back": {
+      "project_fallback": "Project"
+    },
+    "title": "Run Details",
+    "status": {
+      "completed": "Completed",
+      "failed": "Failed",
+      "running": "Running",
+      "pending": "Pending"
+    },
+    "mode": {
+      "initial": "Initial",
+      "incremental": "Incremental",
+      "incremental_hint": "New requirement layered on an existing baseline. Runs incremental design, incremental implementation, and FULL test suite."
+    },
+    "section": {
+      "requirement": "Requirement",
+      "stage_progress": "Stage Progress",
+      "stage_progress_filter_hint": " — click to clear filter",
+      "log_title": "A2A Task Log",
+      "delivery_report": "Delivery Report",
+      "error": "Error"
+    },
+    "stat": {
+      "stages": "Stages",
+      "dispatches": "Dispatches",
+      "completed": "Completed",
+      "failed": "Failed"
+    },
+    "log": {
+      "waiting": "Waiting for dispatches...",
+      "empty": "No task log"
+    },
+    "view": {
+      "timeline": "Timeline",
+      "agents": "Agent Interactions"
+    }
+  },
+  "entry": {
+    "meta": {
+      "stage": "Stage: ",
+      "status": "Status: ",
+      "task_id": "Task: ",
+      "step": "Step: ",
+      "phase": "Phase: ",
+      "output": "Output: {{n}} chars"
+    },
+    "status": {
+      "completed": "✓ Completed",
+      "failed": "✕ Failed",
+      "running": "● Running"
+    },
+    "task_description_title": "Task description",
+    "execution_result_title": "Execution result",
+    "no_text_output": "(no text output — agent wrote files directly)",
+    "fallback_task_name": "Task",
+    "summary_no_summary": "(no summary)",
+    "tool_fallback_name": "tool"
+  },
+  "todo": {
+    "title": "Task Steps",
+    "status": {
+      "pending": "Pending",
+      "in_progress": "In progress",
+      "completed": "Completed"
+    }
+  },
+  "task": {
+    "title": "Task Details",
+    "field": {
+      "phase": "Phase",
+      "task_key": "Task",
+      "status": "Status",
+      "artifact_id": "Artifact ID"
+    },
+    "back_to_run": "← Back to Run Details"
+  },
+  "stage": {
+    "process_selection": "Process Selection",
+    "team_assembly": "Team Assembly",
+    "workflow_planning": "Workflow Planning",
+    "execution": "Execution",
+    "phase_1_requirement": "Requirements",
+    "phase_2_design": "Architecture",
+    "phase_3_implementation": "Implementation",
+    "phase_4_verification": "Verification",
+    "requirement": "Requirements",
+    "requirements": "Requirements",
+    "design": "Architecture",
+    "architecture": "Architecture",
+    "implementation": "Implementation",
+    "main_entry": "Entry Point",
+    "testing": "Testing",
+    "verification": "Verification",
+    "qa_testing": "Integration Testing",
+    "delivery": "Delivery",
+    "sprint_planning": "Sprint Planning",
+    "sprint_design": "Sprint Design",
+    "sprint_execution": "Sprint Execution",
+    "sprint_main_entry": "Entry Point",
+    "sprint_review": "Sprint Review",
+    "sprint_retrospective": "Retrospective"
+  },
+  "agents": {
+    "section_title": "Agent Interactions",
+    "role": {
+      "orchestrator": "Orchestrator",
+      "worker": "Worker"
+    },
+    "status": {
+      "idle": "Idle",
+      "working": "Working ({{n}})",
+      "done": "Done"
+    },
+    "stat": {
+      "running": "Running tasks",
+      "completed": "Completed tasks",
+      "failed": "Failed tasks"
+    },
+    "tasks_heading": "Tasks",
+    "no_tasks": "No tasks yet",
+    "no_participants": "No other agents have joined this run yet.",
+    "waiting": "Waiting for the first dispatch...",
+    "dispatches": "{{n}} dispatches"
+  }
+}

--- a/src/aise/web/static/locales/zh/translation.json
+++ b/src/aise/web/static/locales/zh/translation.json
@@ -1,0 +1,128 @@
+{
+  "run": {
+    "back": {
+      "project_fallback": "Project"
+    },
+    "title": "执行详情",
+    "status": {
+      "completed": "已完成",
+      "failed": "失败",
+      "running": "运行中",
+      "pending": "等待"
+    },
+    "mode": {
+      "initial": "初始",
+      "incremental": "增量",
+      "incremental_hint": "基于已完成的项目基线追加的新需求。执行增量设计、增量开发、全量测试。"
+    },
+    "section": {
+      "requirement": "需求",
+      "stage_progress": "阶段进度",
+      "stage_progress_filter_hint": " — 点击取消筛选",
+      "log_title": "A2A 任务日志",
+      "delivery_report": "交付报告",
+      "error": "错误"
+    },
+    "stat": {
+      "stages": "阶段",
+      "dispatches": "任务派发",
+      "completed": "已完成",
+      "failed": "失败"
+    },
+    "log": {
+      "waiting": "等待任务派发...",
+      "empty": "无任务日志"
+    },
+    "view": {
+      "timeline": "阶段视图",
+      "agents": "Agent 交互"
+    }
+  },
+  "entry": {
+    "meta": {
+      "stage": "阶段: ",
+      "status": "状态: ",
+      "task_id": "任务: ",
+      "step": "步骤: ",
+      "phase": "阶段: ",
+      "output": "输出: {{n}} 字符"
+    },
+    "status": {
+      "completed": "✓ 已完成",
+      "failed": "✕ 失败",
+      "running": "● 进行中"
+    },
+    "task_description_title": "任务描述",
+    "execution_result_title": "执行结果",
+    "no_text_output": "(无文本输出 — agent 已直接写入文件)",
+    "fallback_task_name": "任务",
+    "summary_no_summary": "(无摘要)",
+    "tool_fallback_name": "tool"
+  },
+  "todo": {
+    "title": "任务步骤",
+    "status": {
+      "pending": "待处理",
+      "in_progress": "进行中",
+      "completed": "已完成"
+    }
+  },
+  "task": {
+    "title": "任务详情",
+    "field": {
+      "phase": "阶段",
+      "task_key": "任务",
+      "status": "状态",
+      "artifact_id": "产物ID"
+    },
+    "back_to_run": "← 返回执行详情"
+  },
+  "stage": {
+    "process_selection": "流程选择",
+    "team_assembly": "团队组建",
+    "workflow_planning": "流程规划",
+    "execution": "任务执行",
+    "phase_1_requirement": "需求分析",
+    "phase_2_design": "架构设计",
+    "phase_3_implementation": "开发实现",
+    "phase_4_verification": "测试验证",
+    "requirement": "需求分析",
+    "requirements": "需求分析",
+    "design": "架构设计",
+    "architecture": "架构设计",
+    "implementation": "开发实现",
+    "main_entry": "入口验证",
+    "testing": "测试验证",
+    "verification": "测试验证",
+    "qa_testing": "集成测试",
+    "delivery": "交付报告",
+    "sprint_planning": "迭代规划",
+    "sprint_design": "迭代设计",
+    "sprint_execution": "快速开发",
+    "sprint_main_entry": "入口验证",
+    "sprint_review": "迭代评审",
+    "sprint_retrospective": "迭代复盘"
+  },
+  "agents": {
+    "section_title": "Agent 交互视图",
+    "role": {
+      "orchestrator": "编排",
+      "worker": "执行"
+    },
+    "status": {
+      "idle": "空闲",
+      "working": "执行中 ({{n}})",
+      "done": "已完成"
+    },
+    "stat": {
+      "running": "进行中任务",
+      "completed": "已完成任务",
+      "failed": "失败任务"
+    },
+    "tasks_heading": "任务列表",
+    "no_tasks": "暂无任务",
+    "no_participants": "本次执行尚无其他 Agent 参与。",
+    "waiting": "等待首个任务派发...",
+    "dispatches": "{{n}} 次派发"
+  }
+}

--- a/src/aise/web/templates/layout.html
+++ b/src/aise/web/templates/layout.html
@@ -73,7 +73,13 @@
   <script>window.__AISE_LANG = {{ get_ui_language()|tojson }};</script>
   <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
-  <script src="/static/app.js?v=20260421b"></script>
+  <!-- i18next: industry-standard i18n runtime. Resource JSON files live
+       under /static/locales/<lng>/<ns>.json. ``window.__AISE_LANG`` is
+       seeded by the server from the user's Settings so the initial
+       language is authoritative. -->
+  <script src="https://unpkg.com/i18next@23.11.5/dist/umd/i18next.min.js"></script>
+  <script src="https://unpkg.com/i18next-http-backend@2.5.2/i18nextHttpBackend.min.js"></script>
+  <script src="/static/app.js?v=20260421c"></script>
   {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/tests/test_web/test_stage_labels.py
+++ b/tests/test_web/test_stage_labels.py
@@ -224,6 +224,55 @@ class TestStageLabelResolverHelpers:
         body = APP_JS.read_text(encoding="utf-8")
         assert "i18next.exists" in body
 
+    def test_chip_strip_uses_resolveChipLabel_not_resolveStageLabel(self) -> None:
+        """The chip strip must call ``resolveChipLabel`` so multi-layer
+        phases render as one chip without a ``#N`` counter. An expanded
+        log entry still calls ``resolveStageLabel`` to show the raw
+        per-layer detail.
+
+        Regression guard for the pathology where
+        ``implementation_layer1`` / ``implementation_layer2`` each
+        rendered as their own chip, flooding the stage strip."""
+        body = APP_JS.read_text(encoding="utf-8")
+        # The chip .map() block references resolveChipLabel.
+        chip_block_start = body.find("run-stages-flow")
+        assert chip_block_start > 0
+        chip_block_end = body.find("run-log-empty", chip_block_start)
+        assert chip_block_end > chip_block_start
+        chip_block = body[chip_block_start:chip_block_end]
+        assert "resolveChipLabel" in chip_block, (
+            "chip strip must use resolveChipLabel; otherwise per-layer entries show with '#N' suffixes"
+        )
+        # And resolveStageLabel must still exist for the log-entry
+        # stage rows (expanded per-event detail).
+        assert "resolveStageLabel" in body
+
+    def test_normalize_stage_id_strips_suffix(self) -> None:
+        """``normalizeStageId`` is the function the chip accumulator
+        uses to dedupe. It must strip the same counter suffix that
+        ``STAGE_SUFFIX_RE`` recognizes, returning the base phase id."""
+        body = APP_JS.read_text(encoding="utf-8")
+        assert "function normalizeStageId(" in body, "normalizeStageId helper missing; chip collapse depends on it"
+        # The normalized id must be used in the stage accumulator — the
+        # chip list should be built from normalized ids, not raw ones.
+        acc_match = re.search(r"stages\.push\(curNormalizedStage\)", body)
+        assert acc_match, (
+            "stage accumulator must push curNormalizedStage, not the raw "
+            "ev.stage — otherwise implementation_layer1 and "
+            "implementation_layer2 become two separate chips"
+        )
+
+    def test_filter_uses_normalized_stage(self) -> None:
+        """Clicking the ``implementation`` chip must filter events
+        across every ``implementation_layer*`` variant, not just the
+        one raw id. The visibleStages array is therefore derived from
+        the NORMALIZED stage, not the raw one."""
+        body = APP_JS.read_text(encoding="utf-8")
+        assert re.search(
+            r"visibleStages\s*=\s*taskLog\s*\.\s*map\(\s*\(_,\s*i\)\s*=>\s*evStagesNormalized\[i\]\)",
+            body,
+        ), "visibleStages must be built from evStagesNormalized[i]"
+
     def test_resolver_has_humanize_fallback(self) -> None:
         """The final branch of ``resolveStageLabel`` must humanize the
         unknown id — pins the fix for the 2026-04-19 screenshot where

--- a/tests/test_web/test_stage_labels.py
+++ b/tests/test_web/test_stage_labels.py
@@ -1,0 +1,199 @@
+"""Regression guards for the frontend stage-label resolver.
+
+The React frontend in ``src/aise/web/static/app.js`` routes stage names
+through a ``resolveStageLabel`` helper. A screenshot on 2026-04-19
+showed the task-detail chips rendering as ``需求分析 → architecture
+→ implementation_layer1`` — mixed Chinese + raw English IDs — because:
+
+1. ``stage.architecture`` was missing from the translation table.
+2. The suffix matcher only handled ``_cycle_N``, not ``_layer1`` /
+   ``_part_2`` / ``_iter3`` etc.
+3. The fallback returned the raw snake_case ID instead of a
+   human-readable label.
+
+These tests pin the three fixes so a future edit can't reintroduce
+any of them.
+
+Because the resolver is JavaScript, we test it textually — grepping
+``app.js`` for the required translation keys and running Python
+regex against the published suffix pattern. That's enough to pin
+the contract; a JS-level unit test would require a JS runtime the
+repo does not have.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+import aise
+
+APP_JS = Path(aise.__file__).resolve().parent / "web" / "static" / "app.js"
+
+
+def _load_app_js() -> str:
+    assert APP_JS.is_file(), f"missing fixture: {APP_JS}"
+    return APP_JS.read_text(encoding="utf-8")
+
+
+class TestStageTranslationCoverage:
+    """Every phase name the orchestrator / PM emits at dispatch time
+    must have a translation entry in BOTH the ``zh`` and ``en``
+    sections of the ``TRANSLATIONS`` table.
+
+    This list reflects phase names observed in production runs on
+    project_3-snake (2026-04-18 → 2026-04-19) plus the
+    orchestrator-framework defaults. New phase names added in the
+    future should extend both the table and this test.
+    """
+
+    REQUIRED_STAGES = (
+        # Orchestrator framework phases (project_session.py).
+        "requirement",
+        "requirements",
+        "architecture",
+        "design",
+        "implementation",
+        "main_entry",
+        "testing",
+        "verification",
+        "qa_testing",
+        "delivery",
+        "execution",
+    )
+
+    @pytest.mark.parametrize("stage_id", REQUIRED_STAGES)
+    def test_key_present_in_zh_table(self, stage_id: str) -> None:
+        body = _load_app_js()
+        key = f'"stage.{stage_id}"'
+        # The zh table appears before the en table in the source, so
+        # finding the key anywhere implies at least one language has
+        # it — stricter assertion below pins both.
+        assert key in body, f"translation key missing: stage.{stage_id}"
+
+    @pytest.mark.parametrize("stage_id", REQUIRED_STAGES)
+    def test_key_present_in_both_tables(self, stage_id: str) -> None:
+        body = _load_app_js()
+        key = f'"stage.{stage_id}"'
+        # Both tables must have the key, so the occurrence count is 2
+        # (once in zh, once in en). A count of 1 means one table is
+        # missing the key and the frontend would fall back across
+        # languages for this stage.
+        assert body.count(key) == 2, (
+            f"stage.{stage_id} must appear in BOTH zh and en tables (found {body.count(key)} occurrences)"
+        )
+
+
+class TestStageSuffixPattern:
+    """The ``STAGE_SUFFIX_RE`` regex strips a trailing counter suffix
+    so labels like ``implementation_layer1`` resolve to "开发实现 #1"
+    / "Implementation #1" instead of being emitted verbatim.
+
+    The frontend regex is authored in JS; we extract it from app.js
+    and exercise it with Python's ``re`` (compatible syntax for the
+    patterns in use) so this test fails loudly if the pattern is
+    narrowed in a future edit."""
+
+    @pytest.fixture(scope="class")
+    def pattern(self) -> re.Pattern[str]:
+        body = _load_app_js()
+        m = re.search(r"var STAGE_SUFFIX_RE = (/\^.+?\$/);", body)
+        assert m, "STAGE_SUFFIX_RE declaration not found in app.js"
+        js_re = m.group(1)
+        # Strip the JS delimiter ``/.../`` — what's inside is valid
+        # Python regex syntax for this pattern.
+        py_src = js_re[1:-1]
+        return re.compile(py_src)
+
+    @pytest.mark.parametrize(
+        "stage,expected_base,expected_counter",
+        [
+            ("implementation_layer1", "implementation", "1"),
+            ("implementation_layer_2", "implementation", "2"),
+            ("implementation_cycle_3", "implementation", "3"),
+            ("design_part_2", "design", "2"),
+            ("architecture_iter4", "architecture", "4"),
+            ("architecture_iteration_5", "architecture", "5"),
+            ("testing_round_1", "testing", "1"),
+            ("delivery_v2", "delivery", "2"),
+            ("qa_testing_stage_3", "qa_testing", "3"),
+            ("requirement_step_1", "requirement", "1"),
+        ],
+    )
+    def test_suffix_stripped_correctly(
+        self,
+        pattern: re.Pattern[str],
+        stage: str,
+        expected_base: str,
+        expected_counter: str,
+    ) -> None:
+        m = pattern.match(stage)
+        assert m, f"pattern failed to match {stage!r}"
+        assert m.group(1) == expected_base
+        assert m.group(2) == expected_counter
+
+    @pytest.mark.parametrize(
+        "stage",
+        [
+            "architecture",  # no suffix → must NOT match
+            "implementation",  # no suffix
+            "main_entry",  # trailing token is not a counter suffix
+            "qa_testing",  # trailing token is not a counter suffix
+            "step_architecture_design",  # PM step id, no trailing counter
+        ],
+    )
+    def test_non_suffixed_stages_do_not_match(
+        self,
+        pattern: re.Pattern[str],
+        stage: str,
+    ) -> None:
+        m = pattern.match(stage)
+        assert not m, f"pattern wrongly matched {stage!r} — would strip valid stage id"
+
+
+class TestHumanizeFallbackPresent:
+    """When a stage id has no translation and no counter suffix the
+    resolver must fall back to a humanized Title Case label, not to
+    the raw snake_case id. Pinned by grepping for the helper and the
+    call site that uses it."""
+
+    def test_humanize_helper_defined(self) -> None:
+        body = _load_app_js()
+        assert "function humanizeStageId" in body
+
+    def test_resolver_falls_back_to_humanized_form(self) -> None:
+        """The unknown-stage fallback must call ``humanizeStageId`` —
+        pinning this prevents a future refactor from reinstating the
+        old ``return stage`` behavior that caused ``implementation_layer1``
+        to render verbatim among Chinese labels.
+
+        We locate the fallback by finding the ``resolveStageLabel``
+        declaration and asserting the body (up to the first balanced
+        closing brace at column 0 — the function's closing brace)
+        contains a ``return humanizeStageId(`` call.
+        """
+        body = _load_app_js()
+        start = body.find("function resolveStageLabel(stage)")
+        assert start >= 0, "resolveStageLabel not found"
+        # Walk forward until the function's closing ``}`` by tracking
+        # brace depth. This is robust against inner ``if {}`` blocks.
+        depth = 0
+        end = -1
+        in_fn = False
+        for i in range(start, len(body)):
+            ch = body[i]
+            if ch == "{":
+                depth += 1
+                in_fn = True
+            elif ch == "}":
+                depth -= 1
+                if in_fn and depth == 0:
+                    end = i
+                    break
+        assert end > start, "could not locate end of resolveStageLabel"
+        fn_src = body[start : end + 1]
+        assert "return humanizeStageId(stage)" in fn_src, (
+            "resolveStageLabel is missing the humanized-fallback branch — unknown stage ids must not be returned raw"
+        )

--- a/tests/test_web/test_stage_labels.py
+++ b/tests/test_web/test_stage_labels.py
@@ -1,28 +1,29 @@
-"""Regression guards for the frontend stage-label resolver.
+"""Regression guards for the frontend i18n translation resources.
 
-The React frontend in ``src/aise/web/static/app.js`` routes stage names
-through a ``resolveStageLabel`` helper. A screenshot on 2026-04-19
-showed the task-detail chips rendering as ``需求分析 → architecture
-→ implementation_layer1`` — mixed Chinese + raw English IDs — because:
+Translations live in standard i18next JSON resource files under
+``src/aise/web/static/locales/<lng>/translation.json`` (one folder per
+language, one JSON per namespace). These tests validate the resource
+files directly — no need to parse ``app.js``, no JS runtime needed.
 
-1. ``stage.architecture`` was missing from the translation table.
-2. The suffix matcher only handled ``_cycle_N``, not ``_layer1`` /
-   ``_part_2`` / ``_iter3`` etc.
-3. The fallback returned the raw snake_case ID instead of a
-   human-readable label.
+They pin three things:
 
-These tests pin the three fixes so a future edit can't reintroduce
-any of them.
+1. Every declared language has a resource file.
+2. The ``zh`` and ``en`` files have identical key sets — a missing key
+   on one side would make the UI fall through to i18next's fallback
+   language and render mixed Chinese/English, which is the exact
+   symptom that motivated this layer.
+3. Specific keys that the orchestrator / PM emits at dispatch time
+   (``stage.architecture``, ``stage.requirement``, etc.) are present.
+   These reflect phase names observed in project_3-snake runs.
 
-Because the resolver is JavaScript, we test it textually — grepping
-``app.js`` for the required translation keys and running Python
-regex against the published suffix pattern. That's enough to pin
-the contract; a JS-level unit test would require a JS runtime the
-repo does not have.
+The companion ``resolveStageLabel`` helper in ``app.js`` layers a
+suffix-stripper and humanize-fallback on top of i18next; that behavior
+is exercised indirectly by the regex + humanize presence checks below.
 """
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
@@ -30,82 +31,146 @@ import pytest
 
 import aise
 
-APP_JS = Path(aise.__file__).resolve().parent / "web" / "static" / "app.js"
+STATIC_DIR = Path(aise.__file__).resolve().parent / "web" / "static"
+LOCALES_DIR = STATIC_DIR / "locales"
+APP_JS = STATIC_DIR / "app.js"
+
+SUPPORTED_LANGS = ("zh", "en")
+
+# Phase names the orchestrator / PM emits at dispatch time (observed on
+# project_3-snake 2026-04-18 → 2026-04-19 plus the framework defaults
+# declared in project_session.py). Extending this list should go hand
+# in hand with extending both translation.json files.
+REQUIRED_STAGES: tuple[str, ...] = (
+    "requirement",
+    "requirements",
+    "architecture",
+    "design",
+    "implementation",
+    "main_entry",
+    "testing",
+    "verification",
+    "qa_testing",
+    "delivery",
+    "execution",
+)
 
 
-def _load_app_js() -> str:
-    assert APP_JS.is_file(), f"missing fixture: {APP_JS}"
-    return APP_JS.read_text(encoding="utf-8")
+def _flatten(obj: object, prefix: str = "") -> dict[str, str]:
+    """Flatten nested dicts into ``a.b.c`` dotted keys mapping to leaves."""
+    out: dict[str, str] = {}
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            sub = f"{prefix}.{k}" if prefix else k
+            out.update(_flatten(v, sub))
+    else:
+        out[prefix] = obj  # type: ignore[assignment]
+    return out
 
 
-class TestStageTranslationCoverage:
-    """Every phase name the orchestrator / PM emits at dispatch time
-    must have a translation entry in BOTH the ``zh`` and ``en``
-    sections of the ``TRANSLATIONS`` table.
+def _load_locale(lang: str) -> dict[str, str]:
+    path = LOCALES_DIR / lang / "translation.json"
+    assert path.is_file(), f"missing i18next resource: {path}"
+    return _flatten(json.loads(path.read_text(encoding="utf-8")))
 
-    This list reflects phase names observed in production runs on
-    project_3-snake (2026-04-18 → 2026-04-19) plus the
-    orchestrator-framework defaults. New phase names added in the
-    future should extend both the table and this test.
-    """
 
-    REQUIRED_STAGES = (
-        # Orchestrator framework phases (project_session.py).
-        "requirement",
-        "requirements",
-        "architecture",
-        "design",
-        "implementation",
-        "main_entry",
-        "testing",
-        "verification",
-        "qa_testing",
-        "delivery",
-        "execution",
-    )
+class TestLocaleResourceFiles:
+    @pytest.mark.parametrize("lang", SUPPORTED_LANGS)
+    def test_resource_file_exists_and_parses(self, lang: str) -> None:
+        """Each declared language must have a parseable translation.json."""
+        entries = _load_locale(lang)
+        assert entries, f"{lang} translation.json parsed to empty dict"
 
-    @pytest.mark.parametrize("stage_id", REQUIRED_STAGES)
-    def test_key_present_in_zh_table(self, stage_id: str) -> None:
-        body = _load_app_js()
-        key = f'"stage.{stage_id}"'
-        # The zh table appears before the en table in the source, so
-        # finding the key anywhere implies at least one language has
-        # it — stricter assertion below pins both.
-        assert key in body, f"translation key missing: stage.{stage_id}"
+    def test_zh_and_en_have_identical_key_sets(self) -> None:
+        """Key parity between languages: a key missing on one side causes
+        i18next to fall back across languages, producing the mixed
+        Chinese/English rendering that motivated this whole layer.
 
-    @pytest.mark.parametrize("stage_id", REQUIRED_STAGES)
-    def test_key_present_in_both_tables(self, stage_id: str) -> None:
-        body = _load_app_js()
-        key = f'"stage.{stage_id}"'
-        # Both tables must have the key, so the occurrence count is 2
-        # (once in zh, once in en). A count of 1 means one table is
-        # missing the key and the frontend would fall back across
-        # languages for this stage.
-        assert body.count(key) == 2, (
-            f"stage.{stage_id} must appear in BOTH zh and en tables (found {body.count(key)} occurrences)"
+        Both sides must be in lockstep."""
+        zh = _load_locale("zh")
+        en = _load_locale("en")
+        only_in_zh = sorted(set(zh) - set(en))
+        only_in_en = sorted(set(en) - set(zh))
+        assert not only_in_zh, f"keys missing in en/translation.json: {only_in_zh}"
+        assert not only_in_en, f"keys missing in zh/translation.json: {only_in_en}"
+
+    @pytest.mark.parametrize("lang", SUPPORTED_LANGS)
+    @pytest.mark.parametrize("stage", REQUIRED_STAGES)
+    def test_required_stage_key_present(self, lang: str, stage: str) -> None:
+        """Every phase name the orchestrator / PM emits must have a
+        translation entry — otherwise the chip renders as a humanized
+        fallback alongside fully-translated siblings, which reads as
+        the same mixed-language problem."""
+        entries = _load_locale(lang)
+        key = f"stage.{stage}"
+        assert key in entries, f"{lang}/translation.json missing {key}"
+        assert entries[key].strip(), f"{lang}/translation.json has empty value for {key}"
+
+    def test_interpolation_tokens_use_i18next_syntax(self) -> None:
+        """i18next uses ``{{name}}`` for interpolation. Single-brace
+        ``{name}`` tokens would render literally — a common regression
+        when porting from ad-hoc templating."""
+        for lang in SUPPORTED_LANGS:
+            entries = _load_locale(lang)
+            for key, value in entries.items():
+                bad = re.findall(r"(?<!\{)\{(\w+)\}(?!\})", value)
+                assert not bad, (
+                    f"{lang}/{key} uses single-brace interpolation {{...}} instead of i18next's {{{{...}}}}: {value!r}"
+                )
+
+
+class TestI18nextBootstrap:
+    """Pin the client-side integration with the i18next library itself.
+
+    We still verify a couple of things against ``app.js`` by string
+    search — these are lightweight and guard against accidentally
+    rolling the integration back to an ad-hoc table."""
+
+    def test_app_js_initializes_i18next_with_http_backend(self) -> None:
+        body = APP_JS.read_text(encoding="utf-8")
+        # The integration uses i18next + i18next-http-backend; both
+        # must be referenced so the bundler / bootstrap knows to wait
+        # on them.
+        assert "i18next" in body
+        assert "i18nextHttpBackend" in body or "HttpBackend" in body
+        # Resources are loaded from the static mount.
+        assert "/static/locales/{{lng}}/{{ns}}.json" in body
+
+    def test_app_js_waits_for_i18n_before_mount(self) -> None:
+        """React mount must follow ``initI18n()`` so the first paint
+        has translated text, not raw keys."""
+        body = APP_JS.read_text(encoding="utf-8")
+        assert "initI18n()" in body
+        # The DOMContentLoaded handler must chain the setup calls after
+        # the init promise resolves.
+        assert re.search(r"initI18n\(\)\.(?:finally|then)\(", body), (
+            "DOMContentLoaded handler must await initI18n() before mounting"
+        )
+
+    def test_app_js_has_no_inline_translations_table(self) -> None:
+        """Regression: the old ``const TRANSLATIONS = { zh: {...} }``
+        inline table must be gone. All translations live in the JSON
+        resource files under locales/."""
+        body = APP_JS.read_text(encoding="utf-8")
+        assert "const TRANSLATIONS" not in body, (
+            "inline TRANSLATIONS table reintroduced; translations must live in locales/<lng>/translation.json only"
         )
 
 
-class TestStageSuffixPattern:
-    """The ``STAGE_SUFFIX_RE`` regex strips a trailing counter suffix
-    so labels like ``implementation_layer1`` resolve to "开发实现 #1"
-    / "Implementation #1" instead of being emitted verbatim.
-
-    The frontend regex is authored in JS; we extract it from app.js
-    and exercise it with Python's ``re`` (compatible syntax for the
-    patterns in use) so this test fails loudly if the pattern is
-    narrowed in a future edit."""
+class TestStageLabelResolverHelpers:
+    """The ``resolveStageLabel`` helper in app.js layers two extra
+    strategies on top of i18next: a counter-suffix stripper (so
+    ``implementation_layer1`` → ``Implementation #1``) and a humanize
+    fallback (so an unknown id renders as Title Case English instead of
+    raw snake_case)."""
 
     @pytest.fixture(scope="class")
-    def pattern(self) -> re.Pattern[str]:
-        body = _load_app_js()
+    def suffix_pattern(self) -> re.Pattern[str]:
+        body = APP_JS.read_text(encoding="utf-8")
         m = re.search(r"var STAGE_SUFFIX_RE = (/\^.+?\$/);", body)
         assert m, "STAGE_SUFFIX_RE declaration not found in app.js"
         js_re = m.group(1)
-        # Strip the JS delimiter ``/.../`` — what's inside is valid
-        # Python regex syntax for this pattern.
-        py_src = js_re[1:-1]
-        return re.compile(py_src)
+        return re.compile(js_re[1:-1])
 
     @pytest.mark.parametrize(
         "stage,expected_base,expected_counter",
@@ -124,12 +189,12 @@ class TestStageSuffixPattern:
     )
     def test_suffix_stripped_correctly(
         self,
-        pattern: re.Pattern[str],
+        suffix_pattern: re.Pattern[str],
         stage: str,
         expected_base: str,
         expected_counter: str,
     ) -> None:
-        m = pattern.match(stage)
+        m = suffix_pattern.match(stage)
         assert m, f"pattern failed to match {stage!r}"
         assert m.group(1) == expected_base
         assert m.group(2) == expected_counter
@@ -137,48 +202,35 @@ class TestStageSuffixPattern:
     @pytest.mark.parametrize(
         "stage",
         [
-            "architecture",  # no suffix → must NOT match
-            "implementation",  # no suffix
-            "main_entry",  # trailing token is not a counter suffix
-            "qa_testing",  # trailing token is not a counter suffix
-            "step_architecture_design",  # PM step id, no trailing counter
+            "architecture",
+            "implementation",
+            "main_entry",
+            "qa_testing",
+            "step_architecture_design",
         ],
     )
     def test_non_suffixed_stages_do_not_match(
         self,
-        pattern: re.Pattern[str],
+        suffix_pattern: re.Pattern[str],
         stage: str,
     ) -> None:
-        m = pattern.match(stage)
+        m = suffix_pattern.match(stage)
         assert not m, f"pattern wrongly matched {stage!r} — would strip valid stage id"
 
+    def test_resolver_uses_i18next_exists(self) -> None:
+        """The resolver must probe i18next via its public ``exists``
+        API, not via a string-equality trick against the return value
+        of ``t()``."""
+        body = APP_JS.read_text(encoding="utf-8")
+        assert "i18next.exists" in body
 
-class TestHumanizeFallbackPresent:
-    """When a stage id has no translation and no counter suffix the
-    resolver must fall back to a humanized Title Case label, not to
-    the raw snake_case id. Pinned by grepping for the helper and the
-    call site that uses it."""
-
-    def test_humanize_helper_defined(self) -> None:
-        body = _load_app_js()
-        assert "function humanizeStageId" in body
-
-    def test_resolver_falls_back_to_humanized_form(self) -> None:
-        """The unknown-stage fallback must call ``humanizeStageId`` —
-        pinning this prevents a future refactor from reinstating the
-        old ``return stage`` behavior that caused ``implementation_layer1``
-        to render verbatim among Chinese labels.
-
-        We locate the fallback by finding the ``resolveStageLabel``
-        declaration and asserting the body (up to the first balanced
-        closing brace at column 0 — the function's closing brace)
-        contains a ``return humanizeStageId(`` call.
-        """
-        body = _load_app_js()
+    def test_resolver_has_humanize_fallback(self) -> None:
+        """The final branch of ``resolveStageLabel`` must humanize the
+        unknown id — pins the fix for the 2026-04-19 screenshot where
+        ``implementation_layer1`` rendered verbatim."""
+        body = APP_JS.read_text(encoding="utf-8")
         start = body.find("function resolveStageLabel(stage)")
         assert start >= 0, "resolveStageLabel not found"
-        # Walk forward until the function's closing ``}`` by tracking
-        # brace depth. This is robust against inner ``if {}`` blocks.
         depth = 0
         end = -1
         in_fn = False
@@ -192,8 +244,6 @@ class TestHumanizeFallbackPresent:
                 if in_fn and depth == 0:
                     end = i
                     break
-        assert end > start, "could not locate end of resolveStageLabel"
+        assert end > start
         fn_src = body[start : end + 1]
-        assert "return humanizeStageId(stage)" in fn_src, (
-            "resolveStageLabel is missing the humanized-fallback branch — unknown stage ids must not be returned raw"
-        )
+        assert "return humanizeStageId(stage)" in fn_src


### PR DESCRIPTION
## Summary
- **Stage-label resolver** — generalizes `STAGE_SUFFIX_RE` beyond `_cycle_N` to cover `_(layer|cycle|part|iter|iteration|round|stage|v|step)_N`; adds `humanizeStageId` fallback; introduces a three-tier strategy (exact key → suffix-strip + base key → humanized fallback). Also adds missing `stage.architecture` / `stage.requirements` / `stage.main_entry` / `stage.qa_testing` / `stage.delivery` keys in both `zh` and `en`. Fixes the regression where `需求分析 → architecture → implementation_layer1` rendered mixed Chinese and raw English IDs.
- **i18n migration** — replaces the ad-hoc inline `TRANSLATIONS` table + home-rolled `t()` with standard `i18next` + `i18next-http-backend`; moves resources into `static/locales/{zh,en}/translation.json`; updates `pyproject.toml` package-data so the JSON files ship in the wheel.
- **Chip collapsing** — new `normalizeStageId` / `resolveChipLabel`; `implementation_layer1`..`implementation_layerN` now fold into a single canonical `implementation` chip in the progress strip (per-layer detail still visible when drilling into log rows).

## Test plan
- [ ] `pytest tests/test_web/test_stage_labels.py` — 49 parametrized cases (translation coverage parity, suffix regex positives/negatives, humanize fallback pin, locale JSON structure, i18next bootstrap, chip collapsing).
- [ ] Full suite: `pytest` — 788 passed, 26 skipped when branch was last built.
- [ ] Ruff + format clean.
- [ ] Manual: load the task-detail page with an `implementation_layer*` run; verify one `implementation` chip in the strip and per-layer labels in the expanded log.

## Merge note
Expect a small text-level conflict in `app.js` translation block — PR #115 independently added `stage.architecture` / `requirements` / `main_entry` / `qa_testing` / `delivery` plus some `sprint_*` keys. Resolution: accept the i18next migration (deletes the inline `TRANSLATIONS` block and moves keys into `locales/*/translation.json`); carry the `sprint_*` keys from main into the JSON resources.