### PR TITLE
feat(web+runtime): agile process, user/role management, log viewer

### DIFF
--- a/src/aise/config.py
+++ b/src/aise/config.py
@@ -151,6 +151,12 @@ class ProjectConfig:
 
     project_name: str = "Untitled Project"
     development_mode: str = "local"  # "local" or "github"
+    # Development process chosen at project creation time. ``waterfall``
+    # (default) runs the sequential lifecycle from the existing
+    # waterfall.process.md; ``agile`` runs the sprint-oriented
+    # agile.process.md. The ProjectSession uses this to pick the phase
+    # prompt set.
+    process_type: str = "waterfall"
     # UI language for the web console. ``zh`` (Simplified Chinese) or
     # ``en`` (English). The web app reads this at render time and emits
     # it as ``window.__AISE_LANG`` so the frontend ``t()`` helper can
@@ -463,6 +469,7 @@ class ProjectConfig:
         return {
             "project_name": self.project_name,
             "development_mode": self.development_mode,
+            "process_type": self.process_type,
             "ui_language": self.ui_language,
             "default_model": {
                 "provider": self.default_model.provider,
@@ -553,6 +560,9 @@ class ProjectConfig:
             config.project_name = str(data["project_name"])
         if "development_mode" in data:
             config.development_mode = str(data["development_mode"])
+        if "process_type" in data:
+            raw_process = str(data["process_type"]).strip().lower()
+            config.process_type = raw_process if raw_process in ("waterfall", "agile") else config.process_type
         if "ui_language" in data:
             raw_lang = str(data["ui_language"]).strip().lower()
             # Clamp to the two supported values; fall back to the default

--- a/src/aise/core/project.py
+++ b/src/aise/core/project.py
@@ -74,6 +74,12 @@ class Project:
         # Fallback to checking GitHub config
         return "github" if self.config.github.is_configured else "local"
 
+    @property
+    def process_type(self) -> str:
+        """Get the development process (waterfall or agile)."""
+        value = getattr(self.config, "process_type", "waterfall")
+        return value if value in ("waterfall", "agile") else "waterfall"
+
     def pause(self) -> None:
         """Pause the project (stop accepting new work)."""
         self.status = ProjectStatus.PAUSED
@@ -106,6 +112,7 @@ class Project:
             "project_name": self.project_name,
             "status": self.status.value,
             "development_mode": self.development_mode,
+            "process_type": self.process_type,
             "agent_count": self.agent_count,
             "project_root": self.project_root,
             "created_at": self.created_at.isoformat(),

--- a/src/aise/processes/agile.process.md
+++ b/src/aise/processes/agile.process.md
@@ -1,48 +1,80 @@
+---
+process_id: agile_sprint_v1
+name: Iterative Agile Sprint Workflow
+work_type: rapid_iteration
+keywords: agile, sprint, backlog, mvp, feedback, iterative
+summary: An iterative approach centered on sprint planning, rapid prototyping, continuous review, and retrospective. Produces a working MVP each sprint.
+caps:
+  max_dispatches: 30
+  max_continuations: 15
+terminal_step: deliver_report
+required_phases:
+  - phase_sprint_planning
+  - phase_sprint_execution
+  - phase_sprint_review
+  - phase_sprint_retrospective
+  - phase_delivery
+---
+
 # Agile Iterative Development Process
+
+<!-- Legacy bullet metadata duplicated from the YAML frontmatter above so
+     the older aise.core.process_md_repository parser still loads this
+     process. The new runtime parser reads the frontmatter directly. -->
 - process_id: agile_sprint_v1
 - name: Iterative Agile Sprint Workflow
 - work_type: rapid_iteration
 - keywords: agile, sprint, backlog, mvp, feedback, iterative
-- summary: An iterative approach focusing on continuous feedback, rapid prototyping, and delivering a Minimum Viable Product (MVP).
-
-## Global Agent Requirements
-### product_owner_agent
-- focus: user_value_prioritization
-### developer_agent
-- style: functional_and_modular
+- summary: An iterative approach centered on sprint planning, rapid prototyping, continuous review, and retrospective. Produces a working MVP each sprint.
 
 ## Steps
-### sprint_planning: Backlog & Prioritization
-- agents: product_owner_agent, master_agent
-- description: Breakdown user stories and select items for the current short-term sprint.
-#### Responsibilities
-##### product_owner_agent
-- Define "Definition of Done" (DoD) for each story.
-- Prioritize high-value features for the MVP.
-##### master_agent
-- Allocate tasks based on agent capability and workload.
 
-### sprint_execution: Rapid Prototyping & Coding
-- agents: developer_agent, reviewer_agent
-- description: Fast-paced development focusing on functional features and immediate code quality.
-#### Responsibilities
-##### developer_agent
-- Implement core logic in small, testable increments.
-- Output format: executable_snippets
-##### reviewer_agent
-- Perform continuous integration checks and quick logic validation.
+### phase_sprint_planning: Sprint Planning
+#### step_backlog_and_stories: Backlog & User Stories
+- agents: product_manager
+- description: Read the raw requirement. Produce docs/product_backlog.md — list user stories (As a …, I want …, So that …) with acceptance criteria and Definition of Done (DoD). Highlight the MVP scope for the first sprint. Each user story MUST carry a Mermaid use case diagram.
+- deliverables: docs/product_backlog.md
 
-### sprint_review: Feedback & Demo
-- agents: qa_agent, product_owner_agent
-- description: Review the increment and collect feedback for the next iteration.
-#### Responsibilities
-##### qa_agent
-- Verify functionality against user stories.
-##### product_owner_agent
-- Evaluate if the increment meets "User Value" and update the backlog.
+### phase_sprint_execution: Sprint Execution
+#### step_sprint_design: Lightweight Sprint Design
+- agents: architect
+- description: Read docs/product_backlog.md. Produce docs/sprint_design.md — a LIGHTWEIGHT technical design (modules, public interfaces, data flow). Prefer simplicity over completeness; this is a sprint, not a long-design phase. Use Mermaid (C4Context, C4Container) for architecture diagrams.
+- deliverables: docs/sprint_design.md
 
-### sprint_retrospective: Process Optimization
-- agents: master_agent
-- description: Analyze the performance of the Multi-Agent system to optimize the next sprint's coordination.
-#### Requirements
-- include: efficiency_bottleneck_analysis
+#### step_sprint_implementation: Rapid Prototyping & TDD
+- agents: developer
+- description: |
+    Dispatch developer per MVP module. Each task writes
+    tests/test_<module>.py, then src/<module>.py, then runs ONLY that
+    module's test file. Keep modules small and focused on shipping the
+    MVP, not on finishing every backlog item.
+- deliverables: src/, tests/
+- verification_command: python -m pytest tests/ -q --tb=short
+- on_failure: retry_with_output
+- max_retries: 2
+
+#### step_sprint_main_entry: Working Entry Point
+- agents: developer
+- description: Wire all sprint modules into a runnable entry file so the MVP can be demoed at review.
+- deliverables: src/main.py
+
+### phase_sprint_review: Sprint Review & Demo
+#### step_sprint_integration: Integration + Demo Test
+- agents: qa_engineer
+- description: Run the FULL pytest suite. Verify each user story's acceptance criteria against real output. Summarize pass/fail per story in tests/test_integration.py + docs/sprint_review.md.
+- deliverables: tests/test_integration.py, docs/sprint_review.md
+- verification_command: python -m pytest tests/ -q --tb=short
+- on_failure: retry_with_output
+- max_retries: 2
+
+### phase_sprint_retrospective: Sprint Retrospective
+#### step_retrospective: Process Optimization
+- agents: project_manager
+- description: Produce docs/sprint_retrospective.md — what went well, what did not, efficiency bottlenecks (which agents stalled, which dispatches needed retries). Feed the outcome into the next sprint's backlog.
+- deliverables: docs/sprint_retrospective.md
+
+### phase_delivery: Sprint Delivery
+#### deliver_report: MVP Delivery Report
+- agents: product_manager
+- description: Compose docs/delivery_report.md — MVP summary, user stories shipped vs deferred, implementation / test metrics, retrospective highlights. End with mark_complete.
+- deliverables: docs/delivery_report.md

--- a/src/aise/runtime/project_session.py
+++ b/src/aise/runtime/project_session.py
@@ -53,6 +53,7 @@ class ProjectSession:
         on_event: Any | None = None,
         runtime_config: RuntimeConfig | None = None,
         mode: str = "initial",
+        process_type: str = "waterfall",
     ) -> None:
         """Initialize a project session.
 
@@ -70,6 +71,11 @@ class ProjectSession:
                 the phase prompts to instruct agents to READ existing
                 artifacts first and only add / update what the new
                 requirement demands.
+            process_type: ``"waterfall"`` (default) or ``"agile"``.
+                Selects the phase-prompt set that drives the orchestrator.
+                Agile swaps the waterfall linear lifecycle for an MVP-
+                centered sprint sequence (planning → execution → review
+                → retrospective → delivery).
         """
         self._manager = manager
         self._session_id = uuid.uuid4().hex[:12]
@@ -78,6 +84,8 @@ class ProjectSession:
         self._workflow_state = WorkflowState()
         raw_mode = str(mode or "initial").strip().lower()
         self._mode = raw_mode if raw_mode in ("initial", "incremental") else "initial"
+        raw_process = str(process_type or "waterfall").strip().lower()
+        self._process_type = raw_process if raw_process in ("waterfall", "agile") else "waterfall"
 
         if self._project_root:
             self._scaffold_project_dirs(self._project_root)
@@ -429,6 +437,10 @@ class ProjectSession:
         requirement demands. The QA phase stays full (runs the whole
         test suite, not just new tests) regardless of mode.
         """
+        if self._process_type == "agile":
+            if self._mode == "incremental":
+                return self._build_agile_incremental_phase_prompts(requirement)
+            return self._build_agile_initial_phase_prompts(requirement)
         if self._mode == "incremental":
             return self._build_incremental_phase_prompts(requirement)
         return self._build_initial_phase_prompts(requirement)
@@ -611,6 +623,313 @@ class ProjectSession:
                 "   Include: project name, 'incremental', pass rate, number\n"
                 "   of new modules + edited modules, and whether the entry\n"
                 "   point verified successfully in Phase 4.",
+            ),
+        ]
+
+    def _build_agile_initial_phase_prompts(self, requirement: str) -> list[tuple[str, str]]:
+        """Agile phase prompts for a clean-slate project.
+
+        Follows ``src/aise/processes/agile.process.md`` — a sprint-centric
+        lifecycle: Sprint Planning → Sprint Execution (light design +
+        rapid TDD + working main) → Sprint Review → Retrospective →
+        Delivery. The structure is explicitly different from waterfall:
+        design is LIGHTWEIGHT, implementation is MVP-scoped, and a
+        retrospective phase captures process feedback.
+        """
+        return [
+            (
+                "sprint_planning",
+                f"Project requirement: {requirement}\n\n"
+                "Execute Phase 1 — Sprint Planning (AGILE):\n"
+                "1. Call list_processes, then get_process('agile.process.md').\n"
+                "2. Call list_agents to discover agents.\n"
+                "3. dispatch_task to product_manager. Require the PM to:\n"
+                "   - Break the raw requirement into user stories using the\n"
+                "     'As a <role>, I want <goal>, so that <value>' pattern.\n"
+                "   - For each story write Acceptance Criteria (Given/When/Then)\n"
+                "     and a Definition of Done (DoD).\n"
+                "   - Mark which stories are IN SCOPE for the first sprint's\n"
+                "     MVP vs deferred. Favor shipping something end-to-end\n"
+                "     over completeness.\n"
+                "   - Write everything to docs/product_backlog.md. Every\n"
+                "     story MUST carry its own Mermaid use case diagram\n"
+                "     (flowchart LR with actor/use-case nodes — see\n"
+                "     product_manager.md).\n"
+                "   - Validate every ```mermaid block via the mermaid skill\n"
+                "     and fix any syntax error before responding.\n"
+                "   Pass expected_artifacts=['docs/product_backlog.md'].\n"
+                "4. STOP. Do NOT call mark_complete.",
+            ),
+            (
+                "sprint_design",
+                f"Project requirement: {requirement}\n\n"
+                "Execute Phase 2a — Lightweight Sprint Design (AGILE):\n"
+                "dispatch_task to architect. Require the architect to:\n"
+                "- Read docs/product_backlog.md.\n"
+                "- Produce docs/sprint_design.md with a LIGHTWEIGHT design\n"
+                "  scoped to the MVP stories only. Include: module\n"
+                "  decomposition (tables of modules with 1-line responsibility\n"
+                "  and public interface), data flow, and just ONE C4Container\n"
+                "  diagram (skip deep C4Component unless strictly necessary —\n"
+                "  this is a sprint, not a waterfall design phase).\n"
+                "- Keep deferred stories out of the design; they will drive\n"
+                "  a future sprint.\n"
+                "- Validate every ```mermaid block via the mermaid skill and\n"
+                "  fix any syntax error before responding.\n"
+                "Pass expected_artifacts=['docs/sprint_design.md'].\n"
+                "After it completes, STOP.\n"
+                "Do NOT call mark_complete.",
+            ),
+            (
+                "sprint_execution",
+                f"Project requirement: {requirement}\n\n"
+                "Execute Phase 2b — Sprint Execution (AGILE, rapid TDD):\n"
+                "1. Read docs/sprint_design.md to identify the MVP modules.\n"
+                "2. For EACH MVP module, dispatch developer via\n"
+                "   dispatch_tasks_parallel. Each task description must:\n"
+                "   - Include the module's spec from sprint_design.md.\n"
+                "   - Instruct strict TDD: write tests/test_<module>.py,\n"
+                "     then src/<module>.py, then run ONLY that module's test\n"
+                "     file (python -m pytest tests/test_<module>.py -q\n"
+                "     --tb=short). Up to 3 fix attempts.\n"
+                "   - Keep each module small enough to ship within the sprint.\n"
+                "     If a design element is large, reduce scope rather than\n"
+                "     stretching the sprint.\n"
+                "   - Set expected_artifacts=['src/<module>.py',\n"
+                "     'tests/test_<module>.py'].\n"
+                "3. When all dispatches return, STOP.\n"
+                "Do NOT call mark_complete.",
+            ),
+            (
+                "sprint_main_entry",
+                f"Project requirement: {requirement}\n\n"
+                "Execute Phase 2c — Working Entry Point (AGILE):\n"
+                "1. dispatch_task to developer: 'Write the project's main\n"
+                "   entry-point file that wires all MVP modules together so\n"
+                "   the sprint output can be demoed at review. Use the\n"
+                "   language convention (src/main.py for Python, src/index.js\n"
+                "   for Node, cmd/<app>/main.go for Go, etc.). The file MUST\n"
+                "   boot directly (python src/main.py, node src/index.js,\n"
+                "   go run …). End your response with ONE line:\n"
+                "       RUN: <command to launch>'\n"
+                "2. Run the RUN command with execute_shell(timeout=5).\n"
+                "   - timeout after 5s → SUCCESS (entered main loop).\n"
+                "   - exit_code 0 with normal output → SUCCESS.\n"
+                "   - exit_code != 0 with ImportError / SyntaxError /\n"
+                "     ModuleNotFoundError / NameError / AttributeError or\n"
+                "     missing-module startup failures → FAILURE.\n"
+                "3. If FAILURE, dispatch developer again with the failure\n"
+                "   text. Up to 3 attempts total.\n"
+                "4. STOP. Do NOT call mark_complete.",
+            ),
+            (
+                "sprint_review",
+                f"Project requirement: {requirement}\n\n"
+                "Execute Phase 3 — Sprint Review & Demo (AGILE):\n"
+                "dispatch_task to qa_engineer. Require the QA agent to:\n"
+                "- Read docs/product_backlog.md AND docs/sprint_design.md.\n"
+                "- Write tests/test_integration.py (ONLY integration tests —\n"
+                "  developers already wrote per-module unit tests). Cover\n"
+                "  every MVP user story's acceptance criteria end-to-end.\n"
+                "- RUN the FULL suite: execute(command=\"python -m pytest\n"
+                "  tests/ -q --tb=short\") and iterate up to 3 times until\n"
+                "  tests pass.\n"
+                "- Write docs/sprint_review.md with a per-user-story\n"
+                "  PASS/FAIL table so the product owner can verify delivery\n"
+                "  during review. Include pytest final summary.\n"
+                "Pass expected_artifacts=['tests/test_integration.py',\n"
+                "'docs/sprint_review.md'].\n"
+                "After it completes, STOP.\n"
+                "Do NOT call mark_complete.",
+            ),
+            (
+                "sprint_retrospective",
+                f"Project requirement: {requirement}\n\n"
+                "Execute Phase 4 — Sprint Retrospective (AGILE):\n"
+                "dispatch_task to project_manager. Require the PM to write\n"
+                "docs/sprint_retrospective.md covering:\n"
+                "- What went well (which agents finished cleanly, which\n"
+                "  tests passed first try).\n"
+                "- What did not go well (failed dispatches, retries burned,\n"
+                "  modules that stretched).\n"
+                "- Action items for the next sprint (process changes,\n"
+                "  scope adjustments, additional tests to write).\n"
+                "The retrospective should ground itself in observable\n"
+                "metrics — have the PM look at docs/, src/, tests/ and\n"
+                "describe real outcomes, not speculation.\n"
+                "Pass expected_artifacts=['docs/sprint_retrospective.md'].\n"
+                "After it completes, STOP.\n"
+                "Do NOT call mark_complete.",
+            ),
+            (
+                "delivery",
+                f"Project requirement: {requirement}\n\n"
+                "Execute Phase 5 — Sprint Delivery Report (AGILE):\n\n"
+                "Collect real metrics then have product_manager write the\n"
+                "report. Do NOT guess numbers.\n\n"
+                "1. Collect metrics via execute_shell:\n"
+                "   a) Source file count:\n"
+                "      execute_shell('find src -type f -name \"*.py\" | wc -l')\n"
+                "   b) Source LOC (top files + total):\n"
+                "      execute_shell('find src -type f -name \"*.py\" -exec wc -l {} + | sort -rn | head -30')\n"
+                "   c) Test files + collected cases:\n"
+                "      execute_shell('find tests -type f -name \"test_*.py\" 2>/dev/null | wc -l')\n"
+                "      execute_shell('python -m pytest tests/ --collect-only -q 2>&1 | tail -5')\n"
+                "   d) Final pytest summary:\n"
+                "      execute_shell('python -m pytest tests/ -q --tb=line 2>&1 | tail -20')\n\n"
+                "2. Dispatch product_manager to write docs/delivery_report.md.\n"
+                "   Pass expected_artifacts=['docs/delivery_report.md'].\n"
+                "   Require the report to cover:\n"
+                "   1. MVP Summary — one paragraph on what shipped this sprint\n"
+                "      and whether it meets the DoD of the in-scope stories.\n"
+                "   2. User Stories Shipped vs Deferred — table with story ID,\n"
+                "      title, status (shipped / deferred / blocked).\n"
+                "   3. Design — bullets from docs/sprint_design.md.\n"
+                "   4. Implementation Metrics — source file count, LOC, entry\n"
+                "      point RUN command.\n"
+                "   5. Test Metrics — FULL-suite pass/fail/skipped from step d,\n"
+                "      pass rate percentage.\n"
+                "   6. Retrospective Highlights — 3-5 bullets from\n"
+                "      docs/sprint_retrospective.md.\n"
+                "   7. Next-Sprint Candidates — deferred stories + retro\n"
+                "      action items.\n"
+                "   EMBED the raw tool outputs verbatim so the PM cites real\n"
+                "   numbers.\n\n"
+                "3. After product_manager returns, call mark_complete with a\n"
+                "   short paragraph referencing docs/delivery_report.md.\n"
+                "   Include: project name, 'agile sprint', pass rate, shipped\n"
+                "   user stories count, deferred stories count, entry point\n"
+                "   verification outcome.",
+            ),
+        ]
+
+    def _build_agile_incremental_phase_prompts(self, requirement: str) -> list[tuple[str, str]]:
+        """Agile phase prompts for a follow-up sprint.
+
+        Each incremental requirement on an agile project is treated as a
+        NEW sprint: append stories to the backlog, design only what the
+        new stories touch, implement, review, retro, deliver. The full
+        test suite still runs in review — an agile sprint delivering a
+        broken baseline is not a sprint review.
+        """
+        return [
+            (
+                "sprint_planning",
+                f"New requirement for the next sprint: {requirement}\n\n"
+                "Execute Phase 1 — Sprint Planning (AGILE, INCREMENTAL):\n"
+                "dispatch_task to product_manager. Require the PM to:\n"
+                "- Read docs/product_backlog.md if present.\n"
+                "- APPEND a new '## Sprint <N> (ISO date)' section with\n"
+                "  stories derived from the new requirement. Mark MVP scope.\n"
+                "- Keep earlier stories untouched.\n"
+                "- Every new story keeps its own Mermaid use case diagram.\n"
+                "- Validate every ```mermaid block via the mermaid skill.\n"
+                "Pass expected_artifacts=['docs/product_backlog.md'].\n"
+                "STOP. Do NOT call mark_complete.",
+            ),
+            (
+                "sprint_design",
+                f"New requirement for the next sprint: {requirement}\n\n"
+                "Execute Phase 2a — Lightweight Sprint Design (AGILE,\n"
+                "INCREMENTAL):\n"
+                "dispatch_task to architect. Require the architect to:\n"
+                "- Read docs/sprint_design.md + docs/product_backlog.md.\n"
+                "- APPEND / UPDATE only the sections the new stories touch.\n"
+                "  Existing design stays. Keep C4 for architecture views.\n"
+                "- Validate every ```mermaid block via the mermaid skill.\n"
+                "Pass expected_artifacts=['docs/sprint_design.md'].\n"
+                "STOP. Do NOT call mark_complete.",
+            ),
+            (
+                "sprint_execution",
+                f"New requirement for the next sprint: {requirement}\n\n"
+                "Execute Phase 2b — Sprint Execution (AGILE, INCREMENTAL):\n"
+                "1. Read docs/sprint_design.md. Identify NEW/CHANGED MVP\n"
+                "   modules for this sprint only.\n"
+                "2. dispatch_tasks_parallel to developer for each module:\n"
+                "   - NEW modules: strict TDD. Write tests then source then\n"
+                "     run per-module tests. Up to 3 fix attempts.\n"
+                "   - CHANGED modules: task MUST say the file exists and\n"
+                "     developer must EDIT in place (edit_file) — never\n"
+                "     rewrite. Existing tests must keep passing.\n"
+                "   - expected_artifacts=['src/<module>.py',\n"
+                "     'tests/test_<module>.py'].\n"
+                "3. STOP. Do NOT call mark_complete.",
+            ),
+            (
+                "sprint_main_entry",
+                f"New requirement for the next sprint: {requirement}\n\n"
+                "Execute Phase 2c — Working Entry Point (AGILE,\n"
+                "INCREMENTAL, verify-only):\n"
+                "1. Check whether an entry file exists (src/main.py,\n"
+                "   src/index.js, cmd/<app>/main.go, src/main.rs). If yes,\n"
+                "   jump to step 3 with its RUN command; if no, dispatch\n"
+                "   developer to create one with a RUN: line.\n"
+                "2. Run RUN command via execute_shell(timeout=5). Same\n"
+                "   interpretation as initial mode (timeout/exit-0 success;\n"
+                "   startup-failure exit codes fail).\n"
+                "3. On FAILURE dispatch developer to fix. Up to 3 attempts.\n"
+                "4. STOP. Do NOT call mark_complete.",
+            ),
+            (
+                "sprint_review",
+                f"New requirement for the next sprint: {requirement}\n\n"
+                "Execute Phase 3 — Sprint Review & Demo (AGILE,\n"
+                "INCREMENTAL):\n"
+                "dispatch_task to qa_engineer:\n"
+                "- Read docs/product_backlog.md + docs/sprint_design.md\n"
+                "  (including the new sections).\n"
+                "- EDIT tests/test_integration.py in place (do NOT rewrite)\n"
+                "  to add scenarios for the new MVP stories.\n"
+                "- RUN the FULL suite: execute(command=\"python -m pytest\n"
+                "  tests/ -q --tb=short\") and iterate up to 3 times until\n"
+                "  tests pass.\n"
+                "- EDIT docs/sprint_review.md — append a new section for\n"
+                "  this sprint with per-user-story PASS/FAIL.\n"
+                "Pass expected_artifacts=['tests/test_integration.py',\n"
+                "'docs/sprint_review.md'].\n"
+                "STOP. Do NOT call mark_complete.",
+            ),
+            (
+                "sprint_retrospective",
+                f"New requirement for the next sprint: {requirement}\n\n"
+                "Execute Phase 4 — Sprint Retrospective (AGILE,\n"
+                "INCREMENTAL):\n"
+                "dispatch_task to project_manager. APPEND a new sprint\n"
+                "section to docs/sprint_retrospective.md. Keep earlier\n"
+                "retros untouched. Cover went-well, did-not-go-well, and\n"
+                "action items — scoped to THIS sprint.\n"
+                "Pass expected_artifacts=['docs/sprint_retrospective.md'].\n"
+                "STOP. Do NOT call mark_complete.",
+            ),
+            (
+                "delivery",
+                f"New requirement for the next sprint: {requirement}\n\n"
+                "Execute Phase 5 — Sprint Delivery Report (AGILE,\n"
+                "INCREMENTAL):\n\n"
+                "Collect delta + full metrics:\n"
+                "   a) New or modified files since baseline:\n"
+                "      execute_shell('git status --short 2>/dev/null || true')\n"
+                "      execute_shell('git diff --name-only HEAD~1 2>/dev/null || true')\n"
+                "   b) Full file / LOC count:\n"
+                "      execute_shell('find src -type f -name \"*.py\" | wc -l')\n"
+                "      execute_shell('find src -type f -name \"*.py\" -exec wc -l {} + | sort -rn | head -30')\n"
+                "   c) Test suite:\n"
+                "      execute_shell('find tests -type f -name \"test_*.py\" 2>/dev/null | wc -l')\n"
+                "      execute_shell('python -m pytest tests/ --collect-only -q 2>&1 | tail -5')\n"
+                "      execute_shell('python -m pytest tests/ -q --tb=line 2>&1 | tail -20')\n\n"
+                "Dispatch product_manager to EDIT docs/delivery_report.md\n"
+                "(append a new sprint section — do NOT recreate). Cover:\n"
+                "  1. Sprint Delta Summary — new requirement + shipped /\n"
+                "     deferred stories.\n"
+                "  2. Modules added vs modules edited (from step a).\n"
+                "  3. Updated implementation metrics (step b).\n"
+                "  4. FULL-suite test metrics (step c).\n"
+                "  5. Retrospective bullets for this sprint.\n"
+                "Pass expected_artifacts=['docs/delivery_report.md'].\n"
+                "After it returns, call mark_complete with: project name,\n"
+                "'agile sprint <incremental>', pass rate, shipped stories\n"
+                "count, entry verification outcome.",
             ),
         ]
 

--- a/src/aise/runtime/project_session.py
+++ b/src/aise/runtime/project_session.py
@@ -731,8 +731,8 @@ class ProjectSession:
                 "- Write tests/test_integration.py (ONLY integration tests —\n"
                 "  developers already wrote per-module unit tests). Cover\n"
                 "  every MVP user story's acceptance criteria end-to-end.\n"
-                "- RUN the FULL suite: execute(command=\"python -m pytest\n"
-                "  tests/ -q --tb=short\") and iterate up to 3 times until\n"
+                '- RUN the FULL suite: execute(command="python -m pytest\n'
+                '  tests/ -q --tb=short") and iterate up to 3 times until\n'
                 "  tests pass.\n"
                 "- Write docs/sprint_review.md with a per-user-story\n"
                 "  PASS/FAIL table so the product owner can verify delivery\n"
@@ -881,8 +881,8 @@ class ProjectSession:
                 "  (including the new sections).\n"
                 "- EDIT tests/test_integration.py in place (do NOT rewrite)\n"
                 "  to add scenarios for the new MVP stories.\n"
-                "- RUN the FULL suite: execute(command=\"python -m pytest\n"
-                "  tests/ -q --tb=short\") and iterate up to 3 times until\n"
+                '- RUN the FULL suite: execute(command="python -m pytest\n'
+                '  tests/ -q --tb=short") and iterate up to 3 times until\n'
                 "  tests pass.\n"
                 "- EDIT docs/sprint_review.md — append a new section for\n"
                 "  this sprint with per-user-story PASS/FAIL.\n"

--- a/src/aise/web/app.py
+++ b/src/aise/web/app.py
@@ -25,6 +25,18 @@ from ..config import ProjectConfig
 from ..core.project import Project, ProjectStatus
 from ..core.project_manager import ProjectManager
 from ..utils.logging import configure_logging, configure_module_file_logger, get_logger
+from .log_service import LogService
+from .user_store import (
+    PERM_ANALYZE_LOGS,
+    PERM_MANAGE_PROJECTS,
+    PERM_MANAGE_SYSTEM,
+    PERM_MANAGE_USERS,
+    PERM_RUN_PROJECTS,
+    PERM_VIEW_LOGS,
+    UserStore,
+    has_permission,
+    session_payload,
+)
 
 try:
     from authlib.integrations.starlette_client import OAuth
@@ -56,6 +68,7 @@ class WorkflowRun:
     result: str = ""
     task_log: list[dict[str, Any]] = field(default_factory=list)
     mode: str = "initial"
+    process_type: str = "waterfall"
 
 
 @dataclass
@@ -91,6 +104,9 @@ class WebProjectService:
         self._lock = RLock()
         self._active_workflow_runs: set[tuple[str, str]] = set()
         self._state_path = self.project_manager._projects_root / "web_state.json"
+        self._users_path = self.project_manager._projects_root / "users.json"
+        self._user_store = UserStore(self._users_path)
+        self._log_service = LogService(self.project_manager._global_config.logging.log_dir)
         self._restore_projects_from_disk()
         self._load_state()
 
@@ -98,8 +114,17 @@ class WebProjectService:
 
         self._runtime_manager = RuntimeManager(config=self.project_manager._global_config)
         self._runtime_manager.start()
+        self._log_service.set_runtime_manager(self._runtime_manager)
 
         logger.info("WebProjectService initialized: state_path=%s", self._state_path)
+
+    @property
+    def user_store(self) -> UserStore:
+        return self._user_store
+
+    @property
+    def log_service(self) -> LogService:
+        return self._log_service
 
     # -- Project CRUD --------------------------------------------------------
 
@@ -126,12 +151,14 @@ class WebProjectService:
         development_mode: str,
         agent_models: dict[str, str] | None = None,
         initial_requirement: str = "",
+        process_type: str = "waterfall",
     ) -> str:
         project_id, _ = self.create_project_with_initial_run(
             project_name=project_name,
             development_mode=development_mode,
             agent_models=agent_models,
             initial_requirement=initial_requirement,
+            process_type=process_type,
         )
         return project_id
 
@@ -142,12 +169,16 @@ class WebProjectService:
         development_mode: str,
         agent_models: dict[str, str] | None = None,
         initial_requirement: str = "",
+        process_type: str = "waterfall",
     ) -> tuple[str, str | None]:
         if not project_name.strip():
             raise ValueError("Project name cannot be empty")
         mode = "github" if development_mode == "github" else "local"
+        raw_process = str(process_type or "waterfall").strip().lower()
+        process = raw_process if raw_process in ("waterfall", "agile") else "waterfall"
         config = self.project_manager.create_default_project_config(project_name)
         config.development_mode = mode
+        config.process_type = process
         if agent_models:
             for agent_name, model_id in agent_models.items():
                 normalized = str(model_id).strip()
@@ -273,6 +304,9 @@ class WebProjectService:
             prior_runs = self._runs_by_project.get(project_id, [])
             has_baseline = any(r.status == "completed" and (r.result or "").strip() for r in prior_runs)
             mode = "incremental" if has_baseline else "initial"
+            process_type = getattr(project.config, "process_type", "waterfall") or "waterfall"
+            if process_type not in ("waterfall", "agile"):
+                process_type = "waterfall"
             run_id = f"run_{uuid.uuid4().hex[:10]}"
             run = WorkflowRun(
                 run_id=run_id,
@@ -280,6 +314,7 @@ class WebProjectService:
                 started_at=datetime.now(timezone.utc),
                 status="running",
                 mode=mode,
+                process_type=process_type,
             )
             self._runs_by_project.setdefault(project_id, []).append(run)
             self._requirements_by_project.setdefault(project_id, []).append(
@@ -295,7 +330,7 @@ class WebProjectService:
 
         Thread(
             target=self._execute_run,
-            args=(project_id, run_id, requirement_text, mode),
+            args=(project_id, run_id, requirement_text, mode, process_type),
             daemon=True,
         ).start()
         return run_id
@@ -306,6 +341,7 @@ class WebProjectService:
         run_id: str,
         requirement: str,
         mode: str = "initial",
+        process_type: str = "waterfall",
     ) -> None:
         """Background thread: run requirement via ProjectSession."""
         from ..runtime.project_session import ProjectSession
@@ -330,6 +366,7 @@ class WebProjectService:
                 project_root=project_root,
                 on_event=on_event,
                 mode=mode,
+                process_type=process_type,
             )
             result = session.run(requirement)
 
@@ -700,6 +737,9 @@ class WebProjectService:
                     raw_mode = str(item.get("mode", "initial")).strip().lower()
                     if raw_mode not in ("initial", "incremental"):
                         raw_mode = "initial"
+                    raw_process = str(item.get("process_type", "waterfall")).strip().lower()
+                    if raw_process not in ("waterfall", "agile"):
+                        raw_process = "waterfall"
                     self._runs_by_project[project_id].append(
                         WorkflowRun(
                             run_id=str(item.get("run_id", "")),
@@ -711,6 +751,7 @@ class WebProjectService:
                             result=str(item.get("result", "")),
                             task_log=list(item.get("task_log", [])),
                             mode=raw_mode,
+                            process_type=raw_process,
                         )
                     )
 
@@ -797,6 +838,7 @@ class WebProjectService:
             "result": run.result,
             "task_log": run.task_log,
             "mode": run.mode,
+            "process_type": run.process_type,
         }
 
     @staticmethod
@@ -845,35 +887,65 @@ def _static_dir() -> Path:
 
 def create_app() -> FastAPI:
     """Create the AISE web app."""
-    _LOCALHOST_AUTO_USER: dict[str, Any] = {
-        "id": "local-auto",
-        "name": "Local User",
-        "email": "local@aise.local",
-        "provider": "local",
-        "role": "super_admin",
-        "permissions": ["super_admin", "rd_director"],
-    }
+    # Localhost auto-login no longer injects a synthetic user. Instead it
+    # signs in as the bootstrapped super_admin from the UserStore so
+    # every action is attributed to a real user record.
     _AUTH_PUBLIC_PATHS = {"/login", "/auth/local-login", "/auth/dev-login", "/api/health"}
+
+    app = FastAPI(title="AISE Web Console")
+
+    def _refresh_session_user(request: Request, user_dict: dict[str, Any] | None) -> dict[str, Any] | None:
+        """Re-hydrate the session user from the store (role may have changed).
+
+        Keeps the session object fresh so a user whose role was changed
+        by an admin picks up new permissions on their next request
+        without needing a re-login.
+        """
+        if not user_dict:
+            return None
+        user_id = str(user_dict.get("id", ""))
+        if not user_id:
+            return user_dict
+        stored = service.user_store.get_user(user_id)
+        if stored is None:
+            # Stored record deleted — force re-login.
+            request.session.clear()
+            return None
+        if not stored.enabled:
+            request.session.clear()
+            return None
+        payload = session_payload(stored)
+        if payload != user_dict:
+            request.session["user"] = payload
+        return payload
 
     class _LocalhostAuthMiddleware(BaseHTTPMiddleware):
         async def dispatch(self, request: Request, call_next):
             path = request.url.path
-            if not path.startswith("/static"):
-                host = (request.headers.get("host") or "").split(":")[0].strip().lower()
-                is_local = host in {"127.0.0.1", "localhost", "::1"}
-                if is_local and not request.session.get("user"):
-                    request.session["user"] = _LOCALHOST_AUTO_USER
-                elif (
-                    not is_local
-                    and not request.session.get("user")
-                    and not path.startswith("/auth/")
-                    and path not in _AUTH_PUBLIC_PATHS
-                    and not path.startswith("/api/")
-                ):
-                    return RedirectResponse(url="/login", status_code=HTTP_303_SEE_OTHER)
+            if path.startswith("/static"):
+                return await call_next(request)
+            host = (request.headers.get("host") or "").split(":")[0].strip().lower()
+            is_local = host in {"127.0.0.1", "localhost", "::1"}
+            current = request.session.get("user")
+            if is_local and not current:
+                # Pick the first enabled super_admin as the auto-user.
+                for candidate in service.user_store.list_users():
+                    if candidate.role == "super_admin" and candidate.enabled:
+                        request.session["user"] = session_payload(candidate)
+                        current = request.session["user"]
+                        break
+            if current:
+                _refresh_session_user(request, current)
+            if (
+                not is_local
+                and not request.session.get("user")
+                and not path.startswith("/auth/")
+                and path not in _AUTH_PUBLIC_PATHS
+                and not path.startswith("/api/")
+            ):
+                return RedirectResponse(url="/login", status_code=HTTP_303_SEE_OTHER)
             return await call_next(request)
 
-    app = FastAPI(title="AISE Web Console")
     app.add_middleware(_LocalhostAuthMiddleware)
     app.add_middleware(SessionMiddleware, secret_key=secrets.token_urlsafe(32))
     app.mount("/static", StaticFiles(directory=_static_dir()), name="static")
@@ -888,12 +960,17 @@ def create_app() -> FastAPI:
     oauth = _build_oauth()
     dev_login_enabled = os.environ.get("AISE_WEB_ENABLE_DEV_LOGIN", "").lower() in {"1", "true", "yes"}
     local_admin_username = os.environ.get("AISE_ADMIN_USERNAME", "admin")
-    local_admin_password = os.environ.get("AISE_ADMIN_PASSWORD", "123456")
 
     def require_login(request: Request) -> dict[str, Any]:
         user = request.session.get("user")
         if not user:
             raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="Login required")
+        return user
+
+    def require_permission(request: Request, permission: str) -> dict[str, Any]:
+        user = require_login(request)
+        if not has_permission(user, permission):
+            raise HTTPException(status_code=403, detail=f"Permission denied: {permission}")
         return user
 
     # -- Page routes ---------------------------------------------------------
@@ -939,30 +1016,30 @@ def create_app() -> FastAPI:
 
     @app.post("/auth/local-login")
     async def local_login(request: Request, username: str = Form(...), password: str = Form(...)):
-        if username.strip() != local_admin_username or password != local_admin_password:
-            return RedirectResponse(url="/login?error=用户名或���码错误", status_code=HTTP_303_SEE_OTHER)
-        request.session["user"] = {
-            "id": "local-admin",
-            "name": "System Admin",
-            "email": "admin@aise.local",
-            "provider": "local",
-            "role": "super_admin",
-            "permissions": ["super_admin", "rd_director"],
-        }
+        user = service.user_store.authenticate(username, password)
+        if user is None:
+            return RedirectResponse(url="/login?error=用户名或密码错误", status_code=HTTP_303_SEE_OTHER)
+        request.session["user"] = session_payload(user)
         return RedirectResponse(url="/", status_code=HTTP_303_SEE_OTHER)
 
     @app.get("/auth/dev-login")
     async def dev_login(request: Request, name: str = "Dev User", email: str = "dev@aise.local"):
         if not dev_login_enabled:
             raise HTTPException(status_code=404, detail="Not found")
-        request.session["user"] = {
-            "id": "dev-user",
-            "name": name,
-            "email": email,
-            "provider": "dev",
-            "role": "super_admin",
-            "permissions": ["super_admin", "rd_director"],
-        }
+        user = service.user_store.record_external_login(
+            provider="dev",
+            external_id=email,
+            email=email,
+            display_name=name,
+        )
+        # Dev login always grants super_admin so developers can poke every
+        # page without a two-step "create user, promote" dance.
+        try:
+            service.user_store.update_user(user.id, role="super_admin")
+        except Exception as exc:
+            logger.warning("Failed to elevate dev user to super_admin: %s", exc)
+        user = service.user_store.get_user(user.id) or user
+        request.session["user"] = session_payload(user)
         return RedirectResponse(url="/", status_code=HTTP_303_SEE_OTHER)
 
     @app.get("/auth/{provider}")
@@ -997,14 +1074,15 @@ def create_app() -> FastAPI:
                         "name": g.get("displayName", ""),
                         "email": g.get("mail") or g.get("userPrincipalName", ""),
                     }
-        request.session["user"] = {
-            "id": userinfo.get("sub", ""),
-            "name": userinfo.get("name", "User"),
-            "email": userinfo.get("email", ""),
-            "provider": provider,
-            "role": "user",
-            "permissions": [],
-        }
+        user = service.user_store.record_external_login(
+            provider=provider,
+            external_id=str(userinfo.get("sub", "")),
+            email=str(userinfo.get("email", "")),
+            display_name=str(userinfo.get("name", "") or userinfo.get("email", "") or "User"),
+        )
+        if not user.enabled:
+            return RedirectResponse(url="/login?error=账户已禁用，联系管理员", status_code=HTTP_303_SEE_OTHER)
+        request.session["user"] = session_payload(user)
         return RedirectResponse(url="/", status_code=HTTP_303_SEE_OTHER)
 
     @app.get("/logout")
@@ -1019,6 +1097,7 @@ def create_app() -> FastAPI:
         require_login(request)
         form_data = await request.form()
         initial_requirement = str(form_data.get("initial_requirement", ""))
+        process_type = str(form_data.get("process_type", "waterfall"))
         agent_models: dict[str, str] = {}
         for key, value in form_data.multi_items():
             if key.startswith("agent_model_"):
@@ -1029,6 +1108,7 @@ def create_app() -> FastAPI:
                 development_mode=development_mode,
                 agent_models=agent_models,
                 initial_requirement=initial_requirement,
+                process_type=process_type,
             )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -1185,7 +1265,7 @@ def create_app() -> FastAPI:
 
     @app.post("/api/projects")
     async def api_create_project(request: Request) -> dict[str, Any]:
-        require_login(request)
+        require_permission(request, PERM_MANAGE_PROJECTS)
         payload = await request.json()
         if not isinstance(payload, dict):
             raise HTTPException(status_code=400, detail="Invalid JSON body")
@@ -1195,6 +1275,7 @@ def create_app() -> FastAPI:
                 development_mode=str(payload.get("development_mode", "local")),
                 agent_models={str(k): str(v) for k, v in (payload.get("agent_models") or {}).items()},
                 initial_requirement=str(payload.get("initial_requirement", "")),
+                process_type=str(payload.get("process_type", "waterfall")),
             )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -1210,7 +1291,7 @@ def create_app() -> FastAPI:
 
     @app.delete("/api/projects/{project_id}")
     async def api_delete_project(request: Request, project_id: str) -> dict[str, Any]:
-        require_login(request)
+        require_permission(request, PERM_MANAGE_PROJECTS)
         try:
             service.delete_project(project_id)
         except ValueError as exc:
@@ -1219,7 +1300,7 @@ def create_app() -> FastAPI:
 
     @app.post("/api/projects/{project_id}/restart")
     async def api_restart_project(request: Request, project_id: str) -> dict[str, Any]:
-        require_login(request)
+        require_permission(request, PERM_RUN_PROJECTS)
         try:
             run_id = service.restart_project(project_id)
         except ValueError as exc:
@@ -1236,7 +1317,7 @@ def create_app() -> FastAPI:
 
     @app.post("/api/projects/{project_id}/requirements")
     async def api_add_requirement(request: Request, project_id: str) -> dict[str, Any]:
-        require_login(request)
+        require_permission(request, PERM_RUN_PROJECTS)
         payload = await request.json()
         if not isinstance(payload, dict):
             raise HTTPException(status_code=400, detail="Invalid JSON body")
@@ -1269,7 +1350,7 @@ def create_app() -> FastAPI:
 
     @app.post("/api/config/global")
     async def api_set_global_config(request: Request) -> dict[str, Any]:
-        require_login(request)
+        require_permission(request, PERM_MANAGE_SYSTEM)
         payload = await request.json()
         if not isinstance(payload, dict):
             raise HTTPException(status_code=400, detail="Invalid JSON body")
@@ -1286,7 +1367,7 @@ def create_app() -> FastAPI:
 
     @app.post("/api/config/global/data")
     async def api_set_global_config_data(request: Request) -> dict[str, Any]:
-        require_login(request)
+        require_permission(request, PERM_MANAGE_SYSTEM)
         payload = await request.json()
         if not isinstance(payload, dict):
             raise HTTPException(status_code=400, detail="Invalid JSON body")
@@ -1311,5 +1392,160 @@ def create_app() -> FastAPI:
         except Exception as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         return {"saved": True}
+
+    # -- User management pages + API ----------------------------------------
+
+    @app.get("/users", response_class=HTMLResponse)
+    async def users_page(request: Request) -> HTMLResponse:
+        user = require_login(request)
+        if not has_permission(user, PERM_MANAGE_USERS):
+            raise HTTPException(status_code=403, detail="Permission denied")
+        return templates.TemplateResponse(
+            request,
+            "users.html",
+            {"user": user},
+        )
+
+    @app.get("/api/users/me")
+    async def api_current_user(request: Request) -> dict[str, Any]:
+        user = require_login(request)
+        return {"user": user}
+
+    @app.get("/api/users")
+    async def api_list_users(request: Request) -> dict[str, Any]:
+        require_permission(request, PERM_MANAGE_USERS)
+        users = [u.to_dict() for u in service.user_store.list_users()]
+        return {"users": users, "roles": service.user_store.list_role_definitions()}
+
+    @app.get("/api/roles")
+    async def api_list_roles(request: Request) -> dict[str, Any]:
+        require_login(request)
+        return {
+            "roles": service.user_store.list_role_definitions(),
+            "permissions": service.user_store.list_all_permissions(),
+        }
+
+    @app.post("/api/users")
+    async def api_create_user(request: Request) -> dict[str, Any]:
+        require_permission(request, PERM_MANAGE_USERS)
+        payload = await request.json()
+        if not isinstance(payload, dict):
+            raise HTTPException(status_code=400, detail="Invalid JSON body")
+        try:
+            user = service.user_store.create_user(
+                username=str(payload.get("username", "")),
+                email=str(payload.get("email", "")),
+                display_name=str(payload.get("display_name", "")),
+                role=str(payload.get("role", "viewer")),
+                password=str(payload.get("password", "")),
+                enabled=bool(payload.get("enabled", True)),
+                provider=str(payload.get("provider", "local")),
+                notes=str(payload.get("notes", "")),
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return {"user": user.to_dict()}
+
+    @app.put("/api/users/{user_id}")
+    async def api_update_user(request: Request, user_id: str) -> dict[str, Any]:
+        require_permission(request, PERM_MANAGE_USERS)
+        payload = await request.json()
+        if not isinstance(payload, dict):
+            raise HTTPException(status_code=400, detail="Invalid JSON body")
+        kwargs: dict[str, Any] = {}
+        for key in ("email", "display_name", "role", "notes"):
+            if key in payload:
+                kwargs[key] = str(payload[key]) if payload[key] is not None else ""
+        if "enabled" in payload:
+            kwargs["enabled"] = bool(payload["enabled"])
+        try:
+            user = service.user_store.update_user(user_id, **kwargs)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return {"user": user.to_dict()}
+
+    @app.post("/api/users/{user_id}/password")
+    async def api_set_user_password(request: Request, user_id: str) -> dict[str, Any]:
+        require_permission(request, PERM_MANAGE_USERS)
+        payload = await request.json()
+        if not isinstance(payload, dict):
+            raise HTTPException(status_code=400, detail="Invalid JSON body")
+        try:
+            service.user_store.set_password(user_id, str(payload.get("password", "")))
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return {"updated": True}
+
+    @app.delete("/api/users/{user_id}")
+    async def api_delete_user(request: Request, user_id: str) -> dict[str, Any]:
+        require_permission(request, PERM_MANAGE_USERS)
+        session_user = request.session.get("user") or {}
+        if session_user.get("id") == user_id:
+            raise HTTPException(status_code=400, detail="Cannot delete yourself")
+        try:
+            service.user_store.delete_user(user_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return {"deleted": True, "user_id": user_id}
+
+    # -- Logs page + API ----------------------------------------------------
+
+    @app.get("/logs", response_class=HTMLResponse)
+    async def logs_page(request: Request) -> HTMLResponse:
+        user = require_login(request)
+        if not has_permission(user, PERM_VIEW_LOGS):
+            raise HTTPException(status_code=403, detail="Permission denied")
+        return templates.TemplateResponse(request, "logs.html", {"user": user})
+
+    @app.get("/api/logs/files")
+    async def api_list_log_files(request: Request) -> dict[str, Any]:
+        require_permission(request, PERM_VIEW_LOGS)
+        files = service.log_service.list_files()
+        return {"files": files, "log_dir": str(service.log_service.log_dir)}
+
+    @app.get("/api/logs/tail")
+    async def api_tail_log(
+        request: Request,
+        filename: str,
+        limit: int = 500,
+        level: str | None = None,
+        logger: str | None = None,
+        q: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+    ) -> dict[str, Any]:
+        require_permission(request, PERM_VIEW_LOGS)
+        try:
+            return service.log_service.read_tail(
+                filename=filename,
+                limit=limit,
+                level=level,
+                logger_filter=logger,
+                query=q,
+                since=since,
+                until=until,
+            )
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=f"Log file not found: {exc}") from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    @app.post("/api/logs/analyze")
+    async def api_analyze_logs(request: Request) -> dict[str, Any]:
+        require_permission(request, PERM_ANALYZE_LOGS)
+        payload = await request.json()
+        if not isinstance(payload, dict):
+            raise HTTPException(status_code=400, detail="Invalid JSON body")
+        try:
+            return service.log_service.analyze(
+                records_text=str(payload.get("text", "")),
+                focus=str(payload.get("focus", "")),
+                agent_name=str(payload.get("agent", "rd_director")),
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except Exception as exc:
+            logger.error("Log analyze failed: %s", exc)
+            raise HTTPException(status_code=500, detail=f"Analysis failed: {exc}") from exc
 
     return app

--- a/src/aise/web/log_service.py
+++ b/src/aise/web/log_service.py
@@ -1,0 +1,345 @@
+"""Log file access + LLM-driven analysis for the web console.
+
+Exposes:
+
+- ``LogService.list_files()`` — enumerate rotated / current log files.
+- ``LogService.read_tail(...)`` — filter + tail log lines with parsing
+  into structured records (timestamp / level / logger / message).
+- ``LogService.analyze(...)`` — ship a text excerpt to a registered
+  AgentRuntime (defaults to ``rd_director``) for LLM summarisation and
+  root-cause reasoning.
+
+The module deliberately keeps parsing loose: AISE logs are written in
+the standard format ``%(asctime)s | %(levelname)s | %(name)s |
+%(message)s`` (see ``utils/logging.py``). A JSON formatter is also
+supported — lines that parse as a JSON object with a ``level`` field
+are treated as JSON records.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable
+
+from ..utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+# Standard pipe-delimited plain-text line produced by the shared formatter:
+#   2026-04-21 12:34:56 | INFO | aise.web.app | some message
+_PLAIN_LINE_RE = re.compile(
+    r"^(?P<ts>\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)\s*\|\s*"
+    r"(?P<level>[A-Z]+)\s*\|\s*"
+    r"(?P<logger>[\w.\-]+)\s*\|\s*"
+    r"(?P<message>.*)$"
+)
+
+LEVEL_ORDER = {
+    "DEBUG": 10,
+    "INFO": 20,
+    "WARNING": 30,
+    "WARN": 30,
+    "ERROR": 40,
+    "CRITICAL": 50,
+    "FATAL": 50,
+}
+
+
+@dataclass
+class LogRecord:
+    """One parsed log line ready for the UI."""
+
+    raw: str
+    timestamp: str = ""
+    level: str = ""
+    logger_name: str = ""
+    message: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "raw": self.raw,
+            "timestamp": self.timestamp,
+            "level": self.level,
+            "logger": self.logger_name,
+            "message": self.message,
+        }
+
+
+def _parse_line(line: str) -> LogRecord:
+    """Best-effort parse of a single log line.
+
+    Falls back to ``raw``-only record if no structured format matches
+    so the UI can still display the line.
+    """
+    stripped = line.rstrip("\n")
+    if not stripped:
+        return LogRecord(raw="")
+
+    # JSON formatter path
+    if stripped[:1] == "{":
+        try:
+            obj = json.loads(stripped)
+            if isinstance(obj, dict) and "level" in obj:
+                return LogRecord(
+                    raw=stripped,
+                    timestamp=str(obj.get("ts", "")),
+                    level=str(obj.get("level", "")).upper(),
+                    logger_name=str(obj.get("logger", "")),
+                    message=str(obj.get("message", "")),
+                )
+        except Exception:
+            pass
+
+    match = _PLAIN_LINE_RE.match(stripped)
+    if match:
+        return LogRecord(
+            raw=stripped,
+            timestamp=match.group("ts"),
+            level=match.group("level").upper(),
+            logger_name=match.group("logger"),
+            message=match.group("message"),
+        )
+
+    return LogRecord(raw=stripped, message=stripped)
+
+
+def _iter_lines_tail(path: Path, max_lines: int) -> Iterable[str]:
+    """Read up to ``max_lines`` from the tail of the file.
+
+    Streams the whole file through a bounded ``deque`` — simple and
+    robust for the sizes web consoles care about (single-digit MB).
+    """
+    if max_lines <= 0:
+        return ()
+    buf: deque[str] = deque(maxlen=max_lines)
+    with path.open("r", encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            buf.append(line)
+    return list(buf)
+
+
+class LogService:
+    """Thin service wrapping log-dir reads and a dispatch hook."""
+
+    def __init__(self, log_dir: str | Path, *, runtime_manager: Any | None = None) -> None:
+        self._log_dir = Path(log_dir)
+        self._runtime_manager = runtime_manager
+
+    @property
+    def log_dir(self) -> Path:
+        return self._log_dir
+
+    def set_runtime_manager(self, runtime_manager: Any) -> None:
+        self._runtime_manager = runtime_manager
+
+    # -- Listing -------------------------------------------------------------
+
+    def list_files(self) -> list[dict[str, Any]]:
+        """Return metadata for every log file in the directory.
+
+        Includes both the current rotated file (``aise.log``) and the
+        dated backups (``aise.log.2026-04-19``) so admins can read
+        historical runs, not just today's log.
+        """
+        if not self._log_dir.is_dir():
+            return []
+        items: list[dict[str, Any]] = []
+        for entry in self._log_dir.iterdir():
+            if not entry.is_file():
+                continue
+            name = entry.name
+            if not (name.endswith(".log") or ".log." in name):
+                continue
+            try:
+                st = entry.stat()
+            except OSError:
+                continue
+            items.append(
+                {
+                    "name": name,
+                    "size": st.st_size,
+                    "mtime": datetime.utcfromtimestamp(st.st_mtime).isoformat() + "Z",
+                }
+            )
+        items.sort(key=lambda item: item["mtime"], reverse=True)
+        return items
+
+    # -- Reading -------------------------------------------------------------
+
+    def read_tail(
+        self,
+        *,
+        filename: str,
+        limit: int = 500,
+        level: str | None = None,
+        logger_filter: str | None = None,
+        query: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+    ) -> dict[str, Any]:
+        """Read + filter the tail of a log file.
+
+        Returns a dict with ``file``, ``records`` (list[LogRecord]),
+        ``total_read``, ``returned``, and ``truncated`` so the UI can
+        tell the user whether more lines exist outside the window.
+        """
+        if not filename:
+            raise ValueError("filename is required")
+        # Path traversal guard.
+        candidate = (self._log_dir / filename).resolve()
+        root = self._log_dir.resolve()
+        try:
+            candidate.relative_to(root)
+        except ValueError as exc:
+            raise ValueError("filename escapes log directory") from exc
+        if not candidate.is_file():
+            raise FileNotFoundError(filename)
+
+        limit = max(1, min(int(limit), 5000))
+        raw_level = (level or "").strip().upper()
+        level_threshold = LEVEL_ORDER.get(raw_level)
+        logger_substring = (logger_filter or "").strip()
+        query_lc = (query or "").strip().lower()
+        since_norm = _normalize_iso(since)
+        until_norm = _normalize_iso(until)
+
+        # Oversample 3x so filters don't leave the UI with a near-empty
+        # result when the user asks for "latest 100 ERRORs".
+        read_max = min(limit * 3 + 200, 20000)
+        total_scanned = 0
+        matched: list[LogRecord] = []
+        for raw in _iter_lines_tail(candidate, read_max):
+            total_scanned += 1
+            record = _parse_line(raw)
+            if level_threshold is not None:
+                rec_level = LEVEL_ORDER.get(record.level.upper())
+                if rec_level is None or rec_level < level_threshold:
+                    continue
+            if logger_substring:
+                if logger_substring.lower() not in record.logger_name.lower():
+                    continue
+            if query_lc:
+                if query_lc not in raw.lower():
+                    continue
+            if since_norm or until_norm:
+                rec_ts = _normalize_iso(record.timestamp)
+                if since_norm and (rec_ts is None or rec_ts < since_norm):
+                    continue
+                if until_norm and (rec_ts is None or rec_ts > until_norm):
+                    continue
+            matched.append(record)
+            if len(matched) > limit:
+                matched.pop(0)
+        return {
+            "file": filename,
+            "total_scanned": total_scanned,
+            "returned": len(matched),
+            "records": [r.to_dict() for r in matched],
+            "truncated": total_scanned >= read_max,
+        }
+
+    # -- Analysis ------------------------------------------------------------
+
+    def analyze(
+        self,
+        *,
+        records_text: str,
+        focus: str = "",
+        agent_name: str = "rd_director",
+    ) -> dict[str, Any]:
+        """Ship ``records_text`` to an agent runtime for analysis.
+
+        The default target is ``rd_director`` because it already
+        inspects other agents' outputs and has a broad system view.
+        Falls back to ``project_manager`` then the first available
+        runtime so the feature works even on stripped-down setups.
+        """
+        if self._runtime_manager is None:
+            raise RuntimeError("LogService has no runtime_manager — cannot analyze")
+        text = (records_text or "").strip()
+        if not text:
+            raise ValueError("records_text is empty")
+        # Clamp size so a clueless admin doesn't ship 20MB of logs.
+        MAX_CHARS = 40000
+        truncated = False
+        if len(text) > MAX_CHARS:
+            text = text[-MAX_CHARS:]
+            truncated = True
+
+        candidates = [agent_name, "rd_director", "project_manager"]
+        runtime = None
+        for name in candidates:
+            candidate = self._runtime_manager.get_runtime(name)
+            if candidate is not None:
+                runtime = candidate
+                agent_name = name
+                break
+        if runtime is None:
+            runtimes = getattr(self._runtime_manager, "runtimes", {}) or {}
+            if runtimes:
+                agent_name, runtime = next(iter(runtimes.items()))
+        if runtime is None:
+            raise RuntimeError("No agent runtime available for log analysis")
+
+        focus_hint = focus.strip()
+        prompt = (
+            "You are a senior SRE reviewing AISE application logs.\n\n"
+            "Return a concise Markdown report with EXACTLY these sections:\n"
+            "1. **Summary** — one or two sentences describing what is happening.\n"
+            "2. **Severity** — one of NORMAL / WARNING / CRITICAL with a short justification.\n"
+            "3. **Top Issues** — a numbered list of the 1-5 most impactful problems. For each:\n"
+            "   - a one-line symptom,\n"
+            "   - the logger/module that produced it,\n"
+            "   - the likely root cause (be specific — name the function, config, or dependency),\n"
+            "   - suggested next action.\n"
+            "4. **Errors vs Warnings vs Info** — counts of each.\n"
+            "5. **Notable Loggers** — short table of the top 3 loggers by volume.\n"
+            "6. **Follow-up Questions** — 1-3 diagnostic questions worth answering.\n\n"
+            "Rules:\n"
+            "- Do NOT invent log lines; only analyze what is supplied.\n"
+            "- Quote at most one short log excerpt per issue (<=200 chars).\n"
+            "- If the log is empty or uninformative, say so clearly.\n"
+        )
+        if focus_hint:
+            prompt += f"\nAdditional focus from the operator: {focus_hint}\n"
+        if truncated:
+            prompt += "\n(Note: only the most recent segment of the log is shown.)\n"
+        prompt += "\n--- LOG EXCERPT START ---\n" + text + "\n--- LOG EXCERPT END ---\n"
+
+        try:
+            response = runtime.handle_message(prompt)
+        except Exception as exc:
+            logger.warning("Log analysis dispatch failed: agent=%s error=%s", agent_name, exc)
+            raise
+        return {
+            "agent": agent_name,
+            "analysis": response or "",
+            "truncated": truncated,
+            "input_chars": len(text),
+        }
+
+
+def _normalize_iso(value: str | None) -> str | None:
+    """Lowercase ISO-8601 string for lexicographic comparison.
+
+    Log timestamps are already ISO-like, so a plain string compare is
+    enough to implement ``since/until`` without pulling in timezone
+    math. If parsing fails we return the raw string — the caller will
+    either compare or skip it as appropriate.
+    """
+    if not value:
+        return None
+    stripped = str(value).strip()
+    if not stripped:
+        return None
+    # Convert ``YYYY-MM-DD HH:MM:SS`` to ``YYYY-MM-DDTHH:MM:SS`` for
+    # consistent comparison against ISO inputs from the frontend.
+    if " " in stripped and "T" not in stripped:
+        stripped = stripped.replace(" ", "T", 1)
+    return stripped

--- a/src/aise/web/static/app.js
+++ b/src/aise/web/static/app.js
@@ -1,35 +1,35 @@
 function escapeHtml(value) {
-  return String(value)
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
+    return String(value)
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#39;");
 }
 
 async function fetchJson(url, options) {
-  const response = await fetch(url, options || {});
-  if (!response.ok) {
-    throw new Error(`Request failed: ${response.status}`);
-  }
-  return response.json();
+    const response = await fetch(url, options || {});
+    if (!response.ok) {
+        throw new Error(`Request failed: ${response.status}`);
+    }
+    return response.json();
 }
 
 function readScriptJson(id, fallback) {
-  const node = document.getElementById(id);
-  if (!node) return fallback;
-  try {
-    return JSON.parse(node.textContent || "null") || fallback;
-  } catch {
-    return fallback;
-  }
+    const node = document.getElementById(id);
+    if (!node) return fallback;
+    try {
+        return JSON.parse(node.textContent || "null") || fallback;
+    } catch {
+        return fallback;
+    }
 }
 
 function mountReact(rootId, componentFactory) {
-  const rootNode = document.getElementById(rootId);
-  if (!rootNode || !window.React || !window.ReactDOM) return;
-  const root = window.ReactDOM.createRoot(rootNode);
-  root.render(componentFactory(window.React));
+    const rootNode = document.getElementById(rootId);
+    if (!rootNode || !window.React || !window.ReactDOM) return;
+    const root = window.ReactDOM.createRoot(rootNode);
+    root.render(componentFactory(window.React));
 }
 
 // ---------------------------------------------------------------------------
@@ -57,8 +57,8 @@ const I18N_SUPPORTED_LANGS = ["zh", "en"];
 const I18N_DEFAULT_LANG = "zh";
 
 function resolveInitialLang() {
-  const raw = (window.__AISE_LANG || "").toString().toLowerCase();
-  return I18N_SUPPORTED_LANGS.indexOf(raw) >= 0 ? raw : I18N_DEFAULT_LANG;
+    const raw = (window.__AISE_LANG || "").toString().toLowerCase();
+    return I18N_SUPPORTED_LANGS.indexOf(raw) >= 0 ? raw : I18N_DEFAULT_LANG;
 }
 
 // Bootstraps i18next once per page load. Subsequent calls return the
@@ -66,1640 +66,1638 @@ function resolveInitialLang() {
 // run, task, etc.) can all ``await`` the shared init.
 let _i18nReady = null;
 function initI18n() {
-  if (_i18nReady) return _i18nReady;
-  if (!window.i18next || !window.i18nextHttpBackend) {
-    // Vendor scripts didn't load (offline / CDN blocked). Resolve the
-    // promise so pages still mount; ``t()`` will fall through to the
-    // raw key and at least be legible in English-ish form.
-    _i18nReady = Promise.resolve(null);
+    if (_i18nReady) return _i18nReady;
+    if (!window.i18next || !window.i18nextHttpBackend) {
+        // Vendor scripts didn't load (offline / CDN blocked). Resolve the
+        // promise so pages still mount; ``t()`` will fall through to the
+        // raw key and at least be legible in English-ish form.
+        _i18nReady = Promise.resolve(null);
+        return _i18nReady;
+    }
+    _i18nReady = window.i18next.use(window.i18nextHttpBackend).init({
+        lng: resolveInitialLang(),
+        fallbackLng: "en",
+        supportedLngs: I18N_SUPPORTED_LANGS,
+        defaultNS: "translation",
+        ns: ["translation"],
+        backend: {
+            loadPath: "/static/locales/{{lng}}/{{ns}}.json",
+        },
+        interpolation: {
+            // React escapes children already — don't double-escape.
+            escapeValue: false,
+        },
+        returnEmptyString: false,
+    });
     return _i18nReady;
-  }
-  _i18nReady = window.i18next.use(window.i18nextHttpBackend).init({
-    lng: resolveInitialLang(),
-    fallbackLng: "en",
-    supportedLngs: I18N_SUPPORTED_LANGS,
-    defaultNS: "translation",
-    ns: ["translation"],
-    backend: {
-      loadPath: "/static/locales/{{lng}}/{{ns}}.json",
-    },
-    interpolation: {
-      // React escapes children already — don't double-escape.
-      escapeValue: false,
-    },
-    returnEmptyString: false,
-  });
-  return _i18nReady;
 }
 
 function t(key, params) {
-  if (window.i18next && window.i18next.isInitialized) {
-    return window.i18next.t(key, params);
-  }
-  // Pre-init fallback: return the key itself. Any code that renders
-  // before ``await initI18n()`` will show raw keys — which is louder
-  // than silent undefined and easy to spot in dev.
-  return key;
+    if (window.i18next && window.i18next.isInitialized) {
+        return window.i18next.t(key, params);
+    }
+    // Pre-init fallback: return the key itself. Any code that renders
+    // before ``await initI18n()`` will show raw keys — which is louder
+    // than silent undefined and easy to spot in dev.
+    return key;
 }
 
 function currentLang() {
-  if (window.i18next && window.i18next.language) {
-    return String(window.i18next.language).toLowerCase();
-  }
-  return resolveInitialLang();
+    if (window.i18next && window.i18next.language) {
+        return String(window.i18next.language).toLowerCase();
+    }
+    return resolveInitialLang();
 }
 
 function formatLocalTime(ts) {
-  if (!ts) return "";
-  try {
-    const d = new Date(ts);
-    if (isNaN(d.getTime())) return String(ts);
-    const locale = currentLang() === "en" ? "en-US" : "zh-CN";
-    return d.toLocaleString(locale, {
-      year: "numeric", month: "2-digit", day: "2-digit",
-      hour: "2-digit", minute: "2-digit", second: "2-digit",
-      hour12: false
-    });
-  } catch { return String(ts); }
+    if (!ts) return "";
+    try {
+        const d = new Date(ts);
+        if (isNaN(d.getTime())) return String(ts);
+        const locale = currentLang() === "en" ? "en-US" : "zh-CN";
+        return d.toLocaleString(locale, {
+            year: "numeric", month: "2-digit", day: "2-digit",
+            hour: "2-digit", minute: "2-digit", second: "2-digit",
+            hour12: false
+        });
+    } catch { return String(ts); }
 }
 
 function setupDashboardReact() {
-  const initial = readScriptJson("dashboard-initial-data", { projects: [], global_config_data: {} });
+    const initial = readScriptJson("dashboard-initial-data", { projects: [], global_config_data: {} });
 
-  function formatTime(ts) {
-    if (!ts) return "";
-    const d = new Date(ts);
-    if (isNaN(d.getTime())) return String(ts);
-    const now = Date.now();
-    const diff = now - d.getTime();
-    if (diff < 60000) return "刚刚";
-    if (diff < 3600000) return `${Math.floor(diff / 60000)} 分钟前`;
-    if (diff < 86400000) return `${Math.floor(diff / 3600000)} 小时前`;
-    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-  }
+    function formatTime(ts) {
+        if (!ts) return "";
+        const d = new Date(ts);
+        if (isNaN(d.getTime())) return String(ts);
+        const now = Date.now();
+        const diff = now - d.getTime();
+        if (diff < 60000) return "刚刚";
+        if (diff < 3600000) return `${Math.floor(diff / 60000)} 分钟前`;
+        if (diff < 86400000) return `${Math.floor(diff / 3600000)} 小时前`;
+        return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+    }
 
-  function DashboardApp() {
-    const h = window.React.createElement;
-    const config = initial.global_config_data || {};
-    const availableAgents = Array.isArray(config.available_agents) ? config.available_agents : [];
-    const [projects, setProjects] = window.React.useState(Array.isArray(initial.projects) ? initial.projects : []);
-    const [catalog, setCatalog] = window.React.useState(Array.isArray(config.model_catalog) ? config.model_catalog : []);
-    const [agentModels, setAgentModels] = window.React.useState(config.agent_model_selection || {});
-    const [formData, setFormData] = window.React.useState({
-      project_name: "",
-      development_mode: config.development_mode || "local",
-      process_type: "waterfall",
-      initial_requirement: "",
-    });
-    const [submitting, setSubmitting] = window.React.useState(false);
-    const [deletingProjectId, setDeletingProjectId] = window.React.useState("");
-    const [error, setError] = window.React.useState("");
-    const [showModal, setShowModal] = window.React.useState(false);
-
-    window.React.useEffect(() => {
-      let active = true;
-      async function refresh() {
-        try {
-          const [projectsData, cfgData] = await Promise.all([
-            fetchJson("/api/projects"),
-            fetchJson("/api/config/global/data"),
-          ]);
-          if (!active) return;
-          setProjects(Array.isArray(projectsData.projects) ? projectsData.projects : []);
-          const nextCatalog = Array.isArray(cfgData.model_catalog) ? cfgData.model_catalog : [];
-          setCatalog(nextCatalog);
-          setAgentModels(cfgData.agent_model_selection || {});
-          setFormData((prev) => ({
-            project_name: prev.project_name,
-            initial_requirement: prev.initial_requirement,
-            development_mode: prev.development_mode || cfgData.development_mode || "local",
-            process_type: prev.process_type || "waterfall",
-            _showAgentModels: prev._showAgentModels,
-          }));
-        } catch {
-          // keep current state
-        }
-      }
-
-      refresh();
-      const timer = window.setInterval(refresh, 3000);
-      return () => {
-        active = false;
-        window.clearInterval(timer);
-      };
-    }, []);
-
-    async function submitProject(event) {
-      event.preventDefault();
-      setSubmitting(true);
-      setError("");
-      try {
-        const payload = {
-          project_name: String(formData.project_name || ""),
-          development_mode: String(formData.development_mode || "local"),
-          process_type: String(formData.process_type || "waterfall"),
-          initial_requirement: String(formData.initial_requirement || ""),
-          agent_models: agentModels,
-        };
-        const created = await fetchJson("/api/projects", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(payload),
+    function DashboardApp() {
+        const h = window.React.createElement;
+        const config = initial.global_config_data || {};
+        const availableAgents = Array.isArray(config.available_agents) ? config.available_agents : [];
+        const [projects, setProjects] = window.React.useState(Array.isArray(initial.projects) ? initial.projects : []);
+        const [catalog, setCatalog] = window.React.useState(Array.isArray(config.model_catalog) ? config.model_catalog : []);
+        const [agentModels, setAgentModels] = window.React.useState(config.agent_model_selection || {});
+        const [formData, setFormData] = window.React.useState({
+            project_name: "",
+            development_mode: config.development_mode || "local",
+            process_type: "waterfall",
+            initial_requirement: "",
         });
-        setShowModal(false);
-        if (created.run_id) {
-          window.location.href = `/projects/${encodeURIComponent(created.project_id)}/runs/${encodeURIComponent(created.run_id)}`;
-          return;
+        const [submitting, setSubmitting] = window.React.useState(false);
+        const [deletingProjectId, setDeletingProjectId] = window.React.useState("");
+        const [error, setError] = window.React.useState("");
+        const [showModal, setShowModal] = window.React.useState(false);
+
+        window.React.useEffect(() => {
+            let active = true;
+            async function refresh() {
+                try {
+                    const [projectsData, cfgData] = await Promise.all([
+                        fetchJson("/api/projects"),
+                        fetchJson("/api/config/global/data"),
+                    ]);
+                    if (!active) return;
+                    setProjects(Array.isArray(projectsData.projects) ? projectsData.projects : []);
+                    const nextCatalog = Array.isArray(cfgData.model_catalog) ? cfgData.model_catalog : [];
+                    setCatalog(nextCatalog);
+                    setAgentModels(cfgData.agent_model_selection || {});
+                    setFormData((prev) => ({
+                        project_name: prev.project_name,
+                        initial_requirement: prev.initial_requirement,
+                        development_mode: prev.development_mode || cfgData.development_mode || "local",
+                        process_type: prev.process_type || "waterfall",
+                        _showAgentModels: prev._showAgentModels,
+                    }));
+                } catch {
+                    // keep current state
+                }
+            }
+
+            refresh();
+            const timer = window.setInterval(refresh, 3000);
+            return () => {
+                active = false;
+                window.clearInterval(timer);
+            };
+        }, []);
+
+        async function submitProject(event) {
+            event.preventDefault();
+            setSubmitting(true);
+            setError("");
+            try {
+                const payload = {
+                    project_name: String(formData.project_name || ""),
+                    development_mode: String(formData.development_mode || "local"),
+                    process_type: String(formData.process_type || "waterfall"),
+                    initial_requirement: String(formData.initial_requirement || ""),
+                    agent_models: agentModels,
+                };
+                const created = await fetchJson("/api/projects", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify(payload),
+                });
+                setShowModal(false);
+                if (created.run_id) {
+                    window.location.href = `/projects/${encodeURIComponent(created.project_id)}/runs/${encodeURIComponent(created.run_id)}`;
+                    return;
+                }
+                window.location.href = `/projects/${encodeURIComponent(created.project_id)}`;
+            } catch (err) {
+                setError(err instanceof Error ? err.message : "创建失败");
+                setSubmitting(false);
+            }
         }
-        window.location.href = `/projects/${encodeURIComponent(created.project_id)}`;
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "创建失败");
-        setSubmitting(false);
-      }
-    }
 
-    async function deleteProject(project, e) {
-      e.preventDefault();
-      e.stopPropagation();
-      const projectId = String(project.project_id || "");
-      if (!projectId) return;
-      const first = window.confirm(`确认删除项目「${project.project_name || projectId}」？`);
-      if (!first) return;
-      const second = window.confirm(`再次确认：删除后将同步清理目录，且不可恢复。\n项目ID: ${projectId}`);
-      if (!second) return;
-      setDeletingProjectId(projectId);
-      setError("");
-      try {
-        await fetchJson(`/api/projects/${encodeURIComponent(projectId)}`, { method: "DELETE" });
-        setProjects((prev) => prev.filter((p) => String(p.project_id) !== projectId));
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "删除失败");
-      } finally {
-        setDeletingProjectId("");
-      }
-    }
-
-    async function restartProject(project, e) {
-      e.preventDefault();
-      e.stopPropagation();
-      const projectId = String(project.project_id || "");
-      if (!projectId) return;
-      if (!window.confirm(`确认重新开始项目「${project.project_name || projectId}」？\n将清除所有执行记录，重新提交原始需求。`)) return;
-      setError("");
-      try {
-        const result = await fetchJson(`/api/projects/${encodeURIComponent(projectId)}/restart`, { method: "POST" });
-        if (result.run_id) {
-          window.location.href = `/projects/${encodeURIComponent(projectId)}/runs/${encodeURIComponent(result.run_id)}`;
+        async function deleteProject(project, e) {
+            e.preventDefault();
+            e.stopPropagation();
+            const projectId = String(project.project_id || "");
+            if (!projectId) return;
+            const first = window.confirm(`确认删除项目「${project.project_name || projectId}」？`);
+            if (!first) return;
+            const second = window.confirm(`再次确认：删除后将同步清理目录，且不可恢复。\n项目ID: ${projectId}`);
+            if (!second) return;
+            setDeletingProjectId(projectId);
+            setError("");
+            try {
+                await fetchJson(`/api/projects/${encodeURIComponent(projectId)}`, { method: "DELETE" });
+                setProjects((prev) => prev.filter((p) => String(p.project_id) !== projectId));
+            } catch (err) {
+                setError(err instanceof Error ? err.message : "删除失败");
+            } finally {
+                setDeletingProjectId("");
+            }
         }
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "重启失败");
-      }
-    }
 
-    function defaultModelId() {
-      const byFlag = catalog.find((item) => !!item.default && item.id);
-      if (byFlag) return String(byFlag.id);
-      if (catalog.length && catalog[0].id) return String(catalog[0].id);
-      return "";
-    }
+        async function restartProject(project, e) {
+            e.preventDefault();
+            e.stopPropagation();
+            const projectId = String(project.project_id || "");
+            if (!projectId) return;
+            if (!window.confirm(`确认重新开始项目「${project.project_name || projectId}」？\n将清除所有执行记录，重新提交原始需求。`)) return;
+            setError("");
+            try {
+                const result = await fetchJson(`/api/projects/${encodeURIComponent(projectId)}/restart`, { method: "POST" });
+                if (result.run_id) {
+                    window.location.href = `/projects/${encodeURIComponent(projectId)}/runs/${encodeURIComponent(result.run_id)}`;
+                }
+            } catch (err) {
+                setError(err instanceof Error ? err.message : "重启失败");
+            }
+        }
 
-    function selectOptionsFor(agent) {
-      return catalog.map((item) => {
-        const optionId = String(item.id || "");
-        const isDefault = !!item.default;
-        const optionText = `${optionId}${isDefault ? " (default)" : ""}`;
-        return h("option", { key: optionId, value: optionId }, optionText);
-      });
-    }
+        function defaultModelId() {
+            const byFlag = catalog.find((item) => !!item.default && item.id);
+            if (byFlag) return String(byFlag.id);
+            if (catalog.length && catalog[0].id) return String(catalog[0].id);
+            return "";
+        }
 
-    // Project card badge: prefer workflow-run state (has_active_run +
-    // latest_run_status) over the project-lifecycle status. The lifecycle
-    // ``active`` just means "not paused/archived", which is the default for
-    // every project — rendering that as "in progress" made every card look busy.
-    function projectBadge(project) {
-      if (project && project.has_active_run) {
-        return h("span", { className: "status-badge status-running" }, "◉ 运行中");
-      }
-      const latest = project ? project.latest_run_status : null;
-      if (latest === "completed" || latest === "success") return h("span", { className: "status-badge status-success" }, "✓ 成功");
-      if (latest === "failed" || latest === "error") return h("span", { className: "status-badge status-failed" }, "✕ 失败");
-      const lifecycle = project ? project.status : null;
-      if (lifecycle === "paused") return h("span", { className: "status-badge status-pending" }, "⏸ 暂停");
-      if (lifecycle === "archived") return h("span", { className: "status-badge status-pending" }, "▣ 归档");
-      if (lifecycle === "completed") return h("span", { className: "status-badge status-success" }, "✓ 已完成");
-      return h("span", { className: "status-badge status-pending" }, "○ 就绪");
-    }
+        function selectOptionsFor(agent) {
+            return catalog.map((item) => {
+                const optionId = String(item.id || "");
+                const isDefault = !!item.default;
+                const optionText = `${optionId}${isDefault ? " (default)" : ""}`;
+                return h("option", { key: optionId, value: optionId }, optionText);
+            });
+        }
 
-    const runningCount = projects.filter((p) => p.has_active_run).length;
-    const successCount = projects.filter((p) => (p.latest_run_status === "completed" || p.latest_run_status === "success") && !p.has_active_run).length;
-    const failedCount = projects.filter((p) => (p.latest_run_status === "failed" || p.latest_run_status === "error") && !p.has_active_run).length;
+        // Project card badge: prefer workflow-run state (has_active_run +
+        // latest_run_status) over the project-lifecycle status. The lifecycle
+        // ``active`` just means "not paused/archived", which is the default for
+        // every project — rendering that as "in progress" made every card look busy.
+        function projectBadge(project) {
+            if (project && project.has_active_run) {
+                return h("span", { className: "status-badge status-running" }, "◉ 运行中");
+            }
+            const latest = project ? project.latest_run_status : null;
+            if (latest === "completed" || latest === "success") return h("span", { className: "status-badge status-success" }, "✓ 成功");
+            if (latest === "failed" || latest === "error") return h("span", { className: "status-badge status-failed" }, "✕ 失败");
+            const lifecycle = project ? project.status : null;
+            if (lifecycle === "paused") return h("span", { className: "status-badge status-pending" }, "⏸ 暂停");
+            if (lifecycle === "archived") return h("span", { className: "status-badge status-pending" }, "▣ 归档");
+            if (lifecycle === "completed") return h("span", { className: "status-badge status-success" }, "✓ 已完成");
+            return h("span", { className: "status-badge status-pending" }, "○ 就绪");
+        }
 
-    const modal = showModal
-      ? h(
-          "div",
-          {
-            className: "modal-overlay",
-            onClick: (e) => { if (e.target === e.currentTarget) setShowModal(false); },
-          },
-          h(
-            "div",
-            { className: "modal-content" },
-            h(
-              "div",
-              { className: "modal-header" },
-              h("h2", null, "新建项目"),
-              h("button", { className: "modal-close", onClick: () => setShowModal(false) }, "×")
-            ),
-            h(
-              "form",
-              { className: "modal-form", onSubmit: submitProject },
-              h("label", null, "项目名称"),
-              h("input", {
-                required: true,
-                value: formData.project_name,
-                placeholder: "例如: UserAPI",
-                onChange: (e) => setFormData((prev) => ({ ...prev, project_name: e.target.value })),
-              }),
-              h("label", null, "开发模式"),
-              h(
-                "select",
-                {
-                  value: formData.development_mode,
-                  onChange: (e) => setFormData((prev) => ({ ...prev, development_mode: e.target.value })),
-                },
-                h("option", { value: "local" }, "Local"),
-                h("option", { value: "github" }, "GitHub")
-              ),
-              h("label", null, "研发流程"),
-              h(
-                "select",
-                {
-                  value: formData.process_type || "waterfall",
-                  onChange: (e) => setFormData((prev) => ({ ...prev, process_type: e.target.value })),
-                },
-                h("option", { value: "waterfall" }, "Waterfall — 线性全生命周期"),
-                h("option", { value: "agile" }, "Agile Sprint — 迭代交付 MVP")
-              ),
-              h("p", { style: { margin: "4px 0 12px", color: "#888", fontSize: "12px" } },
-                formData.process_type === "agile"
-                  ? "迭代模式：sprint planning / sprint execution / sprint review / retrospective / delivery"
-                  : "瀑布模式：需求 / 架构 / 开发 / 入口验证 / 集成测试 / 交付报告"),
-              h("label", null, "初始需求（可选）"),
-              h("textarea", {
-                rows: 4,
-                placeholder: "例如：构建一个用户管理 API",
-                value: formData.initial_requirement,
-                onChange: (e) => setFormData((prev) => ({ ...prev, initial_requirement: e.target.value })),
-              }),
-              h("div", { className: "agent-model-toggle-row" },
-                h("button", {
-                  type: "button",
-                  className: "btn secondary btn-sm",
-                  onClick: () => setFormData((prev) => ({ ...prev, _showAgentModels: !prev._showAgentModels })),
-                }, formData._showAgentModels ? "\u25BC \u6536\u8D77 Agent \u6A21\u578B\u914D\u7F6E" : "\u25B6 \u81EA\u5B9A\u4E49 Agent \u6A21\u578B"),
-              ),
-              formData._showAgentModels ? h(
+        const runningCount = projects.filter((p) => p.has_active_run).length;
+        const successCount = projects.filter((p) => (p.latest_run_status === "completed" || p.latest_run_status === "success") && !p.has_active_run).length;
+        const failedCount = projects.filter((p) => (p.latest_run_status === "failed" || p.latest_run_status === "error") && !p.has_active_run).length;
+
+        const modal = showModal
+            ? h(
                 "div",
-                { className: "agent-grid" },
-                ...availableAgents.flatMap((agent) => [
-                  h("label", { key: `${agent}-label` }, agent),
-                  h(
-                    "select",
-                    {
-                      key: `${agent}-select`,
-                      value: String(agentModels[agent] || defaultModelId()),
-                      onChange: (e) =>
-                        setAgentModels((prev) => ({
-                          ...prev,
-                          [agent]: e.target.value,
-                        })),
-                    },
-                    ...selectOptionsFor(agent)
-                  ),
-                ])
-              ) : null,
-              error ? h("p", { className: "warning" }, error) : null,
-              h(
-                "div",
-                { className: "modal-actions" },
-                h("button", { type: "button", className: "btn secondary", onClick: () => setShowModal(false) }, "取消"),
-                h("button", { className: "btn", type: "submit", disabled: submitting }, submitting ? "创建中..." : "创建项目")
-              )
-            )
-          )
-        )
-      : null;
-
-    return h(
-      "div",
-      { className: "dashboard-shell" },
-      h(
-        "div",
-        { className: "dashboard-topbar" },
-        h(
-          "div",
-          { className: "dashboard-topbar-left" },
-          h("h1", { className: "dashboard-title" }, "项目"),
-          h(
-            "div",
-            { className: "dashboard-stats" },
-            h("span", { className: "stat-chip" }, `共 ${projects.length} 个`),
-            runningCount > 0 ? h("span", { className: "stat-chip stat-running" }, `${runningCount} 运行中`) : null,
-            successCount > 0 ? h("span", { className: "stat-chip stat-success" }, `${successCount} 成功`) : null,
-            failedCount > 0 ? h("span", { className: "stat-chip stat-failed" }, `${failedCount} 失败`) : null
-          )
-        ),
-        h("button", { className: "btn create-project-btn", onClick: () => setShowModal(true) }, "＋ 新建项目")
-      ),
-      error ? h("div", { className: "dashboard-error" }, error) : null,
-      h(
-        "div",
-        { className: "project-cards-grid" },
-        projects.length
-          ? projects.map((project) =>
-              h(
-                "a",
                 {
-                  key: project.project_id,
-                  className: "project-card",
-                  href: `/projects/${encodeURIComponent(project.project_id)}`,
+                    className: "modal-overlay",
+                    onClick: (e) => { if (e.target === e.currentTarget) setShowModal(false); },
                 },
                 h(
-                  "div",
-                  { className: "project-card-header" },
-                  h("h3", null, project.project_name),
-                  projectBadge(project)
-                ),
-                h(
-                  "div",
-                  { className: "project-card-meta" },
-                  h("span", null, `模式: ${project.development_mode}`),
-                  h("span", null, `流程: ${project.process_type || "waterfall"}`),
-                  h("span", null, `Agent: ${project.agent_count}`)
-                ),
-                h(
-                  "div",
-                  { className: "project-card-footer" },
-                  h("span", { className: "project-card-time" }, formatTime(project.updated_at)),
-                  h(
-                    "button",
-                    {
-                      className: "project-card-action project-card-restart",
-                      onClick: (e) => restartProject(project, e),
-                    },
-                    "\u21BB"
-                  ),
-                  h(
-                    "button",
-                    {
-                      className: "project-card-action project-card-delete",
-                      disabled: deletingProjectId === String(project.project_id),
-                      onClick: (e) => deleteProject(project, e),
-                    },
-                    deletingProjectId === String(project.project_id) ? "..." : "\u2715"
-                  )
+                    "div",
+                    { className: "modal-content" },
+                    h(
+                        "div",
+                        { className: "modal-header" },
+                        h("h2", null, "新建项目"),
+                        h("button", { className: "modal-close", onClick: () => setShowModal(false) }, "×")
+                    ),
+                    h(
+                        "form",
+                        { className: "modal-form", onSubmit: submitProject },
+                        h("label", null, "项目名称"),
+                        h("input", {
+                            required: true,
+                            value: formData.project_name,
+                            placeholder: "例如: UserAPI",
+                            onChange: (e) => setFormData((prev) => ({ ...prev, project_name: e.target.value })),
+                        }),
+                        h("label", null, "开发模式"),
+                        h(
+                            "select",
+                            {
+                                value: formData.development_mode,
+                                onChange: (e) => setFormData((prev) => ({ ...prev, development_mode: e.target.value })),
+                            },
+                            h("option", { value: "local" }, "Local"),
+                            h("option", { value: "github" }, "GitHub")
+                        ),
+                        h("label", null, "研发流程"),
+                        h(
+                            "select",
+                            {
+                                value: formData.process_type || "waterfall",
+                                onChange: (e) => setFormData((prev) => ({ ...prev, process_type: e.target.value })),
+                            },
+                            h("option", { value: "waterfall" }, "Waterfall — 线性全生命周期"),
+                            h("option", { value: "agile" }, "Agile Sprint — 迭代交付 MVP")
+                        ),
+                        h("p", { style: { margin: "4px 0 12px", color: "#888", fontSize: "12px" } },
+                            formData.process_type === "agile"
+                                ? "迭代模式：sprint planning / sprint execution / sprint review / retrospective / delivery"
+                                : "瀑布模式：需求 / 架构 / 开发 / 入口验证 / 集成测试 / 交付报告"),
+                        h("label", null, "初始需求（可选）"),
+                        h("textarea", {
+                            rows: 4,
+                            placeholder: "例如：构建一个用户管理 API",
+                            value: formData.initial_requirement,
+                            onChange: (e) => setFormData((prev) => ({ ...prev, initial_requirement: e.target.value })),
+                        }),
+                        h("div", { className: "agent-model-toggle-row" },
+                            h("button", {
+                                type: "button",
+                                className: "btn secondary btn-sm",
+                                onClick: () => setFormData((prev) => ({ ...prev, _showAgentModels: !prev._showAgentModels })),
+                            }, formData._showAgentModels ? "\u25BC \u6536\u8D77 Agent \u6A21\u578B\u914D\u7F6E" : "\u25B6 \u81EA\u5B9A\u4E49 Agent \u6A21\u578B"),
+                        ),
+                        formData._showAgentModels ? h(
+                            "div",
+                            { className: "agent-grid" },
+                            ...availableAgents.flatMap((agent) => [
+                                h("label", { key: `${agent}-label` }, agent),
+                                h(
+                                    "select",
+                                    {
+                                        key: `${agent}-select`,
+                                        value: String(agentModels[agent] || defaultModelId()),
+                                        onChange: (e) =>
+                                            setAgentModels((prev) => ({
+                                                ...prev,
+                                                [agent]: e.target.value,
+                                            })),
+                                    },
+                                    ...selectOptionsFor(agent)
+                                ),
+                            ])
+                        ) : null,
+                        error ? h("p", { className: "warning" }, error) : null,
+                        h(
+                            "div",
+                            { className: "modal-actions" },
+                            h("button", { type: "button", className: "btn secondary", onClick: () => setShowModal(false) }, "取消"),
+                            h("button", { className: "btn", type: "submit", disabled: submitting }, submitting ? "创建中..." : "创建项目")
+                        )
+                    )
                 )
-              )
             )
-          : h(
-              "div",
-              { className: "empty-state" },
-              h("div", { className: "empty-icon" }, "📂"),
-              h("p", null, "暂无项目"),
-              h("p", null, "点击上方按钮创建你的第一个项目")
-            )
-      ),
-      modal
-    );
-  }
+            : null;
 
-  mountReact("dashboard-react-root", () => window.React.createElement(DashboardApp));
+        return h(
+            "div",
+            { className: "dashboard-shell" },
+            h(
+                "div",
+                { className: "dashboard-topbar" },
+                h(
+                    "div",
+                    { className: "dashboard-topbar-left" },
+                    h("h1", { className: "dashboard-title" }, "项目"),
+                    h(
+                        "div",
+                        { className: "dashboard-stats" },
+                        h("span", { className: "stat-chip" }, `共 ${projects.length} 个`),
+                        runningCount > 0 ? h("span", { className: "stat-chip stat-running" }, `${runningCount} 运行中`) : null,
+                        successCount > 0 ? h("span", { className: "stat-chip stat-success" }, `${successCount} 成功`) : null,
+                        failedCount > 0 ? h("span", { className: "stat-chip stat-failed" }, `${failedCount} 失败`) : null
+                    )
+                ),
+                h("button", { className: "btn create-project-btn", onClick: () => setShowModal(true) }, "＋ 新建项目")
+            ),
+            error ? h("div", { className: "dashboard-error" }, error) : null,
+            h(
+                "div",
+                { className: "project-cards-grid" },
+                projects.length
+                    ? projects.map((project) =>
+                        h(
+                            "a",
+                            {
+                                key: project.project_id,
+                                className: "project-card",
+                                href: `/projects/${encodeURIComponent(project.project_id)}`,
+                            },
+                            h(
+                                "div",
+                                { className: "project-card-header" },
+                                h("h3", null, project.project_name),
+                                projectBadge(project)
+                            ),
+                            h(
+                                "div",
+                                { className: "project-card-meta" },
+                                h("span", null, `模式: ${project.development_mode}`),
+                                h("span", null, `流程: ${project.process_type || "waterfall"}`),
+                                h("span", null, `Agent: ${project.agent_count}`)
+                            ),
+                            h(
+                                "div",
+                                { className: "project-card-footer" },
+                                h("span", { className: "project-card-time" }, formatTime(project.updated_at)),
+                                h(
+                                    "button",
+                                    {
+                                        className: "project-card-action project-card-restart",
+                                        onClick: (e) => restartProject(project, e),
+                                    },
+                                    "\u21BB"
+                                ),
+                                h(
+                                    "button",
+                                    {
+                                        className: "project-card-action project-card-delete",
+                                        disabled: deletingProjectId === String(project.project_id),
+                                        onClick: (e) => deleteProject(project, e),
+                                    },
+                                    deletingProjectId === String(project.project_id) ? "..." : "\u2715"
+                                )
+                            )
+                        )
+                    )
+                    : h(
+                        "div",
+                        { className: "empty-state" },
+                        h("div", { className: "empty-icon" }, "📂"),
+                        h("p", null, "暂无项目"),
+                        h("p", null, "点击上方按钮创建你的第一个项目")
+                    )
+            ),
+            modal
+        );
+    }
+
+    mountReact("dashboard-react-root", () => window.React.createElement(DashboardApp));
 }
 
 function setupProjectReact() {
-  const initial = readScriptJson("project-initial-data", { project: null });
-  if (!initial.project) return;
+    const initial = readScriptJson("project-initial-data", { project: null });
+    if (!initial.project) return;
 
-  function ProjectApp() {
-    const h = window.React.createElement;
-    const project = initial.project;
-    const projectId = String((project.info || {}).project_id || "");
-    const [requirements, setRequirements] = window.React.useState(Array.isArray(project.requirements) ? project.requirements : []);
-    const [runs, setRuns] = window.React.useState(Array.isArray(project.runs) ? project.runs : []);
-    const [text, setText] = window.React.useState("");
-    const [submitting, setSubmitting] = window.React.useState(false);
-    const [deleting, setDeleting] = window.React.useState(false);
-    const [error, setError] = window.React.useState("");
-    const [projectMissing, setProjectMissing] = window.React.useState(false);
+    function ProjectApp() {
+        const h = window.React.createElement;
+        const project = initial.project;
+        const projectId = String((project.info || {}).project_id || "");
+        const [requirements, setRequirements] = window.React.useState(Array.isArray(project.requirements) ? project.requirements : []);
+        const [runs, setRuns] = window.React.useState(Array.isArray(project.runs) ? project.runs : []);
+        const [text, setText] = window.React.useState("");
+        const [submitting, setSubmitting] = window.React.useState(false);
+        const [deleting, setDeleting] = window.React.useState(false);
+        const [error, setError] = window.React.useState("");
+        const [projectMissing, setProjectMissing] = window.React.useState(false);
 
-    window.React.useEffect(() => {
-      let active = true;
-      let timer = 0;
-      async function refresh() {
-        try {
-          const [requirementsData, runsData] = await Promise.all([
-            fetchJson(`/api/projects/${encodeURIComponent(projectId)}/requirements`),
-            fetchJson(`/api/projects/${encodeURIComponent(projectId)}/runs`),
-          ]);
-          if (!active) return;
-          setRequirements(Array.isArray(requirementsData.requirements) ? requirementsData.requirements : []);
-          setRuns(Array.isArray(runsData.runs) ? runsData.runs : []);
-          setProjectMissing(false);
-        } catch (err) {
-          if (!active) return;
-          const message = err instanceof Error ? err.message : "";
-          if (String(message).includes("404")) {
-            setProjectMissing(true);
-            setError("项目不存在或已被删除。");
-            if (timer) window.clearInterval(timer);
-          }
+        window.React.useEffect(() => {
+            let active = true;
+            let timer = 0;
+            async function refresh() {
+                try {
+                    const [requirementsData, runsData] = await Promise.all([
+                        fetchJson(`/api/projects/${encodeURIComponent(projectId)}/requirements`),
+                        fetchJson(`/api/projects/${encodeURIComponent(projectId)}/runs`),
+                    ]);
+                    if (!active) return;
+                    setRequirements(Array.isArray(requirementsData.requirements) ? requirementsData.requirements : []);
+                    setRuns(Array.isArray(runsData.runs) ? runsData.runs : []);
+                    setProjectMissing(false);
+                } catch (err) {
+                    if (!active) return;
+                    const message = err instanceof Error ? err.message : "";
+                    if (String(message).includes("404")) {
+                        setProjectMissing(true);
+                        setError("项目不存在或已被删除。");
+                        if (timer) window.clearInterval(timer);
+                    }
+                }
+            }
+            if (projectMissing) return () => { };
+            refresh();
+            timer = window.setInterval(refresh, 3000);
+            return () => {
+                active = false;
+                if (timer) window.clearInterval(timer);
+            };
+        }, [projectId, projectMissing]);
+
+        async function submitRequirement(event) {
+            event.preventDefault();
+            if (!text.trim()) return;
+            setSubmitting(true);
+            setError("");
+            try {
+                const created = await fetchJson(`/api/projects/${encodeURIComponent(projectId)}/requirements`, {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ requirement_text: text }),
+                });
+                window.location.href = `/projects/${encodeURIComponent(projectId)}/runs/${encodeURIComponent(created.run_id)}`;
+            } catch (err) {
+                setError(err instanceof Error ? err.message : "提交失败");
+                setSubmitting(false);
+            }
         }
-      }
-      if (projectMissing) return () => {};
-      refresh();
-      timer = window.setInterval(refresh, 3000);
-      return () => {
-        active = false;
-        if (timer) window.clearInterval(timer);
-      };
-    }, [projectId, projectMissing]);
 
-    async function submitRequirement(event) {
-      event.preventDefault();
-      if (!text.trim()) return;
-      setSubmitting(true);
-      setError("");
-      try {
-        const created = await fetchJson(`/api/projects/${encodeURIComponent(projectId)}/requirements`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ requirement_text: text }),
-        });
-        window.location.href = `/projects/${encodeURIComponent(projectId)}/runs/${encodeURIComponent(created.run_id)}`;
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "提交失败");
-        setSubmitting(false);
-      }
-    }
-
-    async function deleteCurrentProject() {
-      const first = window.confirm(`确认删除项目「${project.info.project_name || projectId}」？`);
-      if (!first) return;
-      const second = window.confirm(`再次确认：删除后将同步清理目录，且不可恢复。\n项目ID: ${projectId}`);
-      if (!second) return;
-      setDeleting(true);
-      setError("");
-      try {
-        await fetchJson(`/api/projects/${encodeURIComponent(projectId)}`, { method: "DELETE" });
-        window.location.href = "/";
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "删除失败");
-        setDeleting(false);
-      }
-    }
-
-    async function restartCurrentProject() {
-      if (!window.confirm(`确认重新开始项目「${project.info.project_name || projectId}」？\n将清除所有执行记录，重新提交原始需求。`)) return;
-      setError("");
-      try {
-        const result = await fetchJson(`/api/projects/${encodeURIComponent(projectId)}/restart`, { method: "POST" });
-        if (result.run_id) {
-          window.location.href = `/projects/${encodeURIComponent(projectId)}/runs/${encodeURIComponent(result.run_id)}`;
+        async function deleteCurrentProject() {
+            const first = window.confirm(`确认删除项目「${project.info.project_name || projectId}」？`);
+            if (!first) return;
+            const second = window.confirm(`再次确认：删除后将同步清理目录，且不可恢复。\n项目ID: ${projectId}`);
+            if (!second) return;
+            setDeleting(true);
+            setError("");
+            try {
+                await fetchJson(`/api/projects/${encodeURIComponent(projectId)}`, { method: "DELETE" });
+                window.location.href = "/";
+            } catch (err) {
+                setError(err instanceof Error ? err.message : "删除失败");
+                setDeleting(false);
+            }
         }
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "重启失败");
-      }
-    }
 
-    const [view, setView] = window.React.useState("default");
+        async function restartCurrentProject() {
+            if (!window.confirm(`确认重新开始项目「${project.info.project_name || projectId}」？\n将清除所有执行记录，重新提交原始需求。`)) return;
+            setError("");
+            try {
+                const result = await fetchJson(`/api/projects/${encodeURIComponent(projectId)}/restart`, { method: "POST" });
+                if (result.run_id) {
+                    window.location.href = `/projects/${encodeURIComponent(projectId)}/runs/${encodeURIComponent(result.run_id)}`;
+                }
+            } catch (err) {
+                setError(err instanceof Error ? err.message : "重启失败");
+            }
+        }
 
-    // Backend returns runs in insertion (chronological) order, so ``runs[0]``
-    // is the OLDEST run. Sort by started_at descending and pick the newest
-    // as the "latest run" target for the auto-redirect. Without this,
-    // clicking a project card could bounce the user to a run from days ago
-    // (e.g. an old failed dispatch) instead of whatever was just started.
-    function pickLatestRun(list) {
-      if (!list || list.length === 0) return null;
-      return [...list].sort((a, b) => {
-        const ta = Date.parse(a && a.started_at) || 0;
-        const tb = Date.parse(b && b.started_at) || 0;
-        return tb - ta;
-      })[0];
-    }
+        const [view, setView] = window.React.useState("default");
 
-    // Auto-redirect to latest run if available
-    window.React.useEffect(() => {
-      const latestRun = pickLatestRun(runs);
-      if (latestRun && latestRun.run_id) {
-        window.location.href = `/projects/${encodeURIComponent(projectId)}/runs/${encodeURIComponent(latestRun.run_id)}`;
-      }
-    }, []); // only on initial load
+        // Backend returns runs in insertion (chronological) order, so ``runs[0]``
+        // is the OLDEST run. Sort by started_at descending and pick the newest
+        // as the "latest run" target for the shortcut button. Used to be the
+        // target of an auto-redirect, but auto-redirect hid the 新增需求
+        // entry for any project with a prior run — incremental-requirement
+        // mode exists precisely for that case, so the entry must stay
+        // reachable.
+        function pickLatestRun(list) {
+            if (!list || list.length === 0) return null;
+            return [...list].sort((a, b) => {
+                const ta = Date.parse(a && a.started_at) || 0;
+                const tb = Date.parse(b && b.started_at) || 0;
+                return tb - ta;
+            })[0];
+        }
 
-    // If redirecting, show loading
-    if (runs.length > 0 && view === "default") {
-      return h(
-        "div",
-        { className: "project-layout" },
-        h(
-          "section",
-          { className: "card card-glow project-header-card" },
-          h("h1", null, project.info.project_name),
-          h("p", { className: "muted" }, "正在跳转到最新执行记录...")
-        )
-      );
-    }
-
-    return h(
-      "div",
-      { className: "project-layout" },
-      h(
-        "section",
-        { className: "card card-glow project-header-card" },
-        h("h1", null, project.info.project_name),
-        h("p", { className: "muted" }, `ID: ${project.info.project_id} | 状态: ${project.info.status} | 模式: ${project.info.development_mode}`),
-        h("div", { style: { display: "flex", gap: "8px", marginTop: "8px" } },
-          h(
-            "button",
-            {
-              type: "button",
-              className: "btn secondary",
-              disabled: projectMissing,
-              onClick: restartCurrentProject,
-            },
-            "\u21BB \u91CD\u65B0\u5F00\u59CB"
-          ),
-          h(
-            "button",
-            {
-              type: "button",
-              className: "btn danger",
-              disabled: deleting || projectMissing,
-              onClick: deleteCurrentProject,
-            },
-            deleting ? "\u5220\u9664\u4E2D..." : "\u5220\u9664\u9879\u76EE"
-          ),
-        )
-      ),
-      projectMissing
-        ? h(
-            "section",
-            { className: "card" },
-            h("p", { className: "warning" }, "当前项目已不存在，已停止轮询。"),
-            h("a", { className: "btn secondary", href: "/" }, "返回项目列表")
-          )
-        : null,
-      view === "default" ? h(
-        "section",
-        { className: "card", style: { display: "flex", gap: "16px", justifyContent: "center", padding: "32px" } },
-        h(
-          "button",
-          {
-            type: "button",
-            className: "btn",
-            style: { fontSize: "1.1rem", padding: "12px 32px" },
-            disabled: projectMissing,
-            onClick: () => setView("new-requirement"),
-          },
-          "＋ 新增需求"
-        ),
-        h(
-          "button",
-          {
-            type: "button",
-            className: "btn secondary",
-            style: { fontSize: "1.1rem", padding: "12px 32px" },
-            onClick: () => setView("history"),
-          },
-          "📋 查看历史需求"
-        )
-      ) : null,
-      view === "new-requirement" ? h(
-        "section",
-        { className: "card" },
-        h("div", { style: { display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "12px" } },
-          h("h2", null, "下发新需求"),
-          h("button", { type: "button", className: "btn secondary", onClick: () => setView("default") }, "← 返回")
-        ),
-        h(
-          "form",
-          { className: "stack", onSubmit: submitRequirement },
-          h("label", null, "需求内容"),
-          h("textarea", {
-            required: true,
-            rows: 6,
-            placeholder: "输入新需求",
-            value: text,
-            disabled: projectMissing,
-            onChange: (e) => setText(e.target.value),
-          }),
-          error ? h("p", { className: "warning" }, error) : null,
-          h(
-            "button",
-            { className: "btn", type: "submit", disabled: submitting || projectMissing },
-            submitting ? "提交中..." : "提交并运行工作流"
-          )
-        )
-      ) : null,
-      view === "history" ? h(
-        "div",
-        null,
-        h(
-          "section",
-          { className: "card" },
-          h("div", { style: { display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "12px" } },
-            h("h2", null, "历史需求与执行记录"),
-            h("button", { type: "button", className: "btn secondary", onClick: () => setView("default") }, "← 返回")
-          ),
-          h("h3", null, "需求列表"),
-          h(
-            "ul",
-            { className: "history-list" },
-            ...(requirements.length
-              ? requirements.map((req, idx) => h("li", { key: `${req.created_at}-${idx}` }, `${formatLocalTime(req.created_at)} - ${req.text}`))
-              : [h("li", { key: "empty", className: "muted" }, "暂无需求历史。")])
-          ),
-          h("h3", { style: { marginTop: "24px" } }, "工作流执行记录"),
-          h(
+        return h(
             "div",
-            { className: "table-scroll" },
+            { className: "project-layout" },
             h(
-              "table",
-              null,
-              h(
-                "thead",
+                "section",
+                { className: "card card-glow project-header-card" },
+                h("h1", null, project.info.project_name),
+                h("p", { className: "muted" }, `ID: ${project.info.project_id} | 状态: ${project.info.status} | 模式: ${project.info.development_mode}`),
+                h("div", { style: { display: "flex", gap: "8px", marginTop: "8px" } },
+                    h(
+                        "button",
+                        {
+                            type: "button",
+                            className: "btn secondary",
+                            disabled: projectMissing,
+                            onClick: restartCurrentProject,
+                        },
+                        "\u21BB \u91CD\u65B0\u5F00\u59CB"
+                    ),
+                    h(
+                        "button",
+                        {
+                            type: "button",
+                            className: "btn danger",
+                            disabled: deleting || projectMissing,
+                            onClick: deleteCurrentProject,
+                        },
+                        deleting ? "\u5220\u9664\u4E2D..." : "\u5220\u9664\u9879\u76EE"
+                    ),
+                )
+            ),
+            projectMissing
+                ? h(
+                    "section",
+                    { className: "card" },
+                    h("p", { className: "warning" }, "当前项目已不存在，已停止轮询。"),
+                    h("a", { className: "btn secondary", href: "/" }, "返回项目列表")
+                )
+                : null,
+            view === "default" ? (function () {
+                const latestRun = pickLatestRun(runs);
+                const hasIncrementalBaseline = runs.some(function (r) {
+                    return r && r.status === "completed" && (r.result || "").toString().trim();
+                });
+                return h(
+                    "section",
+                    { className: "card", style: { display: "flex", gap: "16px", justifyContent: "center", padding: "32px", flexWrap: "wrap" } },
+                    h(
+                        "button",
+                        {
+                            type: "button",
+                            className: "btn",
+                            style: { fontSize: "1.1rem", padding: "12px 32px" },
+                            disabled: projectMissing,
+                            onClick: () => setView("new-requirement"),
+                            title: hasIncrementalBaseline
+                                ? "基于已有基线追加需求（增量模式）"
+                                : "下发首个需求（初始模式）",
+                        },
+                        hasIncrementalBaseline ? "＋ 新增增量需求" : "＋ 下发需求"
+                    ),
+                    h(
+                        "button",
+                        {
+                            type: "button",
+                            className: "btn secondary",
+                            style: { fontSize: "1.1rem", padding: "12px 32px" },
+                            onClick: () => setView("history"),
+                        },
+                        "📋 查看历史需求"
+                    ),
+                    latestRun && latestRun.run_id ? h(
+                        "a",
+                        {
+                            className: "btn secondary",
+                            style: { fontSize: "1.1rem", padding: "12px 32px" },
+                            href: `/projects/${encodeURIComponent(projectId)}/runs/${encodeURIComponent(latestRun.run_id)}`,
+                        },
+                        "🕒 查看最新执行"
+                    ) : null,
+                );
+            })() : null,
+            view === "new-requirement" ? h(
+                "section",
+                { className: "card" },
+                h("div", { style: { display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "12px" } },
+                    h("h2", null, "下发新需求"),
+                    h("button", { type: "button", className: "btn secondary", onClick: () => setView("default") }, "← 返回")
+                ),
+                h(
+                    "form",
+                    { className: "stack", onSubmit: submitRequirement },
+                    h("label", null, "需求内容"),
+                    h("textarea", {
+                        required: true,
+                        rows: 6,
+                        placeholder: "输入新需求",
+                        value: text,
+                        disabled: projectMissing,
+                        onChange: (e) => setText(e.target.value),
+                    }),
+                    error ? h("p", { className: "warning" }, error) : null,
+                    h(
+                        "button",
+                        { className: "btn", type: "submit", disabled: submitting || projectMissing },
+                        submitting ? "提交中..." : "提交并运行工作流"
+                    )
+                )
+            ) : null,
+            view === "history" ? h(
+                "div",
                 null,
                 h(
-                  "tr",
-                  null,
-                  h("th", null, "执行ID"),
-                  h("th", null, "时间"),
-                  h("th", null, "状态"),
-                  h("th", null, "需求摘要"),
-                  h("th", null, "查看")
-                )
-              ),
-              h(
-                "tbody",
-                null,
-                ...(runs.length
-                  ? runs.map((run) =>
-                      h(
-                        "tr",
-                        { key: run.run_id },
-                        h("td", null, run.run_id),
-                        h("td", null, formatLocalTime(run.started_at)),
-                        h("td", null, run.status || "pending"),
-                        h("td", null, String(run.requirement_text || "").slice(0, 80)),
+                    "section",
+                    { className: "card" },
+                    h("div", { style: { display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "12px" } },
+                        h("h2", null, "历史需求与执行记录"),
+                        h("button", { type: "button", className: "btn secondary", onClick: () => setView("default") }, "← 返回")
+                    ),
+                    h("h3", null, "需求列表"),
+                    h(
+                        "ul",
+                        { className: "history-list" },
+                        ...(requirements.length
+                            ? requirements.map((req, idx) => h("li", { key: `${req.created_at}-${idx}` }, `${formatLocalTime(req.created_at)} - ${req.text}`))
+                            : [h("li", { key: "empty", className: "muted" }, "暂无需求历史。")])
+                    ),
+                    h("h3", { style: { marginTop: "24px" } }, "工作流执行记录"),
+                    h(
+                        "div",
+                        { className: "table-scroll" },
                         h(
-                          "td",
-                          null,
-                          h(
-                            "a",
-                            {
-                              href: `/projects/${encodeURIComponent(projectId)}/runs/${encodeURIComponent(run.run_id)}`,
-                            },
-                            "详情"
-                          )
+                            "table",
+                            null,
+                            h(
+                                "thead",
+                                null,
+                                h(
+                                    "tr",
+                                    null,
+                                    h("th", null, "执行ID"),
+                                    h("th", null, "时间"),
+                                    h("th", null, "状态"),
+                                    h("th", null, "需求摘要"),
+                                    h("th", null, "查看")
+                                )
+                            ),
+                            h(
+                                "tbody",
+                                null,
+                                ...(runs.length
+                                    ? runs.map((run) =>
+                                        h(
+                                            "tr",
+                                            { key: run.run_id },
+                                            h("td", null, run.run_id),
+                                            h("td", null, formatLocalTime(run.started_at)),
+                                            h("td", null, run.status || "pending"),
+                                            h("td", null, String(run.requirement_text || "").slice(0, 80)),
+                                            h(
+                                                "td",
+                                                null,
+                                                h(
+                                                    "a",
+                                                    {
+                                                        href: `/projects/${encodeURIComponent(projectId)}/runs/${encodeURIComponent(run.run_id)}`,
+                                                    },
+                                                    "详情"
+                                                )
+                                            )
+                                        )
+                                    )
+                                    : [h("tr", { key: "empty" }, h("td", { colSpan: 5, className: "muted" }, "暂无执行记录。"))])
+                            )
                         )
-                      )
                     )
-                  : [h("tr", { key: "empty" }, h("td", { colSpan: 5, className: "muted" }, "暂无执行记录。"))])
-              )
-            )
-          )
-        )
-      ) : null
-    );
-  }
+                )
+            ) : null
+        );
+    }
 
-  mountReact("project-react-root", () => window.React.createElement(ProjectApp));
+    mountReact("project-react-root", () => window.React.createElement(ProjectApp));
 }
 
 function setupRunReact() {
-  const initial = readScriptJson("run-initial-data", { project: null, run: null });
-  if (!initial.project || !initial.run) return;
+    const initial = readScriptJson("run-initial-data", { project: null, run: null });
+    if (!initial.project || !initial.run) return;
 
-  // Stage names live in the ``stage.<id>`` namespace of the i18next
-  // resource files under ``static/locales/<lng>/translation.json``.
-  // Phase names are free-form strings the PM picks at dispatch
-  // time, so this resolver has to handle three cases:
-  //
-  //   1. Exact match on the full stage id  (``architecture`` → 架构设计)
-  //   2. Known suffix patterns that carry a numeric counter —
-  //      ``implementation_layer1`` / ``implementation_cycle_3`` /
-  //      ``design_part_2`` etc. Strip the suffix, translate the base,
-  //      append ``#N``.
-  //   3. Unknown stage id: humanize it (``impl_config_loader`` →
-  //      ``Impl Config Loader``) so the user never sees a raw
-  //      snake_case identifier among Chinese labels.
-  //
-  // Missing-key detection uses i18next's built-in ``exists`` so we
-  // don't depend on any string-equality trick between the probe key
-  // and the return value.
-  function humanizeStageId(stage) {
-    return String(stage)
-      .split(/[_-]+/)
-      .filter(function (w) { return w.length > 0; })
-      .map(function (w) {
-        return w.charAt(0).toUpperCase() + w.slice(1);
-      })
-      .join(" ");
-  }
-
-  // Trailing counter suffix: ``_layer1`` / ``_layer_1`` / ``_cycle2`` /
-  // ``_part_3`` / ``_iter4`` / ``_round_5`` / ``_v2``. Captures base +
-  // numeric N.
-  var STAGE_SUFFIX_RE = /^(.+?)_(?:layer|cycle|part|iter|iteration|round|stage|v|step)_?(\d+)$/;
-
-  function stageKeyExists(stageId) {
-    var key = "stage." + stageId;
-    if (window.i18next && window.i18next.isInitialized) {
-      return window.i18next.exists(key);
-    }
-    return false;
-  }
-
-  // Normalize a raw stage id down to its canonical "phase" id by
-  // stripping the counter suffix. ``implementation_layer1`` and
-  // ``implementation_layer2`` both normalize to ``implementation`` so
-  // the chip strip shows a single "开发实现 / Implementation" chip
-  // instead of one chip per layer. The expanded log entries still
-  // show the raw ``ev.stage`` value (``implementation_layer1``) so
-  // per-layer progress is not lost.
-  function normalizeStageId(stage) {
-    if (!stage) return stage;
-    var m = String(stage).match(STAGE_SUFFIX_RE);
-    return m ? m[1] : stage;
-  }
-
-  function resolveStageLabel(stage) {
-    if (!stage) return stage;
-
-    if (stageKeyExists(stage)) return t("stage." + stage);
-
-    var suffix = stage.match(STAGE_SUFFIX_RE);
-    if (suffix) {
-      var base = stageKeyExists(suffix[1])
-        ? t("stage." + suffix[1])
-        : humanizeStageId(suffix[1]);
-      return base + " #" + suffix[2];
-    }
-
-    return humanizeStageId(stage);
-  }
-
-  // Chip-strip label: always uses the NORMALIZED stage id so
-  // ``implementation_layer2`` renders as just "Implementation" without
-  // a "#2" suffix. This keeps the phase progression readable when a
-  // phase has many sub-layers.
-  function resolveChipLabel(stage) {
-    if (!stage) return stage;
-    var normalized = normalizeStageId(stage);
-    if (stageKeyExists(normalized)) return t("stage." + normalized);
-    return humanizeStageId(normalized);
-  }
-
-  const EVENT_ICONS = {
-    stage_update: "▶",
-    tool_call: "⚙",
-    task_request: "→",
-    task_response: "←",
-    parallel_start: "≡",
-  };
-
-  // Todo status labels resolve via ``t()`` — see ``todo.status.*`` keys
-  // in the i18next locale resource files.
-  function todoStatusLabel(status) {
-    var key = "todo.status." + status;
-    var translated = t(key);
-    return translated === key ? status : translated;
-  }
-
-  function TaskTodoProgress({ todos }) {
-    const h = window.React.createElement;
-    if (!Array.isArray(todos) || todos.length === 0) return null;
-    var total = todos.length;
-    var done = todos.filter((t) => t && t.status === "completed").length;
-    return h("div", { className: "run-log-todos" },
-      h("div", { className: "run-log-todos-header" },
-        h("span", { className: "run-log-todos-title" }, t("todo.title")),
-        h("span", { className: "run-log-todos-progress" }, done + " / " + total),
-      ),
-      h("ol", { className: "run-log-todos-list" },
-        todos.map((t, i) => {
-          var status = (t && t.status) || "pending";
-          var label = (t && (t.activeForm && status === "in_progress" ? t.activeForm : t.content)) || "";
-          var marker = status === "completed" ? "✓" : status === "in_progress" ? "●" : "○";
-          return h("li", { key: i, className: "run-log-todo-item run-log-todo-" + status },
-            h("span", { className: "run-log-todo-marker" }, marker),
-            h("span", { className: "run-log-todo-text" }, label),
-            h("span", { className: "run-log-todo-status" }, todoStatusLabel(status)),
-          );
-        }),
-      ),
-    );
-  }
-
-  function RunApp() {
-    const h = window.React.createElement;
-    const project = initial.project;
-    const [run, setRun] = window.React.useState(initial.run);
-    const [stageFilter, setStageFilter] = window.React.useState(null);
-    const [runView, setRunView] = window.React.useState("timeline");
-    const runStatus = String(run.status || "pending");
-    const isRunning = runStatus === "pending" || runStatus === "running";
-    const taskLog = Array.isArray(run.task_log) ? run.task_log : [];
-
-    window.React.useEffect(() => {
-      if (!isRunning) return;
-      let active = true;
-      const poll = () => {
-        fetchJson("/api/projects/" + encodeURIComponent(project.info.project_id) + "/runs/" + encodeURIComponent(run.run_id))
-          .then((d) => { if (active) setRun(d); })
-          .catch(() => {});
-      };
-      const tid = setInterval(poll, 2000);
-      return () => { active = false; clearInterval(tid); };
-    }, [project.info.project_id, run.run_id, isRunning]);
-
-    // Derive stages and tag each event with its stage.
+    // Stage names live in the ``stage.<id>`` namespace of the i18next
+    // resource files under ``static/locales/<lng>/translation.json``.
+    // Phase names are free-form strings the PM picks at dispatch
+    // time, so this resolver has to handle three cases:
     //
-    // We track TWO things per event: the raw ``ev.stage`` (used in the
-    // expanded log entry so the per-layer detail stays visible) and
-    // the NORMALIZED stage id (e.g. ``implementation`` for
-    // ``implementation_layer1``). The chip strip only shows normalized
-    // ids, deduped, so multi-layer phases render as one chip.
-    const stages = [];
-    const normalizedSeen = new Set();
-    let curRawStage = null;
-    let curNormalizedStage = null;
-    const evStagesRaw = [];
-    const evStagesNormalized = [];
-    for (let i = 0; i < taskLog.length; i++) {
-      const ev = taskLog[i];
-      if (ev.type === "stage_update" && ev.stage) {
-        curRawStage = ev.stage;
-        curNormalizedStage = normalizeStageId(ev.stage);
-        if (!normalizedSeen.has(curNormalizedStage)) {
-          normalizedSeen.add(curNormalizedStage);
-          stages.push(curNormalizedStage);
+    //   1. Exact match on the full stage id  (``architecture`` → 架构设计)
+    //   2. Known suffix patterns that carry a numeric counter —
+    //      ``implementation_layer1`` / ``implementation_cycle_3`` /
+    //      ``design_part_2`` etc. Strip the suffix, translate the base,
+    //      append ``#N``.
+    //   3. Unknown stage id: humanize it (``impl_config_loader`` →
+    //      ``Impl Config Loader``) so the user never sees a raw
+    //      snake_case identifier among Chinese labels.
+    //
+    // Missing-key detection uses i18next's built-in ``exists`` so we
+    // don't depend on any string-equality trick between the probe key
+    // and the return value.
+    function humanizeStageId(stage) {
+        return String(stage)
+            .split(/[_-]+/)
+            .filter(function (w) { return w.length > 0; })
+            .map(function (w) {
+                return w.charAt(0).toUpperCase() + w.slice(1);
+            })
+            .join(" ");
+    }
+
+    // Trailing counter suffix: ``_layer1`` / ``_layer_1`` / ``_cycle2`` /
+    // ``_part_3`` / ``_iter4`` / ``_round_5`` / ``_v2``. Captures base +
+    // numeric N.
+    var STAGE_SUFFIX_RE = /^(.+?)_(?:layer|cycle|part|iter|iteration|round|stage|v|step)_?(\d+)$/;
+
+    function stageKeyExists(stageId) {
+        var key = "stage." + stageId;
+        if (window.i18next && window.i18next.isInitialized) {
+            return window.i18next.exists(key);
         }
-      }
-      evStagesRaw.push(curRawStage);
-      evStagesNormalized.push(curNormalizedStage);
-    }
-    const requests = taskLog.filter((e) => e.type === "task_request");
-    const responses = taskLog.filter((e) => e.type === "task_response");
-    const completed = responses.filter((e) => e.status === "completed").length;
-    const failed = responses.filter((e) => e.status === "failed").length;
-
-    // Build taskId → latest todos list. Each todos_update event carries
-    // the full todo list at the time the agent invoked write_todos, so
-    // the newest entry wins.
-    // Agents often call write_todos once at the start to plan and then
-    // never revisit it, so a task_response(completed) retroactively marks
-    // every remaining todo as done. Failed tasks keep their last snapshot
-    // so the user can see where the agent was when it died.
-    // Tasks that never called write_todos at all (common for small
-    // TDD modules) get a synthetic single-item list derived from the
-    // task's terminal status so the card still shows a progress cue.
-    const taskTodos = {};
-    const taskTerminalStatus = {};
-    const seenTaskIds = new Set();
-    const taskRequestPayload = {};
-    for (let i = 0; i < taskLog.length; i++) {
-      const ev = taskLog[i];
-      if (!ev || !ev.taskId) continue;
-      if (ev.type === "task_request") {
-        seenTaskIds.add(ev.taskId);
-        taskRequestPayload[ev.taskId] = ev.payload || {};
-      } else if (ev.type === "todos_update" && Array.isArray(ev.todos)) {
-        taskTodos[ev.taskId] = ev.todos;
-      } else if (ev.type === "task_response") {
-        seenTaskIds.add(ev.taskId);
-        taskTerminalStatus[ev.taskId] = ev.status;
-      }
-    }
-    for (const tid of Object.keys(taskTerminalStatus)) {
-      if (taskTerminalStatus[tid] !== "completed") continue;
-      const list = taskTodos[tid];
-      if (!Array.isArray(list)) continue;
-      taskTodos[tid] = list.map((t) => (t && t.status !== "completed")
-        ? Object.assign({}, t, { status: "completed" })
-        : t);
-    }
-    // Synthetic fallback: if a task has no todos_update at all, build a
-    // single-row list from its current state (in-progress / completed /
-    // failed). Keeps every task card visually uniform instead of some
-    // showing todos and some showing nothing.
-    for (const tid of seenTaskIds) {
-      if (Array.isArray(taskTodos[tid])) continue;
-      const term = taskTerminalStatus[tid];
-      const payload = taskRequestPayload[tid] || {};
-      const label = payload.step || (payload.task ? String(payload.task).split("\n")[0].slice(0, 60) : "任务");
-      let status = "in_progress";
-      if (term === "completed") status = "completed";
-      else if (term === "failed") status = "pending";
-      taskTodos[tid] = [{
-        content: label,
-        activeForm: label,
-        status: status,
-        synthetic: true,
-      }];
-    }
-    // Each completed task used to produce TWO rows in the log (a
-    // task_request and a task_response). Merge them: render only the
-    // task_request; its card shows the response's status/output in the
-    // expanded details. Map taskId → response event here.
-    const taskResponseByTaskId = {};
-    for (let i = 0; i < taskLog.length; i++) {
-      const ev = taskLog[i];
-      if (ev && ev.type === "task_response" && ev.taskId) {
-        taskResponseByTaskId[ev.taskId] = ev;
-      }
-    }
-    // Hide raw todos_update rows (render inline under their task_request)
-    // and task_response rows (merged into their request).
-    const visibleLog = taskLog.filter(
-      (e) => e.type !== "todos_update" && e.type !== "task_response",
-    );
-    // Filter predicate uses the NORMALIZED stage so a single
-    // ``implementation`` chip matches every ``implementation_layer*``
-    // event, not just the one raw id the user clicked.
-    const visibleStages = taskLog
-      .map((_, i) => evStagesNormalized[i])
-      .filter(
-        (_, i) =>
-          taskLog[i].type !== "todos_update" &&
-          taskLog[i].type !== "task_response",
-      );
-    const filteredLog = stageFilter
-      ? visibleLog.filter((_, i) => visibleStages[i] === stageFilter)
-      : visibleLog;
-
-    const statusCls = runStatus === "completed" ? "run-status-completed"
-      : runStatus === "failed" ? "run-status-failed"
-      : runStatus === "running" ? "run-status-running" : "run-status-pending";
-    const toggleStage = (s) => setStageFilter((prev) => prev === s ? null : s);
-
-    return h("div", { className: "run-container" },
-      h("div", { className: "run-header" },
-        h("div", { className: "run-header-left" },
-          h("a", { className: "run-back-link", href: "/projects/" + project.info.project_id }, "\u2190 " + (project.info.name || t("run.back.project_fallback"))),
-          h("h1", { className: "run-title" }, t("run.title")),
-          h("span", { className: "run-id-label" }, run.run_id),
-        ),
-        h("span", { className: "run-status-badge " + statusCls },
-          isRunning ? h("span", { className: "monitor-task-pulse" }) : null,
-          runStatus === "completed" ? t("run.status.completed")
-            : runStatus === "failed" ? t("run.status.failed")
-            : runStatus === "running" ? t("run.status.running")
-            : t("run.status.pending"),
-        ),
-        run.mode === "incremental" ? h("span", {
-          className: "run-mode-badge run-mode-badge-incremental",
-          title: t("run.mode.incremental_hint"),
-        }, t("run.mode.incremental")) : null,
-        (run.process_type === "agile") ? h("span", {
-          className: "run-mode-badge run-mode-badge-agile",
-          title: currentLang() === "en"
-            ? "Agile Sprint process: Planning → Execution → Review → Retrospective → Delivery"
-            : "Agile Sprint 流程：规划 → 执行 → 评审 → 复盘 → 交付",
-        }, currentLang() === "en" ? "Agile Sprint" : "Agile 迭代") :
-        h("span", {
-          className: "run-mode-badge run-mode-badge-waterfall",
-          title: currentLang() === "en"
-            ? "Waterfall process: Requirements → Architecture → Implementation → Entry → QA → Delivery"
-            : "Waterfall 流程：需求 → 架构 → 实现 → 入口 → 测试 → 交付",
-        }, currentLang() === "en" ? "Waterfall" : "Waterfall 瀑布"),
-      ),
-      h("div", { className: "run-section" },
-        h("div", { className: "run-section-title" }, t("run.section.requirement")),
-        h("div", { className: "run-requirement-text" }, run.requirement_text || ""),
-      ),
-      h("div", { className: "run-stats" },
-        h("div", { className: "run-stat" }, h("span", { className: "run-stat-value" }, stages.length), h("span", { className: "run-stat-label" }, t("run.stat.stages"))),
-        h("div", { className: "run-stat" }, h("span", { className: "run-stat-value" }, requests.length), h("span", { className: "run-stat-label" }, t("run.stat.dispatches"))),
-        h("div", { className: "run-stat" }, h("span", { className: "run-stat-value" }, completed), h("span", { className: "run-stat-label" }, t("run.stat.completed"))),
-        failed > 0 ? h("div", { className: "run-stat run-stat-error" }, h("span", { className: "run-stat-value" }, failed), h("span", { className: "run-stat-label" }, t("run.stat.failed"))) : null,
-      ),
-      // View switcher: "timeline" = current stage-progress + A2A log;
-      // "agents" = the agent-interaction graph. Persists only for the
-      // life of the component (simple UI preference, not a deep link).
-      h("div", { className: "run-view-tabs", role: "tablist" },
-        ["timeline", "agents"].map((key) => h(
-          "button",
-          {
-            key: key,
-            type: "button",
-            role: "tab",
-            "aria-selected": runView === key ? "true" : "false",
-            className: "run-view-tab" + (runView === key ? " run-view-tab-active" : ""),
-            onClick: function () { setRunView(key); },
-          },
-          t("run.view." + key),
-        )),
-      ),
-      runView === "agents" ? h(AgentInteractionView, {
-        taskLog: taskLog,
-        orchestratorName: (project.info || {}).orchestrator_name || null,
-        taskResponseByTaskId: taskResponseByTaskId,
-        isRunning: isRunning,
-      }) : null,
-      runView === "timeline" && stages.length > 0 ? h("div", { className: "run-section" },
-        h("div", { className: "run-section-title" }, t("run.section.stage_progress") + (stageFilter ? t("run.section.stage_progress_filter_hint") : "")),
-        h("div", { className: "run-stages-flow" },
-          stages.map((s, i) => {
-            var lastStageIdx = stages.length - 1;
-            var isDone = isRunning ? i < lastStageIdx : true;
-            var isCurrent = isRunning && i === lastStageIdx;
-            var cls = "run-stage-chip run-stage-clickable"
-              + (stageFilter === s ? " run-stage-selected" : "")
-              + (isDone && !isCurrent ? " run-stage-done" : "")
-              + (isCurrent ? " run-stage-active" : "");
-            return h(window.React.Fragment, { key: s },
-              i > 0 ? h("span", { className: "run-stage-arrow" + (isDone ? " run-stage-arrow-done" : "") }, "\u2192") : null,
-              h("span", { className: cls, onClick: function() { toggleStage(s); } }, resolveChipLabel(s) || s),
-            );
-          }),
-        ),
-      ) : null,
-      runView === "timeline" ? h("div", { className: "run-section" },
-        h("div", { className: "run-section-title" }, t("run.section.log_title") + " (" + filteredLog.length + (stageFilter ? " / " + taskLog.length : "") + ")"),
-        filteredLog.length === 0
-          ? h("div", { className: "run-log-empty" }, isRunning ? t("run.log.waiting") : t("run.log.empty"))
-          : h("div", { className: "run-task-log" }, filteredLog.map((ev, idx) => h(RunLogEntry, {
-              key: idx,
-              event: ev,
-              taskTodos: taskTodos,
-              taskResponse: ev.taskId ? taskResponseByTaskId[ev.taskId] : null,
-            }))),
-      ) : null,
-      // The delivery report (``run.result``) is produced by Phase 6 /
-      // the ``delivery`` stage. It's noisy to show on every view of the
-      // run detail page, so scope it: only render when the user has
-      // actively filtered the log to the delivery stage (by clicking
-      // the delivery chip). When no filter is applied or a different
-      // stage is selected, the report is hidden and the rest of the
-      // A2A log takes the space.
-      run.result && stageFilter && /deliver/i.test(stageFilter)
-        ? h("div", { className: "run-section" },
-            h("div", { className: "run-section-title" }, t("run.section.delivery_report")),
-            h("pre", { className: "run-result-text" }, run.result),
-          )
-        : null,
-      run.error ? h("div", { className: "run-section run-error-section" },
-        h("div", { className: "run-section-title" }, t("run.section.error")),
-        h("pre", { className: "run-error-text" }, run.error),
-      ) : null,
-    );
-  }
-
-  // ------------------------------------------------------------------
-  // Agent interaction view
-  // ------------------------------------------------------------------
-  //
-  // Parses the run's ``task_log`` into three structures:
-  //
-  //   agents     — one card per participating agent (orchestrator on
-  //                the top row, workers in a grid below). Each agent
-  //                carries its running-task count, completed / failed
-  //                totals, and its recent task list.
-  //   edges      — ``(from → to)`` pairs with a count of dispatches.
-  //                Rendered as SVG arrows laid over the grid with a
-  //                small count badge.
-  //   taskById   — ``taskId`` → {agent, label, status, goal, startedAt}
-  //                used to populate the task list under each worker.
-  //
-  // All computation is derived from ``task_request`` / ``task_response``
-  // events that the runtime already emits — no new backend data needed.
-  function computeAgentGraph(taskLog, orchestratorName, taskResponseByTaskId) {
-    var orchestrator = orchestratorName || "orchestrator";
-    var workerSet = new Set();
-    var edges = new Map(); // key "fromto" -> count
-    var tasksByAgent = new Map();
-    var allTasks = [];
-
-    function bumpEdge(from, to) {
-      var k = from + "" + to;
-      edges.set(k, (edges.get(k) || 0) + 1);
+        return false;
     }
 
-    for (var i = 0; i < taskLog.length; i++) {
-      var ev = taskLog[i];
-      if (!ev) continue;
-      if (ev.type === "task_request" && ev.to) {
-        workerSet.add(ev.to);
-        bumpEdge(orchestrator, ev.to);
-        var payload = ev.payload || {};
-        var response = ev.taskId ? taskResponseByTaskId[ev.taskId] : null;
-        var respPayload = (response && response.payload) || {};
-        var goal = payload.step
-          || (payload.task ? String(payload.task).split("\n")[0].slice(0, 80) : "")
-          || t("entry.fallback_task_name");
-        var status = response ? (response.status || "completed") : "running";
-        var outputLen = response ? (respPayload.output_length || 0) : 0;
-        var task = {
-          taskId: ev.taskId || null,
-          agent: ev.to,
-          goal: goal,
-          phase: payload.phase || "",
-          status: status,
-          startedAt: ev.timestamp || "",
-          completedAt: response ? (response.timestamp || "") : "",
-          outputLen: outputLen,
-        };
-        if (!tasksByAgent.has(ev.to)) tasksByAgent.set(ev.to, []);
-        tasksByAgent.get(ev.to).push(task);
-        allTasks.push(task);
-      }
+    // Normalize a raw stage id down to its canonical "phase" id by
+    // stripping the counter suffix. ``implementation_layer1`` and
+    // ``implementation_layer2`` both normalize to ``implementation`` so
+    // the chip strip shows a single "开发实现 / Implementation" chip
+    // instead of one chip per layer. The expanded log entries still
+    // show the raw ``ev.stage`` value (``implementation_layer1``) so
+    // per-layer progress is not lost.
+    function normalizeStageId(stage) {
+        if (!stage) return stage;
+        var m = String(stage).match(STAGE_SUFFIX_RE);
+        return m ? m[1] : stage;
     }
 
-    // Agents array: orchestrator first, then workers in declaration
-    // order (which matches dispatch order — a readable flow).
-    var workers = Array.from(workerSet);
-    var agents = [{ name: orchestrator, role: "orchestrator" }];
-    workers.forEach(function (n) { agents.push({ name: n, role: "worker" }); });
+    function resolveStageLabel(stage) {
+        if (!stage) return stage;
 
-    // Edges as a simple array.
-    var edgeArr = [];
-    edges.forEach(function (count, key) {
-      var parts = key.split("");
-      edgeArr.push({ from: parts[0], to: parts[1], count: count });
-    });
+        if (stageKeyExists(stage)) return t("stage." + stage);
 
-    // Per-agent status summary.
-    agents.forEach(function (a) {
-      var tasks = tasksByAgent.get(a.name) || [];
-      a.tasks = tasks;
-      a.runningCount = tasks.filter(function (t) { return t.status === "running"; }).length;
-      a.completedCount = tasks.filter(function (t) { return t.status === "completed"; }).length;
-      a.failedCount = tasks.filter(function (t) { return t.status === "failed"; }).length;
-    });
-
-    return { agents: agents, edges: edgeArr, tasks: allTasks };
-  }
-
-  function AgentStatusBadge({ agent }) {
-    const h = window.React.createElement;
-    if (agent.runningCount > 0) {
-      return h("span", { className: "agent-card-status agent-card-status-working" },
-        h("span", { className: "monitor-task-pulse" }),
-        t("agents.status.working", { n: agent.runningCount }),
-      );
-    }
-    if (agent.completedCount + agent.failedCount === 0) {
-      return h("span", { className: "agent-card-status agent-card-status-idle" }, t("agents.status.idle"));
-    }
-    return h("span", { className: "agent-card-status agent-card-status-done" }, t("agents.status.done"));
-  }
-
-  function AgentCard({ agent }) {
-    const h = window.React.createElement;
-    // Cap the per-agent task list to the most recent 12 entries so a
-    // long-running project with dozens of dispatches per agent stays
-    // scannable. Older tasks can still be found via the timeline view.
-    var visibleTasks = agent.tasks.slice(-12).reverse();
-    return h("div", {
-      className: "agent-card agent-card-role-" + agent.role,
-      "data-agent-name": agent.name,
-    },
-      h("div", { className: "agent-card-header" },
-        h("span", { className: "agent-card-icon" }, agent.role === "orchestrator" ? "🎯" : "🤖"),
-        h("span", { className: "agent-card-name" }, agent.name),
-        h("span", { className: "agent-card-role-tag" }, t("agents.role." + agent.role)),
-      ),
-      h(AgentStatusBadge, { agent: agent }),
-      h("div", { className: "agent-card-stats" },
-        h("span", { title: t("agents.stat.running") }, "● " + agent.runningCount),
-        h("span", { title: t("agents.stat.completed") }, "✓ " + agent.completedCount),
-        agent.failedCount > 0
-          ? h("span", { className: "agent-card-stat-failed", title: t("agents.stat.failed") }, "✕ " + agent.failedCount)
-          : null,
-      ),
-      h("div", { className: "agent-card-tasks" },
-        h("div", { className: "agent-card-tasks-title" }, t("agents.tasks_heading")),
-        visibleTasks.length === 0
-          ? h("div", { className: "agent-card-tasks-empty" }, t("agents.no_tasks"))
-          : h("ul", { className: "agent-card-tasks-list" }, visibleTasks.map(function (task, idx) {
-              var statusClass = "agent-task-" + task.status;
-              return h("li", { className: "agent-card-task " + statusClass, key: task.taskId || idx },
-                h("span", { className: "agent-card-task-icon" },
-                  task.status === "running" ? "●" : task.status === "failed" ? "✕" : "✓",
-                ),
-                h("span", { className: "agent-card-task-goal", title: task.goal }, task.goal),
-              );
-            })),
-      ),
-    );
-  }
-
-  function AgentInteractionView({ taskLog, orchestratorName, taskResponseByTaskId, isRunning }) {
-    const h = window.React.createElement;
-    const React = window.React;
-    var graph = computeAgentGraph(taskLog, orchestratorName, taskResponseByTaskId);
-    var orchestrators = graph.agents.filter(function (a) { return a.role === "orchestrator"; });
-    var workers = graph.agents.filter(function (a) { return a.role === "worker"; });
-
-    // Per-worker interaction summary: dispatches + completed + failed
-    // counts, keyed by agent name. These numbers land verbatim on the
-    // connector label so the orchestrator → worker edge carries the
-    // per-pair interaction info, not a single aggregate.
-    var interactionByWorker = {};
-    workers.forEach(function (w) {
-      var tasks = w.tasks || [];
-      interactionByWorker[w.name] = {
-        dispatches: tasks.length,
-        completed: w.completedCount || 0,
-        failed: w.failedCount || 0,
-      };
-    });
-
-    // SVG connector geometry is measured from the DOM after render —
-    // one line per worker, anchored at the orchestrator card's
-    // bottom-center and terminating at the worker card's top-center.
-    // Re-measures when the task log grows, when a new worker joins,
-    // and on viewport resize.
-    const containerRef = React.useRef(null);
-    const [edges, setEdges] = React.useState([]);
-    React.useLayoutEffect(function () {
-      function measure() {
-        var container = containerRef.current;
-        if (!container) return;
-        var orchEl = container.querySelector(".agent-card-role-orchestrator");
-        var workerEls = Array.prototype.slice.call(
-          container.querySelectorAll(".agent-card-role-worker")
-        );
-        if (!orchEl || workerEls.length === 0) {
-          setEdges([]);
-          return;
+        var suffix = stage.match(STAGE_SUFFIX_RE);
+        if (suffix) {
+            var base = stageKeyExists(suffix[1])
+                ? t("stage." + suffix[1])
+                : humanizeStageId(suffix[1]);
+            return base + " #" + suffix[2];
         }
-        var cRect = container.getBoundingClientRect();
-        var oRect = orchEl.getBoundingClientRect();
-        var fromX = oRect.left + oRect.width / 2 - cRect.left;
-        var fromY = oRect.bottom - cRect.top;
-        var next = workerEls.map(function (el) {
-          var r = el.getBoundingClientRect();
-          var name = el.getAttribute("data-agent-name") || "";
-          var info = interactionByWorker[name] || { dispatches: 0, completed: 0, failed: 0 };
-          return {
-            name: name,
-            fromX: fromX,
-            fromY: fromY,
-            toX: r.left + r.width / 2 - cRect.left,
-            toY: r.top - cRect.top,
-            dispatches: info.dispatches,
-            completed: info.completed,
-            failed: info.failed,
-          };
-        });
-        setEdges(next);
-      }
-      measure();
-      window.addEventListener("resize", measure);
-      return function () { window.removeEventListener("resize", measure); };
-      // Depend on both length fields so new dispatches + new workers
-      // trigger a re-measure.
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [taskLog.length, workers.length]);
 
-    if (workers.length === 0) {
-      return h("div", { className: "run-section agent-graph-empty" },
-        h("div", { className: "run-log-empty" }, isRunning ? t("agents.waiting") : t("agents.no_participants")),
-      );
+        return humanizeStageId(stage);
     }
 
-    return h("div", { className: "run-section agent-graph-section" },
-      h("div", { className: "run-section-title" }, t("agents.section_title")),
-      h("div", { className: "agent-graph-container", ref: containerRef },
-        // SVG connector overlay: one ``<line>`` per worker + an
-        // HTML label block carried in a ``foreignObject`` at the
-        // midpoint. Sits behind the cards (z-index 0) and has
-        // pointer-events: none so the cards stay clickable. The
-        // ``aria-hidden`` reminds screen readers that the same
-        // numbers are already present on each agent card.
-        h("svg", {
-          className: "agent-graph-connectors",
-          "aria-hidden": "true",
-          xmlns: "http://www.w3.org/2000/svg",
-          preserveAspectRatio: "none",
-        },
-          h("defs", null,
-            h("marker", {
-              id: "agent-graph-arrow",
-              viewBox: "0 0 10 10",
-              refX: "9",
-              refY: "5",
-              markerWidth: "8",
-              markerHeight: "8",
-              orient: "auto-start-reverse",
-            },
-              h("path", { d: "M 0 0 L 10 5 L 0 10 Z", className: "agent-graph-arrow-head" }),
+    // Chip-strip label: always uses the NORMALIZED stage id so
+    // ``implementation_layer2`` renders as just "Implementation" without
+    // a "#2" suffix. This keeps the phase progression readable when a
+    // phase has many sub-layers.
+    function resolveChipLabel(stage) {
+        if (!stage) return stage;
+        var normalized = normalizeStageId(stage);
+        if (stageKeyExists(normalized)) return t("stage." + normalized);
+        return humanizeStageId(normalized);
+    }
+
+    const EVENT_ICONS = {
+        stage_update: "▶",
+        tool_call: "⚙",
+        task_request: "→",
+        task_response: "←",
+        parallel_start: "≡",
+    };
+
+    // Todo status labels resolve via ``t()`` — see ``todo.status.*`` keys
+    // in the i18next locale resource files.
+    function todoStatusLabel(status) {
+        var key = "todo.status." + status;
+        var translated = t(key);
+        return translated === key ? status : translated;
+    }
+
+    function TaskTodoProgress({ todos }) {
+        const h = window.React.createElement;
+        if (!Array.isArray(todos) || todos.length === 0) return null;
+        var total = todos.length;
+        var done = todos.filter((t) => t && t.status === "completed").length;
+        return h("div", { className: "run-log-todos" },
+            h("div", { className: "run-log-todos-header" },
+                h("span", { className: "run-log-todos-title" }, t("todo.title")),
+                h("span", { className: "run-log-todos-progress" }, done + " / " + total),
             ),
-          ),
-          edges.map(function (e) {
-            var midX = (e.fromX + e.toX) / 2;
-            var midY = (e.fromY + e.toY) / 2;
-            return h("g", { key: e.name, className: "agent-graph-connector-group" },
-              h("line", {
-                x1: e.fromX,
-                y1: e.fromY,
-                x2: e.toX,
-                y2: e.toY,
-                className: "agent-graph-connector-line",
-                "marker-end": "url(#agent-graph-arrow)",
-                "data-from": "orchestrator",
-                "data-to": e.name,
-              }),
-              h("foreignObject", {
-                x: midX - 80,
-                y: midY - 14,
-                width: 160,
-                height: 30,
-                className: "agent-graph-connector-fo",
-              },
-                h("div", { className: "agent-graph-connector-label", "data-to": e.name },
-                  h("span", { className: "agent-graph-connector-dispatches" }, t("agents.dispatches", { n: e.dispatches })),
-                  e.completed > 0 ? h("span", {
-                    className: "agent-graph-connector-chip agent-graph-connector-chip-completed",
-                    title: t("agents.stat.completed"),
-                  }, "✓ " + e.completed) : null,
-                  e.failed > 0 ? h("span", {
-                    className: "agent-graph-connector-chip agent-graph-connector-chip-failed",
-                    title: t("agents.stat.failed"),
-                  }, "✕ " + e.failed) : null,
-                ),
-              ),
+            h("ol", { className: "run-log-todos-list" },
+                todos.map((t, i) => {
+                    var status = (t && t.status) || "pending";
+                    var label = (t && (t.activeForm && status === "in_progress" ? t.activeForm : t.content)) || "";
+                    var marker = status === "completed" ? "✓" : status === "in_progress" ? "●" : "○";
+                    return h("li", { key: i, className: "run-log-todo-item run-log-todo-" + status },
+                        h("span", { className: "run-log-todo-marker" }, marker),
+                        h("span", { className: "run-log-todo-text" }, label),
+                        h("span", { className: "run-log-todo-status" }, todoStatusLabel(status)),
+                    );
+                }),
+            ),
+        );
+    }
+
+    function RunApp() {
+        const h = window.React.createElement;
+        const project = initial.project;
+        const [run, setRun] = window.React.useState(initial.run);
+        const [stageFilter, setStageFilter] = window.React.useState(null);
+        const [runView, setRunView] = window.React.useState("timeline");
+        const runStatus = String(run.status || "pending");
+        const isRunning = runStatus === "pending" || runStatus === "running";
+        const taskLog = Array.isArray(run.task_log) ? run.task_log : [];
+
+        window.React.useEffect(() => {
+            if (!isRunning) return;
+            let active = true;
+            const poll = () => {
+                fetchJson("/api/projects/" + encodeURIComponent(project.info.project_id) + "/runs/" + encodeURIComponent(run.run_id))
+                    .then((d) => { if (active) setRun(d); })
+                    .catch(() => { });
+            };
+            const tid = setInterval(poll, 2000);
+            return () => { active = false; clearInterval(tid); };
+        }, [project.info.project_id, run.run_id, isRunning]);
+
+        // Derive stages and tag each event with its stage.
+        //
+        // We track TWO things per event: the raw ``ev.stage`` (used in the
+        // expanded log entry so the per-layer detail stays visible) and
+        // the NORMALIZED stage id (e.g. ``implementation`` for
+        // ``implementation_layer1``). The chip strip only shows normalized
+        // ids, deduped, so multi-layer phases render as one chip.
+        const stages = [];
+        const normalizedSeen = new Set();
+        let curRawStage = null;
+        let curNormalizedStage = null;
+        const evStagesRaw = [];
+        const evStagesNormalized = [];
+        for (let i = 0; i < taskLog.length; i++) {
+            const ev = taskLog[i];
+            if (ev.type === "stage_update" && ev.stage) {
+                curRawStage = ev.stage;
+                curNormalizedStage = normalizeStageId(ev.stage);
+                if (!normalizedSeen.has(curNormalizedStage)) {
+                    normalizedSeen.add(curNormalizedStage);
+                    stages.push(curNormalizedStage);
+                }
+            }
+            evStagesRaw.push(curRawStage);
+            evStagesNormalized.push(curNormalizedStage);
+        }
+        const requests = taskLog.filter((e) => e.type === "task_request");
+        const responses = taskLog.filter((e) => e.type === "task_response");
+        const completed = responses.filter((e) => e.status === "completed").length;
+        const failed = responses.filter((e) => e.status === "failed").length;
+
+        // Build taskId → latest todos list. Each todos_update event carries
+        // the full todo list at the time the agent invoked write_todos, so
+        // the newest entry wins.
+        // Agents often call write_todos once at the start to plan and then
+        // never revisit it, so a task_response(completed) retroactively marks
+        // every remaining todo as done. Failed tasks keep their last snapshot
+        // so the user can see where the agent was when it died.
+        // Tasks that never called write_todos at all (common for small
+        // TDD modules) get a synthetic single-item list derived from the
+        // task's terminal status so the card still shows a progress cue.
+        const taskTodos = {};
+        const taskTerminalStatus = {};
+        const seenTaskIds = new Set();
+        const taskRequestPayload = {};
+        for (let i = 0; i < taskLog.length; i++) {
+            const ev = taskLog[i];
+            if (!ev || !ev.taskId) continue;
+            if (ev.type === "task_request") {
+                seenTaskIds.add(ev.taskId);
+                taskRequestPayload[ev.taskId] = ev.payload || {};
+            } else if (ev.type === "todos_update" && Array.isArray(ev.todos)) {
+                taskTodos[ev.taskId] = ev.todos;
+            } else if (ev.type === "task_response") {
+                seenTaskIds.add(ev.taskId);
+                taskTerminalStatus[ev.taskId] = ev.status;
+            }
+        }
+        for (const tid of Object.keys(taskTerminalStatus)) {
+            if (taskTerminalStatus[tid] !== "completed") continue;
+            const list = taskTodos[tid];
+            if (!Array.isArray(list)) continue;
+            taskTodos[tid] = list.map((t) => (t && t.status !== "completed")
+                ? Object.assign({}, t, { status: "completed" })
+                : t);
+        }
+        // Synthetic fallback: if a task has no todos_update at all, build a
+        // single-row list from its current state (in-progress / completed /
+        // failed). Keeps every task card visually uniform instead of some
+        // showing todos and some showing nothing.
+        for (const tid of seenTaskIds) {
+            if (Array.isArray(taskTodos[tid])) continue;
+            const term = taskTerminalStatus[tid];
+            const payload = taskRequestPayload[tid] || {};
+            const label = payload.step || (payload.task ? String(payload.task).split("\n")[0].slice(0, 60) : "任务");
+            let status = "in_progress";
+            if (term === "completed") status = "completed";
+            else if (term === "failed") status = "pending";
+            taskTodos[tid] = [{
+                content: label,
+                activeForm: label,
+                status: status,
+                synthetic: true,
+            }];
+        }
+        // Each completed task used to produce TWO rows in the log (a
+        // task_request and a task_response). Merge them: render only the
+        // task_request; its card shows the response's status/output in the
+        // expanded details. Map taskId → response event here.
+        const taskResponseByTaskId = {};
+        for (let i = 0; i < taskLog.length; i++) {
+            const ev = taskLog[i];
+            if (ev && ev.type === "task_response" && ev.taskId) {
+                taskResponseByTaskId[ev.taskId] = ev;
+            }
+        }
+        // Hide raw todos_update rows (render inline under their task_request)
+        // and task_response rows (merged into their request).
+        const visibleLog = taskLog.filter(
+            (e) => e.type !== "todos_update" && e.type !== "task_response",
+        );
+        // Filter predicate uses the NORMALIZED stage so a single
+        // ``implementation`` chip matches every ``implementation_layer*``
+        // event, not just the one raw id the user clicked.
+        const visibleStages = taskLog
+            .map((_, i) => evStagesNormalized[i])
+            .filter(
+                (_, i) =>
+                    taskLog[i].type !== "todos_update" &&
+                    taskLog[i].type !== "task_response",
             );
-          }),
-        ),
-        h("div", { className: "agent-graph-row agent-graph-row-top" },
-          orchestrators.map(function (a) { return h(AgentCard, { key: a.name, agent: a }); }),
-        ),
-        h("div", {
-          className: "agent-graph-row agent-graph-row-workers",
-          style: { gridTemplateColumns: "repeat(" + workers.length + ", minmax(0, 1fr))" },
+        const filteredLog = stageFilter
+            ? visibleLog.filter((_, i) => visibleStages[i] === stageFilter)
+            : visibleLog;
+
+        const statusCls = runStatus === "completed" ? "run-status-completed"
+            : runStatus === "failed" ? "run-status-failed"
+                : runStatus === "running" ? "run-status-running" : "run-status-pending";
+        const toggleStage = (s) => setStageFilter((prev) => prev === s ? null : s);
+
+        return h("div", { className: "run-container" },
+            h("div", { className: "run-header" },
+                h("div", { className: "run-header-left" },
+                    h("a", { className: "run-back-link", href: "/projects/" + project.info.project_id }, "\u2190 " + (project.info.name || t("run.back.project_fallback"))),
+                    h("h1", { className: "run-title" }, t("run.title")),
+                    h("span", { className: "run-id-label" }, run.run_id),
+                ),
+                h("span", { className: "run-status-badge " + statusCls },
+                    isRunning ? h("span", { className: "monitor-task-pulse" }) : null,
+                    runStatus === "completed" ? t("run.status.completed")
+                        : runStatus === "failed" ? t("run.status.failed")
+                            : runStatus === "running" ? t("run.status.running")
+                                : t("run.status.pending"),
+                ),
+                run.mode === "incremental" ? h("span", {
+                    className: "run-mode-badge run-mode-badge-incremental",
+                    title: t("run.mode.incremental_hint"),
+                }, t("run.mode.incremental")) : null,
+                (run.process_type === "agile") ? h("span", {
+                    className: "run-mode-badge run-mode-badge-agile",
+                    title: currentLang() === "en"
+                        ? "Agile Sprint process: Planning → Execution → Review → Retrospective → Delivery"
+                        : "Agile Sprint 流程：规划 → 执行 → 评审 → 复盘 → 交付",
+                }, currentLang() === "en" ? "Agile Sprint" : "Agile 迭代") :
+                    h("span", {
+                        className: "run-mode-badge run-mode-badge-waterfall",
+                        title: currentLang() === "en"
+                            ? "Waterfall process: Requirements → Architecture → Implementation → Entry → QA → Delivery"
+                            : "Waterfall 流程：需求 → 架构 → 实现 → 入口 → 测试 → 交付",
+                    }, currentLang() === "en" ? "Waterfall" : "Waterfall 瀑布"),
+            ),
+            h("div", { className: "run-section" },
+                h("div", { className: "run-section-title" }, t("run.section.requirement")),
+                h("div", { className: "run-requirement-text" }, run.requirement_text || ""),
+            ),
+            h("div", { className: "run-stats" },
+                h("div", { className: "run-stat" }, h("span", { className: "run-stat-value" }, stages.length), h("span", { className: "run-stat-label" }, t("run.stat.stages"))),
+                h("div", { className: "run-stat" }, h("span", { className: "run-stat-value" }, requests.length), h("span", { className: "run-stat-label" }, t("run.stat.dispatches"))),
+                h("div", { className: "run-stat" }, h("span", { className: "run-stat-value" }, completed), h("span", { className: "run-stat-label" }, t("run.stat.completed"))),
+                failed > 0 ? h("div", { className: "run-stat run-stat-error" }, h("span", { className: "run-stat-value" }, failed), h("span", { className: "run-stat-label" }, t("run.stat.failed"))) : null,
+            ),
+            // View switcher: "timeline" = current stage-progress + A2A log;
+            // "agents" = the agent-interaction graph. Persists only for the
+            // life of the component (simple UI preference, not a deep link).
+            h("div", { className: "run-view-tabs", role: "tablist" },
+                ["timeline", "agents"].map((key) => h(
+                    "button",
+                    {
+                        key: key,
+                        type: "button",
+                        role: "tab",
+                        "aria-selected": runView === key ? "true" : "false",
+                        className: "run-view-tab" + (runView === key ? " run-view-tab-active" : ""),
+                        onClick: function () { setRunView(key); },
+                    },
+                    t("run.view." + key),
+                )),
+            ),
+            runView === "agents" ? h(AgentInteractionView, {
+                taskLog: taskLog,
+                orchestratorName: (project.info || {}).orchestrator_name || null,
+                taskResponseByTaskId: taskResponseByTaskId,
+                isRunning: isRunning,
+            }) : null,
+            runView === "timeline" && stages.length > 0 ? h("div", { className: "run-section" },
+                h("div", { className: "run-section-title" }, t("run.section.stage_progress") + (stageFilter ? t("run.section.stage_progress_filter_hint") : "")),
+                h("div", { className: "run-stages-flow" },
+                    stages.map((s, i) => {
+                        var lastStageIdx = stages.length - 1;
+                        var isDone = isRunning ? i < lastStageIdx : true;
+                        var isCurrent = isRunning && i === lastStageIdx;
+                        var cls = "run-stage-chip run-stage-clickable"
+                            + (stageFilter === s ? " run-stage-selected" : "")
+                            + (isDone && !isCurrent ? " run-stage-done" : "")
+                            + (isCurrent ? " run-stage-active" : "");
+                        return h(window.React.Fragment, { key: s },
+                            i > 0 ? h("span", { className: "run-stage-arrow" + (isDone ? " run-stage-arrow-done" : "") }, "\u2192") : null,
+                            h("span", { className: cls, onClick: function () { toggleStage(s); } }, resolveChipLabel(s) || s),
+                        );
+                    }),
+                ),
+            ) : null,
+            runView === "timeline" ? h("div", { className: "run-section" },
+                h("div", { className: "run-section-title" }, t("run.section.log_title") + " (" + filteredLog.length + (stageFilter ? " / " + taskLog.length : "") + ")"),
+                filteredLog.length === 0
+                    ? h("div", { className: "run-log-empty" }, isRunning ? t("run.log.waiting") : t("run.log.empty"))
+                    : h("div", { className: "run-task-log" }, filteredLog.map((ev, idx) => h(RunLogEntry, {
+                        key: idx,
+                        event: ev,
+                        taskTodos: taskTodos,
+                        taskResponse: ev.taskId ? taskResponseByTaskId[ev.taskId] : null,
+                    }))),
+            ) : null,
+            // The delivery report (``run.result``) is produced by Phase 6 /
+            // the ``delivery`` stage. It's noisy to show on every view of the
+            // run detail page, so scope it: only render when the user has
+            // actively filtered the log to the delivery stage (by clicking
+            // the delivery chip). When no filter is applied or a different
+            // stage is selected, the report is hidden and the rest of the
+            // A2A log takes the space.
+            run.result && stageFilter && /deliver/i.test(stageFilter)
+                ? h("div", { className: "run-section" },
+                    h("div", { className: "run-section-title" }, t("run.section.delivery_report")),
+                    h("pre", { className: "run-result-text" }, run.result),
+                )
+                : null,
+            run.error ? h("div", { className: "run-section run-error-section" },
+                h("div", { className: "run-section-title" }, t("run.section.error")),
+                h("pre", { className: "run-error-text" }, run.error),
+            ) : null,
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Agent interaction view
+    // ------------------------------------------------------------------
+    //
+    // Parses the run's ``task_log`` into three structures:
+    //
+    //   agents     — one card per participating agent (orchestrator on
+    //                the top row, workers in a grid below). Each agent
+    //                carries its running-task count, completed / failed
+    //                totals, and its recent task list.
+    //   edges      — ``(from → to)`` pairs with a count of dispatches.
+    //                Rendered as SVG arrows laid over the grid with a
+    //                small count badge.
+    //   taskById   — ``taskId`` → {agent, label, status, goal, startedAt}
+    //                used to populate the task list under each worker.
+    //
+    // All computation is derived from ``task_request`` / ``task_response``
+    // events that the runtime already emits — no new backend data needed.
+    function computeAgentGraph(taskLog, orchestratorName, taskResponseByTaskId) {
+        var orchestrator = orchestratorName || "orchestrator";
+        var workerSet = new Set();
+        var edges = new Map(); // key "fromto" -> count
+        var tasksByAgent = new Map();
+        var allTasks = [];
+
+        function bumpEdge(from, to) {
+            var k = from + "" + to;
+            edges.set(k, (edges.get(k) || 0) + 1);
+        }
+
+        for (var i = 0; i < taskLog.length; i++) {
+            var ev = taskLog[i];
+            if (!ev) continue;
+            if (ev.type === "task_request" && ev.to) {
+                workerSet.add(ev.to);
+                bumpEdge(orchestrator, ev.to);
+                var payload = ev.payload || {};
+                var response = ev.taskId ? taskResponseByTaskId[ev.taskId] : null;
+                var respPayload = (response && response.payload) || {};
+                var goal = payload.step
+                    || (payload.task ? String(payload.task).split("\n")[0].slice(0, 80) : "")
+                    || t("entry.fallback_task_name");
+                var status = response ? (response.status || "completed") : "running";
+                var outputLen = response ? (respPayload.output_length || 0) : 0;
+                var task = {
+                    taskId: ev.taskId || null,
+                    agent: ev.to,
+                    goal: goal,
+                    phase: payload.phase || "",
+                    status: status,
+                    startedAt: ev.timestamp || "",
+                    completedAt: response ? (response.timestamp || "") : "",
+                    outputLen: outputLen,
+                };
+                if (!tasksByAgent.has(ev.to)) tasksByAgent.set(ev.to, []);
+                tasksByAgent.get(ev.to).push(task);
+                allTasks.push(task);
+            }
+        }
+
+        // Agents array: orchestrator first, then workers in declaration
+        // order (which matches dispatch order — a readable flow).
+        var workers = Array.from(workerSet);
+        var agents = [{ name: orchestrator, role: "orchestrator" }];
+        workers.forEach(function (n) { agents.push({ name: n, role: "worker" }); });
+
+        // Edges as a simple array.
+        var edgeArr = [];
+        edges.forEach(function (count, key) {
+            var parts = key.split("");
+            edgeArr.push({ from: parts[0], to: parts[1], count: count });
+        });
+
+        // Per-agent status summary.
+        agents.forEach(function (a) {
+            var tasks = tasksByAgent.get(a.name) || [];
+            a.tasks = tasks;
+            a.runningCount = tasks.filter(function (t) { return t.status === "running"; }).length;
+            a.completedCount = tasks.filter(function (t) { return t.status === "completed"; }).length;
+            a.failedCount = tasks.filter(function (t) { return t.status === "failed"; }).length;
+        });
+
+        return { agents: agents, edges: edgeArr, tasks: allTasks };
+    }
+
+    function AgentStatusBadge({ agent }) {
+        const h = window.React.createElement;
+        if (agent.runningCount > 0) {
+            return h("span", { className: "agent-card-status agent-card-status-working" },
+                h("span", { className: "monitor-task-pulse" }),
+                t("agents.status.working", { n: agent.runningCount }),
+            );
+        }
+        if (agent.completedCount + agent.failedCount === 0) {
+            return h("span", { className: "agent-card-status agent-card-status-idle" }, t("agents.status.idle"));
+        }
+        return h("span", { className: "agent-card-status agent-card-status-done" }, t("agents.status.done"));
+    }
+
+    function AgentCard({ agent }) {
+        const h = window.React.createElement;
+        // Cap the per-agent task list to the most recent 12 entries so a
+        // long-running project with dozens of dispatches per agent stays
+        // scannable. Older tasks can still be found via the timeline view.
+        var visibleTasks = agent.tasks.slice(-12).reverse();
+        return h("div", {
+            className: "agent-card agent-card-role-" + agent.role,
+            "data-agent-name": agent.name,
         },
-          workers.map(function (a) { return h(AgentCard, { key: a.name, agent: a }); }),
-        ),
-      ),
-    );
-  }
-
-  function RunLogEntry({ event, taskTodos, taskResponse }) {
-    const h = window.React.createElement;
-    const ev = event;
-    const ts = ev.timestamp ? formatLocalTime(ev.timestamp) : "";
-    const todosForTask = ev && ev.taskId && taskTodos ? taskTodos[ev.taskId] : null;
-
-    // Default-expand running tasks (no response yet); default-collapse
-    // completed/failed tasks. A completed task card is a compact summary
-    // until the user clicks to open it.
-    const taskIsRunning = ev.type === "task_request" && !taskResponse;
-    const [expanded, setExpanded] = window.React.useState(taskIsRunning);
-
-    if (ev.type === "stage_update") {
-      return h("div", { className: "run-log-entry run-log-stage", onClick: function() { setExpanded(!expanded); } },
-        h("div", { className: "run-log-row" },
-          h("span", { className: "run-log-toggle" }, expanded ? "▼" : "▶"),
-          h("span", { className: "run-log-stage-label" }, resolveStageLabel(ev.stage) || ev.stage),
-          h("span", { className: "run-log-ts" }, ts),
-        ),
-        expanded ? h("div", { className: "run-log-body run-log-stage-detail" },
-          h("div", { className: "run-log-meta" }, t("entry.meta.stage") + ev.stage),
-          ev.status ? h("div", { className: "run-log-meta" }, t("entry.meta.status") + ev.status) : null,
-        ) : null,
-      );
+            h("div", { className: "agent-card-header" },
+                h("span", { className: "agent-card-icon" }, agent.role === "orchestrator" ? "🎯" : "🤖"),
+                h("span", { className: "agent-card-name" }, agent.name),
+                h("span", { className: "agent-card-role-tag" }, t("agents.role." + agent.role)),
+            ),
+            h(AgentStatusBadge, { agent: agent }),
+            h("div", { className: "agent-card-stats" },
+                h("span", { title: t("agents.stat.running") }, "● " + agent.runningCount),
+                h("span", { title: t("agents.stat.completed") }, "✓ " + agent.completedCount),
+                agent.failedCount > 0
+                    ? h("span", { className: "agent-card-stat-failed", title: t("agents.stat.failed") }, "✕ " + agent.failedCount)
+                    : null,
+            ),
+            h("div", { className: "agent-card-tasks" },
+                h("div", { className: "agent-card-tasks-title" }, t("agents.tasks_heading")),
+                visibleTasks.length === 0
+                    ? h("div", { className: "agent-card-tasks-empty" }, t("agents.no_tasks"))
+                    : h("ul", { className: "agent-card-tasks-list" }, visibleTasks.map(function (task, idx) {
+                        var statusClass = "agent-task-" + task.status;
+                        return h("li", { className: "agent-card-task " + statusClass, key: task.taskId || idx },
+                            h("span", { className: "agent-card-task-icon" },
+                                task.status === "running" ? "●" : task.status === "failed" ? "✕" : "✓",
+                            ),
+                            h("span", { className: "agent-card-task-goal", title: task.goal }, task.goal),
+                        );
+                    })),
+            ),
+        );
     }
 
-    if (ev.type === "tool_call") {
-      // Collapse tool_call details by default — the summary is only
-      // shown when the user expands. Keeps the main log uncluttered.
-      return h("div", { className: "run-log-entry run-log-tool" + (expanded ? " run-log-expanded" : ""), onClick: function() { setExpanded(!expanded); } },
-        h("div", { className: "run-log-row" },
-          h("span", { className: "run-log-toggle" }, expanded ? "\u25bc" : "\u25b6"),
-          h("span", { className: "run-log-icon" }, EVENT_ICONS.tool_call),
-          h("span", { className: "run-log-tool-name" }, ev.tool || t("entry.tool_fallback_name")),
-          h("span", { className: "run-log-ts" }, ts),
-        ),
-        expanded ? h("div", { className: "run-log-body" },
-          ev.summary ? h("pre", { className: "run-log-full-text" }, ev.summary) : h("div", { className: "run-log-meta" }, t("entry.summary_no_summary")),
-        ) : null,
-      );
+    function AgentInteractionView({ taskLog, orchestratorName, taskResponseByTaskId, isRunning }) {
+        const h = window.React.createElement;
+        const React = window.React;
+        var graph = computeAgentGraph(taskLog, orchestratorName, taskResponseByTaskId);
+        var orchestrators = graph.agents.filter(function (a) { return a.role === "orchestrator"; });
+        var workers = graph.agents.filter(function (a) { return a.role === "worker"; });
+
+        // Per-worker interaction summary: dispatches + completed + failed
+        // counts, keyed by agent name. These numbers land verbatim on the
+        // connector label so the orchestrator → worker edge carries the
+        // per-pair interaction info, not a single aggregate.
+        var interactionByWorker = {};
+        workers.forEach(function (w) {
+            var tasks = w.tasks || [];
+            interactionByWorker[w.name] = {
+                dispatches: tasks.length,
+                completed: w.completedCount || 0,
+                failed: w.failedCount || 0,
+            };
+        });
+
+        // SVG connector geometry is measured from the DOM after render —
+        // one line per worker, anchored at the orchestrator card's
+        // bottom-center and terminating at the worker card's top-center.
+        // Re-measures when the task log grows, when a new worker joins,
+        // and on viewport resize.
+        const containerRef = React.useRef(null);
+        const [edges, setEdges] = React.useState([]);
+        React.useLayoutEffect(function () {
+            function measure() {
+                var container = containerRef.current;
+                if (!container) return;
+                var orchEl = container.querySelector(".agent-card-role-orchestrator");
+                var workerEls = Array.prototype.slice.call(
+                    container.querySelectorAll(".agent-card-role-worker")
+                );
+                if (!orchEl || workerEls.length === 0) {
+                    setEdges([]);
+                    return;
+                }
+                var cRect = container.getBoundingClientRect();
+                var oRect = orchEl.getBoundingClientRect();
+                var fromX = oRect.left + oRect.width / 2 - cRect.left;
+                var fromY = oRect.bottom - cRect.top;
+                var next = workerEls.map(function (el) {
+                    var r = el.getBoundingClientRect();
+                    var name = el.getAttribute("data-agent-name") || "";
+                    var info = interactionByWorker[name] || { dispatches: 0, completed: 0, failed: 0 };
+                    return {
+                        name: name,
+                        fromX: fromX,
+                        fromY: fromY,
+                        toX: r.left + r.width / 2 - cRect.left,
+                        toY: r.top - cRect.top,
+                        dispatches: info.dispatches,
+                        completed: info.completed,
+                        failed: info.failed,
+                    };
+                });
+                setEdges(next);
+            }
+            measure();
+            window.addEventListener("resize", measure);
+            return function () { window.removeEventListener("resize", measure); };
+            // Depend on both length fields so new dispatches + new workers
+            // trigger a re-measure.
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, [taskLog.length, workers.length]);
+
+        if (workers.length === 0) {
+            return h("div", { className: "run-section agent-graph-empty" },
+                h("div", { className: "run-log-empty" }, isRunning ? t("agents.waiting") : t("agents.no_participants")),
+            );
+        }
+
+        return h("div", { className: "run-section agent-graph-section" },
+            h("div", { className: "run-section-title" }, t("agents.section_title")),
+            h("div", { className: "agent-graph-container", ref: containerRef },
+                // SVG connector overlay: one ``<line>`` per worker + an
+                // HTML label block carried in a ``foreignObject`` at the
+                // midpoint. Sits behind the cards (z-index 0) and has
+                // pointer-events: none so the cards stay clickable. The
+                // ``aria-hidden`` reminds screen readers that the same
+                // numbers are already present on each agent card.
+                h("svg", {
+                    className: "agent-graph-connectors",
+                    "aria-hidden": "true",
+                    xmlns: "http://www.w3.org/2000/svg",
+                    preserveAspectRatio: "none",
+                },
+                    h("defs", null,
+                        h("marker", {
+                            id: "agent-graph-arrow",
+                            viewBox: "0 0 10 10",
+                            refX: "9",
+                            refY: "5",
+                            markerWidth: "8",
+                            markerHeight: "8",
+                            orient: "auto-start-reverse",
+                        },
+                            h("path", { d: "M 0 0 L 10 5 L 0 10 Z", className: "agent-graph-arrow-head" }),
+                        ),
+                    ),
+                    edges.map(function (e) {
+                        var midX = (e.fromX + e.toX) / 2;
+                        var midY = (e.fromY + e.toY) / 2;
+                        return h("g", { key: e.name, className: "agent-graph-connector-group" },
+                            h("line", {
+                                x1: e.fromX,
+                                y1: e.fromY,
+                                x2: e.toX,
+                                y2: e.toY,
+                                className: "agent-graph-connector-line",
+                                "marker-end": "url(#agent-graph-arrow)",
+                                "data-from": "orchestrator",
+                                "data-to": e.name,
+                            }),
+                            h("foreignObject", {
+                                x: midX - 80,
+                                y: midY - 14,
+                                width: 160,
+                                height: 30,
+                                className: "agent-graph-connector-fo",
+                            },
+                                h("div", { className: "agent-graph-connector-label", "data-to": e.name },
+                                    h("span", { className: "agent-graph-connector-dispatches" }, t("agents.dispatches", { n: e.dispatches })),
+                                    e.completed > 0 ? h("span", {
+                                        className: "agent-graph-connector-chip agent-graph-connector-chip-completed",
+                                        title: t("agents.stat.completed"),
+                                    }, "✓ " + e.completed) : null,
+                                    e.failed > 0 ? h("span", {
+                                        className: "agent-graph-connector-chip agent-graph-connector-chip-failed",
+                                        title: t("agents.stat.failed"),
+                                    }, "✕ " + e.failed) : null,
+                                ),
+                            ),
+                        );
+                    }),
+                ),
+                h("div", { className: "agent-graph-row agent-graph-row-top" },
+                    orchestrators.map(function (a) { return h(AgentCard, { key: a.name, agent: a }); }),
+                ),
+                h("div", {
+                    className: "agent-graph-row agent-graph-row-workers",
+                    style: { gridTemplateColumns: "repeat(" + workers.length + ", minmax(0, 1fr))" },
+                },
+                    workers.map(function (a) { return h(AgentCard, { key: a.name, agent: a }); }),
+                ),
+            ),
+        );
     }
 
-    if (ev.type === "task_request") {
-      var payload = ev.payload || {};
-      var fullTask = payload.task || "";
-      // The task row shows the task's GOAL (what it is, not the full
-      // description text sent to the worker). Prefer ``payload.step``
-      // (e.g. "impl_config_loader", "phase_2_design") — it is the
-      // orchestrator's short identifier for what the task accomplishes.
-      // Fall back to the first line of the task description, which is
-      // typically a goal-like sentence.
-      var goalText =
-        payload.step ||
-        (fullTask ? fullTask.split("\n")[0].slice(0, 100) : "") ||
-        t("entry.fallback_task_name");
-      var response = taskResponse || null;
-      var responsePayload = (response && response.payload) || {};
-      var responseStatus = response ? response.status : null;
-      var outputText = response
-        ? String(responsePayload.output_preview || responsePayload.output || responsePayload.error || "")
-        : "";
-      var outputLen = response ? (responsePayload.output_length || outputText.length) : 0;
-      var savedTo = response ? (responsePayload.saved_to || "") : "";
-      var displayStatus = responseStatus || "running";
-      var statusTagCls = responseStatus === "completed" ? "log-completed"
-        : responseStatus === "failed" ? "log-failed"
-        : "log-running";
-      // Todos are always visible for running tasks (live progress cue),
-      // and only shown for completed tasks when the card is expanded.
-      var showTodos = todosForTask && (!response || expanded);
-      return h("div", { className: "run-log-entry run-log-request " + statusTagCls + (expanded ? " run-log-expanded" : "") },
-        h("div", { className: "run-log-row", onClick: function() { setExpanded(!expanded); } },
-          h("span", { className: "run-log-toggle" }, expanded ? "\u25bc" : "\u25b6"),
-          h("span", { className: "run-log-icon" }, EVENT_ICONS.task_request),
-          h("span", { className: "run-log-agent" }, ev.to),
-          payload.phase ? h("span", { className: "run-log-phase-tag" }, payload.phase) : null,
-          h("span", { className: "run-log-status-tag " + statusTagCls },
-            response
-              ? (responseStatus === "completed" ? t("entry.status.completed")
-                 : responseStatus === "failed" ? t("entry.status.failed")
-                 : responseStatus)
-              : t("entry.status.running"),
-          ),
-          h("span", { className: "run-log-detail" }, goalText),
-          h("span", { className: "run-log-ts" }, ts),
-        ),
-        showTodos ? h(TaskTodoProgress, { todos: todosForTask }) : null,
-        expanded ? h("div", { className: "run-log-body" },
-          h("div", { className: "run-log-response-meta" },
-            ev.taskId ? h("span", null, t("entry.meta.task_id") + ev.taskId) : null,
-            payload.step ? h("span", null, t("entry.meta.step") + payload.step) : null,
-            payload.phase ? h("span", null, t("entry.meta.phase") + payload.phase) : null,
-            outputLen > 0 ? h("span", null, t("entry.meta.output", { n: outputLen })) : null,
-            savedTo ? h("span", null, "\u2713 " + savedTo) : null,
-          ),
-          fullTask ? h("div", { className: "run-log-subsection" },
-            h("div", { className: "run-log-subsection-title" }, t("entry.task_description_title")),
-            h("pre", { className: "run-log-full-text" }, fullTask),
-          ) : null,
-          response ? h("div", { className: "run-log-subsection" },
-            h("div", { className: "run-log-subsection-title" }, t("entry.execution_result_title")),
-            outputText
-              ? h("pre", { className: "run-log-full-text" }, outputText)
-              : h("div", { className: "run-log-meta" }, t("entry.no_text_output")),
-          ) : null,
-        ) : null,
-      );
+    function RunLogEntry({ event, taskTodos, taskResponse }) {
+        const h = window.React.createElement;
+        const ev = event;
+        const ts = ev.timestamp ? formatLocalTime(ev.timestamp) : "";
+        const todosForTask = ev && ev.taskId && taskTodos ? taskTodos[ev.taskId] : null;
+
+        // Default-expand running tasks (no response yet); default-collapse
+        // completed/failed tasks. A completed task card is a compact summary
+        // until the user clicks to open it.
+        const taskIsRunning = ev.type === "task_request" && !taskResponse;
+        const [expanded, setExpanded] = window.React.useState(taskIsRunning);
+
+        if (ev.type === "stage_update") {
+            return h("div", { className: "run-log-entry run-log-stage", onClick: function () { setExpanded(!expanded); } },
+                h("div", { className: "run-log-row" },
+                    h("span", { className: "run-log-toggle" }, expanded ? "▼" : "▶"),
+                    h("span", { className: "run-log-stage-label" }, resolveStageLabel(ev.stage) || ev.stage),
+                    h("span", { className: "run-log-ts" }, ts),
+                ),
+                expanded ? h("div", { className: "run-log-body run-log-stage-detail" },
+                    h("div", { className: "run-log-meta" }, t("entry.meta.stage") + ev.stage),
+                    ev.status ? h("div", { className: "run-log-meta" }, t("entry.meta.status") + ev.status) : null,
+                ) : null,
+            );
+        }
+
+        if (ev.type === "tool_call") {
+            // Collapse tool_call details by default — the summary is only
+            // shown when the user expands. Keeps the main log uncluttered.
+            return h("div", { className: "run-log-entry run-log-tool" + (expanded ? " run-log-expanded" : ""), onClick: function () { setExpanded(!expanded); } },
+                h("div", { className: "run-log-row" },
+                    h("span", { className: "run-log-toggle" }, expanded ? "\u25bc" : "\u25b6"),
+                    h("span", { className: "run-log-icon" }, EVENT_ICONS.tool_call),
+                    h("span", { className: "run-log-tool-name" }, ev.tool || t("entry.tool_fallback_name")),
+                    h("span", { className: "run-log-ts" }, ts),
+                ),
+                expanded ? h("div", { className: "run-log-body" },
+                    ev.summary ? h("pre", { className: "run-log-full-text" }, ev.summary) : h("div", { className: "run-log-meta" }, t("entry.summary_no_summary")),
+                ) : null,
+            );
+        }
+
+        if (ev.type === "task_request") {
+            var payload = ev.payload || {};
+            var fullTask = payload.task || "";
+            // The task row shows the task's GOAL (what it is, not the full
+            // description text sent to the worker). Prefer ``payload.step``
+            // (e.g. "impl_config_loader", "phase_2_design") — it is the
+            // orchestrator's short identifier for what the task accomplishes.
+            // Fall back to the first line of the task description, which is
+            // typically a goal-like sentence.
+            var goalText =
+                payload.step ||
+                (fullTask ? fullTask.split("\n")[0].slice(0, 100) : "") ||
+                t("entry.fallback_task_name");
+            var response = taskResponse || null;
+            var responsePayload = (response && response.payload) || {};
+            var responseStatus = response ? response.status : null;
+            var outputText = response
+                ? String(responsePayload.output_preview || responsePayload.output || responsePayload.error || "")
+                : "";
+            var outputLen = response ? (responsePayload.output_length || outputText.length) : 0;
+            var savedTo = response ? (responsePayload.saved_to || "") : "";
+            var displayStatus = responseStatus || "running";
+            var statusTagCls = responseStatus === "completed" ? "log-completed"
+                : responseStatus === "failed" ? "log-failed"
+                    : "log-running";
+            // Todos are always visible for running tasks (live progress cue),
+            // and only shown for completed tasks when the card is expanded.
+            var showTodos = todosForTask && (!response || expanded);
+            return h("div", { className: "run-log-entry run-log-request " + statusTagCls + (expanded ? " run-log-expanded" : "") },
+                h("div", { className: "run-log-row", onClick: function () { setExpanded(!expanded); } },
+                    h("span", { className: "run-log-toggle" }, expanded ? "\u25bc" : "\u25b6"),
+                    h("span", { className: "run-log-icon" }, EVENT_ICONS.task_request),
+                    h("span", { className: "run-log-agent" }, ev.to),
+                    payload.phase ? h("span", { className: "run-log-phase-tag" }, payload.phase) : null,
+                    h("span", { className: "run-log-status-tag " + statusTagCls },
+                        response
+                            ? (responseStatus === "completed" ? t("entry.status.completed")
+                                : responseStatus === "failed" ? t("entry.status.failed")
+                                    : responseStatus)
+                            : t("entry.status.running"),
+                    ),
+                    h("span", { className: "run-log-detail" }, goalText),
+                    h("span", { className: "run-log-ts" }, ts),
+                ),
+                showTodos ? h(TaskTodoProgress, { todos: todosForTask }) : null,
+                expanded ? h("div", { className: "run-log-body" },
+                    h("div", { className: "run-log-response-meta" },
+                        ev.taskId ? h("span", null, t("entry.meta.task_id") + ev.taskId) : null,
+                        payload.step ? h("span", null, t("entry.meta.step") + payload.step) : null,
+                        payload.phase ? h("span", null, t("entry.meta.phase") + payload.phase) : null,
+                        outputLen > 0 ? h("span", null, t("entry.meta.output", { n: outputLen })) : null,
+                        savedTo ? h("span", null, "\u2713 " + savedTo) : null,
+                    ),
+                    fullTask ? h("div", { className: "run-log-subsection" },
+                        h("div", { className: "run-log-subsection-title" }, t("entry.task_description_title")),
+                        h("pre", { className: "run-log-full-text" }, fullTask),
+                    ) : null,
+                    response ? h("div", { className: "run-log-subsection" },
+                        h("div", { className: "run-log-subsection-title" }, t("entry.execution_result_title")),
+                        outputText
+                            ? h("pre", { className: "run-log-full-text" }, outputText)
+                            : h("div", { className: "run-log-meta" }, t("entry.no_text_output")),
+                    ) : null,
+                ) : null,
+            );
+        }
+
+        return h("div", { className: "run-log-entry" },
+            h("span", { className: "run-log-icon" }, "\u00b7"),
+            h("span", null, ev.type || "event"),
+            h("span", { className: "run-log-ts" }, ts),
+        );
     }
 
-    return h("div", { className: "run-log-entry" },
-      h("span", { className: "run-log-icon" }, "\u00b7"),
-      h("span", null, ev.type || "event"),
-      h("span", { className: "run-log-ts" }, ts),
-    );
-  }
-
-  mountReact("run-react-root", () => window.React.createElement(RunApp));
+    mountReact("run-react-root", () => window.React.createElement(RunApp));
 }
 
 function setupTaskReact() {
-  const initial = readScriptJson("task-initial-data", null);
-  if (!initial) return;
+    const initial = readScriptJson("task-initial-data", null);
+    if (!initial) return;
 
-  function TaskApp() {
-    const h = window.React.createElement;
-    const task = initial.task || {};
-    return h(
-      "section",
-      { className: "card card-glow" },
-      h("h1", null, t("task.title")),
-      h("p", null, `${t("task.field.phase")}: ${initial.phase_name}`),
-      h("p", null, `${t("task.field.task_key")}: ${initial.task_key}`),
-      h("p", null, `${t("task.field.status")}: ${task.status || ""}`),
-      task.artifact_id ? h("p", null, `${t("task.field.artifact_id")}: ${task.artifact_id}`) : null,
-      task.error ? h("pre", { className: "error" }, task.error) : null,
-      h(
-        "a",
-        {
-          className: "btn secondary",
-          href: `/projects/${encodeURIComponent(initial.project_id)}/runs/${encodeURIComponent(initial.run_id)}`,
-        },
-        t("task.back_to_run"),
-      )
-    );
-  }
+    function TaskApp() {
+        const h = window.React.createElement;
+        const task = initial.task || {};
+        return h(
+            "section",
+            { className: "card card-glow" },
+            h("h1", null, t("task.title")),
+            h("p", null, `${t("task.field.phase")}: ${initial.phase_name}`),
+            h("p", null, `${t("task.field.task_key")}: ${initial.task_key}`),
+            h("p", null, `${t("task.field.status")}: ${task.status || ""}`),
+            task.artifact_id ? h("p", null, `${t("task.field.artifact_id")}: ${task.artifact_id}`) : null,
+            task.error ? h("pre", { className: "error" }, task.error) : null,
+            h(
+                "a",
+                {
+                    className: "btn secondary",
+                    href: `/projects/${encodeURIComponent(initial.project_id)}/runs/${encodeURIComponent(initial.run_id)}`,
+                },
+                t("task.back_to_run"),
+            )
+        );
+    }
 
-  mountReact("task-react-root", () => window.React.createElement(TaskApp));
+    mountReact("task-react-root", () => window.React.createElement(TaskApp));
 }
 
 function setupLoginReact() {
-  const initial = readScriptJson("login-initial-data", {
-    local_admin_username: "admin",
-    error: null,
-    configured: {},
-  });
+    const initial = readScriptJson("login-initial-data", {
+        local_admin_username: "admin",
+        error: null,
+        configured: {},
+    });
 
-  function LoginApp() {
-    const h = window.React.createElement;
-    const configured = initial.configured || {};
-    return h(
-      "section",
-      { className: "card narrow card-glow login-card" },
-      h("h1", null, "⚡ 登录 AISE Web"),
-      h("p", { className: "muted" }, "支持内置管理员账号、Google 或 Microsoft 登录。"),
-      h(
-        "form",
-        { method: "post", action: "/auth/local-login", className: "stack" },
-        h("label", null, "用户名"),
-        h("input", { name: "username", required: true, defaultValue: initial.local_admin_username || "admin" }),
-        h("label", null, "密码"),
-        h("input", { name: "password", type: "password", required: true, placeholder: "请输入密码" }),
-        h("button", { className: "btn", type: "submit" }, "管理员登录")
-      ),
-      initial.error ? h("p", { className: "warning" }, initial.error) : null,
-      h("p", { className: "muted" }, ["默认内置账号: ", h("code", { key: "u" }, "admin"), " / ", h("code", { key: "p" }, "123456")]),
-      h(
-        "div",
-        { className: "auth-grid" },
-        h("a", { className: "btn", href: "/auth/google" }, "使用 Google 登录"),
-        h("a", { className: "btn", href: "/auth/microsoft" }, "使用 Microsoft 登录"),
-        configured.dev_login_enabled ? h("a", { className: "btn secondary", href: "/auth/dev-login" }, "开发环境快速登录") : null
-      ),
-      !configured.oauth_enabled ? h("p", { className: "warning" }, "未安装 OAuth 依赖，请安装 web 依赖后重试。") : null,
-      !configured.google ? h("p", { className: "warning" }, "GOOGLE_CLIENT_ID 未配置。") : null,
-      !configured.microsoft ? h("p", { className: "warning" }, "MICROSOFT_CLIENT_ID 未配置。") : null
-    );
-  }
+    function LoginApp() {
+        const h = window.React.createElement;
+        const configured = initial.configured || {};
+        return h(
+            "section",
+            { className: "card narrow card-glow login-card" },
+            h("h1", null, "⚡ 登录 AISE Web"),
+            h("p", { className: "muted" }, "支持内置管理员账号、Google 或 Microsoft 登录。"),
+            h(
+                "form",
+                { method: "post", action: "/auth/local-login", className: "stack" },
+                h("label", null, "用户名"),
+                h("input", { name: "username", required: true, defaultValue: initial.local_admin_username || "admin" }),
+                h("label", null, "密码"),
+                h("input", { name: "password", type: "password", required: true, placeholder: "请输入密码" }),
+                h("button", { className: "btn", type: "submit" }, "管理员登录")
+            ),
+            initial.error ? h("p", { className: "warning" }, initial.error) : null,
+            h("p", { className: "muted" }, ["默认内置账号: ", h("code", { key: "u" }, "admin"), " / ", h("code", { key: "p" }, "123456")]),
+            h(
+                "div",
+                { className: "auth-grid" },
+                h("a", { className: "btn", href: "/auth/google" }, "使用 Google 登录"),
+                h("a", { className: "btn", href: "/auth/microsoft" }, "使用 Microsoft 登录"),
+                configured.dev_login_enabled ? h("a", { className: "btn secondary", href: "/auth/dev-login" }, "开发环境快速登录") : null
+            ),
+            !configured.oauth_enabled ? h("p", { className: "warning" }, "未安装 OAuth 依赖，请安装 web 依赖后重试。") : null,
+            !configured.google ? h("p", { className: "warning" }, "GOOGLE_CLIENT_ID 未配置。") : null,
+            !configured.microsoft ? h("p", { className: "warning" }, "MICROSOFT_CLIENT_ID 未配置。") : null
+        );
+    }
 
-  mountReact("login-react-root", () => window.React.createElement(LoginApp));
+    mountReact("login-react-root", () => window.React.createElement(LoginApp));
 }
 
 function setupModelsConfigPage() {
-  const modelsEditor = document.getElementById("models-editor");
-  const providersEditor = document.getElementById("providers-editor");
-  const modelsInitialNode = document.getElementById("models-initial-data");
-  const providersInitialNode = document.getElementById("providers-initial-data");
-  const form = document.getElementById("models-config-form");
-  const addModelBtn = document.getElementById("add-model-btn");
-  const addProviderBtn = document.getElementById("add-provider-btn");
-  const modelsOutput = document.getElementById("models-json-input");
-  const providersOutput = document.getElementById("providers-json-input");
+    const modelsEditor = document.getElementById("models-editor");
+    const providersEditor = document.getElementById("providers-editor");
+    const modelsInitialNode = document.getElementById("models-initial-data");
+    const providersInitialNode = document.getElementById("providers-initial-data");
+    const form = document.getElementById("models-config-form");
+    const addModelBtn = document.getElementById("add-model-btn");
+    const addProviderBtn = document.getElementById("add-provider-btn");
+    const modelsOutput = document.getElementById("models-json-input");
+    const providersOutput = document.getElementById("providers-json-input");
 
-  if (!modelsEditor || !providersEditor || !modelsInitialNode || !providersInitialNode || !form || !modelsOutput || !providersOutput) return;
+    if (!modelsEditor || !providersEditor || !modelsInitialNode || !providersInitialNode || !form || !modelsOutput || !providersOutput) return;
 
-  let models = [];
-  let providers = [];
-  try {
-    models = JSON.parse(modelsInitialNode.textContent || "[]");
-  } catch {
-    models = [];
-  }
-  try {
-    providers = JSON.parse(providersInitialNode.textContent || "[]");
-  } catch {
-    providers = [];
-  }
-  if (!Array.isArray(models)) models = [];
-  if (!Array.isArray(providers)) providers = [];
+    let models = [];
+    let providers = [];
+    try {
+        models = JSON.parse(modelsInitialNode.textContent || "[]");
+    } catch {
+        models = [];
+    }
+    try {
+        providers = JSON.parse(providersInitialNode.textContent || "[]");
+    } catch {
+        providers = [];
+    }
+    if (!Array.isArray(models)) models = [];
+    if (!Array.isArray(providers)) providers = [];
 
-  function createProviderRow(provider) {
-    const row = document.createElement("div");
-    row.className = "provider-row";
-    row.innerHTML = `
+    function createProviderRow(provider) {
+        const row = document.createElement("div");
+        row.className = "provider-row";
+        row.innerHTML = `
       <input class="provider-name" placeholder="provider" value="${escapeHtml((provider && provider.provider) || "")}">
       <input class="provider-key" placeholder="api key" value="${escapeHtml((provider && provider.api_key) || "")}">
       <input class="provider-uri" placeholder="base url" value="${escapeHtml((provider && provider.base_url) || "")}">
       <label><input type="checkbox" class="provider-enabled" ${(provider && provider.enabled) !== false ? "checked" : ""}>启用</label>
       <button type="button" class="btn secondary provider-remove">删除</button>
     `;
-    row.querySelector(".provider-name")?.addEventListener("input", syncModelProviderSelectors);
-    row.querySelector(".provider-enabled")?.addEventListener("change", syncModelProviderSelectors);
-    row.querySelector(".provider-remove")?.addEventListener("click", () => {
-      row.remove();
-      syncModelProviderSelectors();
-    });
-    return row;
-  }
+        row.querySelector(".provider-name")?.addEventListener("input", syncModelProviderSelectors);
+        row.querySelector(".provider-enabled")?.addEventListener("change", syncModelProviderSelectors);
+        row.querySelector(".provider-remove")?.addEventListener("click", () => {
+            row.remove();
+            syncModelProviderSelectors();
+        });
+        return row;
+    }
 
-  function getEnabledProviderNames() {
-    return Array.from(providersEditor.querySelectorAll(".provider-row"))
-      .map((row) => ({
-        name: String(row.querySelector(".provider-name")?.value || "").trim(),
-        enabled: !!row.querySelector(".provider-enabled")?.checked,
-      }))
-      .filter((item) => item.name && item.enabled)
-      .map((item) => item.name);
-  }
+    function getEnabledProviderNames() {
+        return Array.from(providersEditor.querySelectorAll(".provider-row"))
+            .map((row) => ({
+                name: String(row.querySelector(".provider-name")?.value || "").trim(),
+                enabled: !!row.querySelector(".provider-enabled")?.checked,
+            }))
+            .filter((item) => item.name && item.enabled)
+            .map((item) => item.name);
+    }
 
-  function createModelCard(model) {
-    const card = document.createElement("div");
-    card.className = "model-card";
-    const modelValue = model || {};
-    const isLocal = !!modelValue.is_local;
-    card.innerHTML = `
+    function createModelCard(model) {
+        const card = document.createElement("div");
+        card.className = "model-card";
+        const modelValue = model || {};
+        const isLocal = !!modelValue.is_local;
+        card.innerHTML = `
       <div class="stack">
         <label>模型ID</label>
         <input class="model-id" placeholder="例如 gpt-4o" value="${escapeHtml(modelValue.id || "")}">
@@ -1719,113 +1717,113 @@ function setupModelsConfigPage() {
       </div>
     `;
 
-    const defaultSelect = card.querySelector(".model-default-provider");
-    const selectors = card.querySelector(".model-provider-selectors");
-    const localCheckbox = card.querySelector(".model-is-local");
-    const presetProviders = Array.isArray(modelValue.providers) ? modelValue.providers.map((p) => String(p)) : [];
+        const defaultSelect = card.querySelector(".model-default-provider");
+        const selectors = card.querySelector(".model-provider-selectors");
+        const localCheckbox = card.querySelector(".model-is-local");
+        const presetProviders = Array.isArray(modelValue.providers) ? modelValue.providers.map((p) => String(p)) : [];
 
-    function syncSelectors() {
-      const available = getEnabledProviderNames();
-      const currentChecked = Array.from(selectors.querySelectorAll('input[type="checkbox"]:checked')).map((el) => el.value);
-      const selected = currentChecked.length ? currentChecked : presetProviders;
-      selectors.innerHTML = available
-        .map((name) => `<label><input type="checkbox" value="${escapeHtml(name)}" ${selected.includes(name) ? "checked" : ""}> ${escapeHtml(name)}</label>`)
-        .join(" ");
-      const selectedNow = Array.from(selectors.querySelectorAll('input[type="checkbox"]:checked')).map((el) => el.value);
-      const localMode = !!localCheckbox?.checked;
-      selectors.style.display = localMode ? "none" : "block";
-      defaultSelect.disabled = localMode;
-      if (localMode) {
-        defaultSelect.innerHTML = '<option value="local">local</option>';
-        defaultSelect.value = "local";
-        return;
-      }
-      const options = selectedNow.length ? selectedNow : available;
-      defaultSelect.innerHTML = options.map((name) => `<option value="${escapeHtml(name)}">${escapeHtml(name)}</option>`).join("");
-      defaultSelect.value = options.includes(String(modelValue.default_provider || "")) ? String(modelValue.default_provider || "") : (options[0] || "");
-    }
-
-    selectors.addEventListener("change", () => syncSelectors());
-    localCheckbox?.addEventListener("change", () => syncSelectors());
-    card.querySelector(".model-remove")?.addEventListener("click", () => card.remove());
-    card.syncSelectors = syncSelectors;
-    syncSelectors();
-    return card;
-  }
-
-  function syncModelProviderSelectors() {
-    Array.from(modelsEditor.querySelectorAll(".model-card")).forEach((card) => {
-      if (typeof card.syncSelectors === "function") {
-        card.syncSelectors();
-      }
-    });
-  }
-
-  providersEditor.innerHTML = "";
-  providers.forEach((p) => providersEditor.appendChild(createProviderRow(p)));
-  if (!providers.length) {
-    providersEditor.appendChild(createProviderRow({ provider: "openai", api_key: "", base_url: "", enabled: true }));
-  }
-
-  modelsEditor.innerHTML = "";
-  models.forEach((m) => modelsEditor.appendChild(createModelCard(m)));
-  if (!models.length) {
-    modelsEditor.appendChild(createModelCard({ id: "", default: true, default_provider: "", providers: [], is_local: false }));
-  }
-
-  syncModelProviderSelectors();
-
-  addProviderBtn?.addEventListener("click", () => {
-    providersEditor.appendChild(createProviderRow({ provider: "", api_key: "", base_url: "", enabled: true }));
-  });
-
-  addModelBtn?.addEventListener("click", () => {
-    modelsEditor.appendChild(createModelCard({ id: "", default: false, default_provider: "", providers: [], is_local: false }));
-    syncModelProviderSelectors();
-  });
-
-  form.addEventListener("submit", () => {
-    const collectedProviders = Array.from(providersEditor.querySelectorAll(".provider-row"))
-      .map((row) => ({
-        provider: String(row.querySelector(".provider-name")?.value || "").trim(),
-        api_key: String(row.querySelector(".provider-key")?.value || ""),
-        base_url: String(row.querySelector(".provider-uri")?.value || ""),
-        enabled: !!row.querySelector(".provider-enabled")?.checked,
-      }))
-      .filter((p) => p.provider);
-
-    const collectedModels = Array.from(modelsEditor.querySelectorAll(".model-card"))
-      .map((card) => {
-        const isLocal = !!card.querySelector(".model-is-local")?.checked;
-        const selectedProviders = Array.from(card.querySelectorAll('.model-provider-selectors input[type="checkbox"]:checked')).map((el) => el.value);
-        return {
-          id: String(card.querySelector(".model-id")?.value || "").trim(),
-          api_model: String(card.querySelector(".model-api-model")?.value || "").trim(),
-          default: !!card.querySelector(".model-default")?.checked,
-          default_provider: String(card.querySelector(".model-default-provider")?.value || "").trim(),
-          is_local: isLocal,
-          providers: isLocal ? [] : selectedProviders,
-          extra: (() => {
-            const raw = String(card.querySelector(".model-extra")?.value || "").trim();
-            if (!raw) return {};
-            try {
-              const parsed = JSON.parse(raw);
-              return typeof parsed === "object" && parsed !== null ? parsed : {};
-            } catch {
-              return {};
+        function syncSelectors() {
+            const available = getEnabledProviderNames();
+            const currentChecked = Array.from(selectors.querySelectorAll('input[type="checkbox"]:checked')).map((el) => el.value);
+            const selected = currentChecked.length ? currentChecked : presetProviders;
+            selectors.innerHTML = available
+                .map((name) => `<label><input type="checkbox" value="${escapeHtml(name)}" ${selected.includes(name) ? "checked" : ""}> ${escapeHtml(name)}</label>`)
+                .join(" ");
+            const selectedNow = Array.from(selectors.querySelectorAll('input[type="checkbox"]:checked')).map((el) => el.value);
+            const localMode = !!localCheckbox?.checked;
+            selectors.style.display = localMode ? "none" : "block";
+            defaultSelect.disabled = localMode;
+            if (localMode) {
+                defaultSelect.innerHTML = '<option value="local">local</option>';
+                defaultSelect.value = "local";
+                return;
             }
-          })(),
-        };
-      })
-      .filter((m) => m.id);
+            const options = selectedNow.length ? selectedNow : available;
+            defaultSelect.innerHTML = options.map((name) => `<option value="${escapeHtml(name)}">${escapeHtml(name)}</option>`).join("");
+            defaultSelect.value = options.includes(String(modelValue.default_provider || "")) ? String(modelValue.default_provider || "") : (options[0] || "");
+        }
 
-    if (!collectedModels.some((m) => m.default) && collectedModels.length) {
-      collectedModels[0].default = true;
+        selectors.addEventListener("change", () => syncSelectors());
+        localCheckbox?.addEventListener("change", () => syncSelectors());
+        card.querySelector(".model-remove")?.addEventListener("click", () => card.remove());
+        card.syncSelectors = syncSelectors;
+        syncSelectors();
+        return card;
     }
 
-    providersOutput.value = JSON.stringify(collectedProviders);
-    modelsOutput.value = JSON.stringify(collectedModels);
-  });
+    function syncModelProviderSelectors() {
+        Array.from(modelsEditor.querySelectorAll(".model-card")).forEach((card) => {
+            if (typeof card.syncSelectors === "function") {
+                card.syncSelectors();
+            }
+        });
+    }
+
+    providersEditor.innerHTML = "";
+    providers.forEach((p) => providersEditor.appendChild(createProviderRow(p)));
+    if (!providers.length) {
+        providersEditor.appendChild(createProviderRow({ provider: "openai", api_key: "", base_url: "", enabled: true }));
+    }
+
+    modelsEditor.innerHTML = "";
+    models.forEach((m) => modelsEditor.appendChild(createModelCard(m)));
+    if (!models.length) {
+        modelsEditor.appendChild(createModelCard({ id: "", default: true, default_provider: "", providers: [], is_local: false }));
+    }
+
+    syncModelProviderSelectors();
+
+    addProviderBtn?.addEventListener("click", () => {
+        providersEditor.appendChild(createProviderRow({ provider: "", api_key: "", base_url: "", enabled: true }));
+    });
+
+    addModelBtn?.addEventListener("click", () => {
+        modelsEditor.appendChild(createModelCard({ id: "", default: false, default_provider: "", providers: [], is_local: false }));
+        syncModelProviderSelectors();
+    });
+
+    form.addEventListener("submit", () => {
+        const collectedProviders = Array.from(providersEditor.querySelectorAll(".provider-row"))
+            .map((row) => ({
+                provider: String(row.querySelector(".provider-name")?.value || "").trim(),
+                api_key: String(row.querySelector(".provider-key")?.value || ""),
+                base_url: String(row.querySelector(".provider-uri")?.value || ""),
+                enabled: !!row.querySelector(".provider-enabled")?.checked,
+            }))
+            .filter((p) => p.provider);
+
+        const collectedModels = Array.from(modelsEditor.querySelectorAll(".model-card"))
+            .map((card) => {
+                const isLocal = !!card.querySelector(".model-is-local")?.checked;
+                const selectedProviders = Array.from(card.querySelectorAll('.model-provider-selectors input[type="checkbox"]:checked')).map((el) => el.value);
+                return {
+                    id: String(card.querySelector(".model-id")?.value || "").trim(),
+                    api_model: String(card.querySelector(".model-api-model")?.value || "").trim(),
+                    default: !!card.querySelector(".model-default")?.checked,
+                    default_provider: String(card.querySelector(".model-default-provider")?.value || "").trim(),
+                    is_local: isLocal,
+                    providers: isLocal ? [] : selectedProviders,
+                    extra: (() => {
+                        const raw = String(card.querySelector(".model-extra")?.value || "").trim();
+                        if (!raw) return {};
+                        try {
+                            const parsed = JSON.parse(raw);
+                            return typeof parsed === "object" && parsed !== null ? parsed : {};
+                        } catch {
+                            return {};
+                        }
+                    })(),
+                };
+            })
+            .filter((m) => m.id);
+
+        if (!collectedModels.some((m) => m.default) && collectedModels.length) {
+            collectedModels[0].default = true;
+        }
+
+        providersOutput.value = JSON.stringify(collectedProviders);
+        modelsOutput.value = JSON.stringify(collectedModels);
+    });
 }
 
 /* ═══════════════════════════════════════════════════════════════
@@ -1833,303 +1831,915 @@ function setupModelsConfigPage() {
    ═══════════════════════════════════════════════════════════════ */
 
 function setupMonitorReact() {
-  const initial = readScriptJson("monitor-initial-data", { agents: [], active_runs: 0, active_retries: 0 });
+    const initial = readScriptJson("monitor-initial-data", { agents: [], active_runs: 0, active_retries: 0 });
 
-  const ROLE_LABELS = {
-    product_manager: "Product Manager",
-    architect: "Architect",
-    developer: "Developer",
-    qa_engineer: "QA Engineer",
-    project_manager: "Project Manager",
-    rd_director: "R&D Director",
-    reviewer: "Reviewer",
-  };
+    const ROLE_LABELS = {
+        product_manager: "Product Manager",
+        architect: "Architect",
+        developer: "Developer",
+        qa_engineer: "QA Engineer",
+        project_manager: "Project Manager",
+        rd_director: "R&D Director",
+        reviewer: "Reviewer",
+    };
 
-  const ROLE_ICONS = {
-    product_manager: "\uD83D\uDCCB",
-    architect: "\uD83C\uDFD7\uFE0F",
-    developer: "\uD83D\uDCBB",
-    qa_engineer: "\uD83D\uDD0D",
-    project_manager: "\uD83D\uDCC8",
-    rd_director: "\uD83C\uDFAF",
-    reviewer: "\uD83D\uDCDD",
-  };
+    const ROLE_ICONS = {
+        product_manager: "\uD83D\uDCCB",
+        architect: "\uD83C\uDFD7\uFE0F",
+        developer: "\uD83D\uDCBB",
+        qa_engineer: "\uD83D\uDD0D",
+        project_manager: "\uD83D\uDCC8",
+        rd_director: "\uD83C\uDFAF",
+        reviewer: "\uD83D\uDCDD",
+    };
 
-  const STATUS_META = {
-    working: { label: "\u6267\u884C\u4E2D", cls: "monitor-status-working" },
-    idle:    { label: "\u7A7A\u95F2",       cls: "monitor-status-idle" },
-    standby: { label: "\u5F85\u547D",       cls: "monitor-status-standby" },
-  };
+    const STATUS_META = {
+        working: { label: "\u6267\u884C\u4E2D", cls: "monitor-status-working" },
+        idle: { label: "\u7A7A\u95F2", cls: "monitor-status-idle" },
+        standby: { label: "\u5F85\u547D", cls: "monitor-status-standby" },
+    };
 
-  function MonitorApp() {
-    const h = window.React.createElement;
-    const [data, setData] = window.React.useState(initial);
-    const [selected, setSelected] = window.React.useState(null);
-    const [filter, setFilter] = window.React.useState(null); // null = all, "working" / "idle" / "standby"
+    function MonitorApp() {
+        const h = window.React.createElement;
+        const [data, setData] = window.React.useState(initial);
+        const [selected, setSelected] = window.React.useState(null);
+        const [filter, setFilter] = window.React.useState(null); // null = all, "working" / "idle" / "standby"
 
-    window.React.useEffect(() => {
-      let active = true;
-      const poll = () => {
-        fetchJson("/api/monitor")
-          .then((d) => { if (active) setData(d); })
-          .catch(() => {});
-      };
-      const tid = setInterval(poll, 3000);
-      return () => { active = false; clearInterval(tid); };
-    }, []);
+        window.React.useEffect(() => {
+            let active = true;
+            const poll = () => {
+                fetchJson("/api/monitor")
+                    .then((d) => { if (active) setData(d); })
+                    .catch(() => { });
+            };
+            const tid = setInterval(poll, 3000);
+            return () => { active = false; clearInterval(tid); };
+        }, []);
 
-    const agents = Array.isArray(data.agents) ? data.agents : [];
-    const workingCount = agents.filter((a) => a.status === "working").length;
-    const idleCount = agents.filter((a) => a.status === "idle").length;
-    const standbyCount = agents.filter((a) => a.status === "standby").length;
-    const filtered = filter ? agents.filter((a) => a.status === filter) : agents;
+        const agents = Array.isArray(data.agents) ? data.agents : [];
+        const workingCount = agents.filter((a) => a.status === "working").length;
+        const idleCount = agents.filter((a) => a.status === "idle").length;
+        const standbyCount = agents.filter((a) => a.status === "standby").length;
+        const filtered = filter ? agents.filter((a) => a.status === filter) : agents;
 
-    const toggle = (status) => setFilter((prev) => prev === status ? null : status);
+        const toggle = (status) => setFilter((prev) => prev === status ? null : status);
 
-    return h("div", { className: "monitor-container" },
-      // Header
-      h("div", { className: "monitor-header" },
-        h("h1", { className: "monitor-title" }, "Agent Monitor"),
-        h("p", { className: "monitor-subtitle" }, "\u5B9E\u65F6\u67E5\u770B Agent \u72B6\u6001\u4E0E\u4EFB\u52A1"),
-      ),
-
-      // Summary cards (clickable filter)
-      h("div", { className: "monitor-summary" },
-        h(SummaryCard, { label: "Agent \u603B\u6570", value: agents.length, cls: "summary-total", active: filter === null, onClick: () => setFilter(null) }),
-        h(SummaryCard, { label: "\u6267\u884C\u4E2D", value: workingCount, cls: "summary-working", active: filter === "working", onClick: () => toggle("working") }),
-        h(SummaryCard, { label: "\u7A7A\u95F2", value: idleCount, cls: "summary-idle", active: filter === "idle", onClick: () => toggle("idle") }),
-        h(SummaryCard, { label: "\u5F85\u547D", value: standbyCount, cls: "summary-standby", active: filter === "standby", onClick: () => toggle("standby") }),
-        h(SummaryCard, { label: "\u6D3B\u8DC3\u8FD0\u884C", value: data.active_runs || 0, cls: "summary-runs summary-info" }),
-      ),
-
-      // Agent grid (filtered)
-      filtered.length === 0
-        ? h("div", { className: "monitor-empty" },
-            filter
-              ? "\u6CA1\u6709\u5904\u4E8E\u201C" + (STATUS_META[filter] || {}).label + "\u201D\u72B6\u6001\u7684 Agent"
-              : "\u6682\u65E0\u6D3B\u8DC3 Agent\u3002\u8BF7\u5148\u521B\u5EFA\u9879\u76EE\u5E76\u63D0\u4EA4\u9700\u6C42\u3002",
-          )
-        : h("div", { className: "monitor-grid" },
-            filtered.map((agent) => h(AgentCard, { key: agent.agent_id, agent: agent, onSelect: setSelected })),
-          ),
-
-      // Detail modal
-      selected ? h(AgentDetailModal, { agent: selected, onClose: () => setSelected(null) }) : null,
-    );
-  }
-
-  function SummaryCard({ label, value, cls, active, onClick }) {
-    const h = window.React.createElement;
-    const classes = "monitor-summary-card " + (cls || "") + (active ? " monitor-summary-active" : "") + (onClick ? " monitor-summary-clickable" : "");
-    return h("div", { className: classes, onClick: onClick || null },
-      h("div", { className: "monitor-summary-value" }, value),
-      h("div", { className: "monitor-summary-label" }, label),
-    );
-  }
-
-  function AgentCard({ agent, onSelect }) {
-    const h = window.React.createElement;
-    const statusMeta = STATUS_META[agent.status] || STATUS_META.standby;
-    const roleLabel = agent.role_display || ROLE_LABELS[agent.role] || agent.role;
-    const roleIcon = ROLE_ICONS[agent.role] || "\uD83E\uDD16";
-    const modelStr = agent.model && agent.model.model ? agent.model.model : "\u672A\u914D\u7F6E";
-    const task = agent.current_task;
-    const isRuntime = agent.source === "runtime";
-
-    return h("div", {
-      className: "monitor-agent-card monitor-agent-card-clickable " + statusMeta.cls,
-      onClick: () => onSelect && onSelect(agent),
-    },
-      // Card header
-      h("div", { className: "monitor-agent-header" },
-        h("span", { className: "monitor-agent-icon" }, roleIcon),
-        h("div", { className: "monitor-agent-identity" },
-          h("div", { className: "monitor-agent-name" },
-            agent.name,
-            isRuntime ? h("span", { className: "monitor-source-tag" }, "Runtime") : null,
-          ),
-          h("div", { className: "monitor-agent-role" }, roleLabel),
-        ),
-        h("span", { className: "monitor-agent-status-badge" }, statusMeta.label),
-      ),
-
-      // Card body
-      h("div", { className: "monitor-agent-body" },
-        // Project (only for project-bound agents)
-        agent.project_id
-          ? h("div", { className: "monitor-agent-field" },
-              h("span", { className: "monitor-field-label" }, "\u9879\u76EE"),
-              h("span", { className: "monitor-field-value" },
-                h("a", { href: "/projects/" + agent.project_id }, agent.project_name),
-              ),
-            )
-          : null,
-        // Model
-        h("div", { className: "monitor-agent-field" },
-          h("span", { className: "monitor-field-label" }, "\u6A21\u578B"),
-          h("span", { className: "monitor-field-value monitor-model-tag" }, modelStr),
-        ),
-        // Skills
-        h("div", { className: "monitor-agent-field" },
-          h("span", { className: "monitor-field-label" }, "\u6280\u80FD"),
-          h("div", { className: "monitor-skills-list" },
-            (agent.skills || []).length > 0
-              ? agent.skills.map((s) => h("span", { key: s, className: "monitor-skill-tag" }, s))
-              : h("span", { className: "monitor-field-muted" }, "\u65E0"),
-          ),
-        ),
-      ),
-
-      // Current task
-      task
-        ? h("div", { className: "monitor-agent-task" },
-            h("div", { className: "monitor-task-header" },
-              h("span", { className: "monitor-task-pulse" }),
-              h("span", null, "\u5F53\u524D\u4EFB\u52A1"),
+        return h("div", { className: "monitor-container" },
+            // Header
+            h("div", { className: "monitor-header" },
+                h("h1", { className: "monitor-title" }, "Agent Monitor"),
+                h("p", { className: "monitor-subtitle" }, "\u5B9E\u65F6\u67E5\u770B Agent \u72B6\u6001\u4E0E\u4EFB\u52A1"),
             ),
-            h("div", { className: "monitor-task-name" }, task.display_name || task.task_key),
-            task.phase
-              ? h("div", { className: "monitor-task-phase" }, "\u9636\u6BB5: " + task.phase)
-              : null,
-          )
-        : null,
-    );
-  }
 
-  function AgentDetailModal({ agent, onClose }) {
-    const h = window.React.createElement;
-    const card = agent.agent_card || {};
-    const roleLabel = agent.role_display || ROLE_LABELS[agent.role] || agent.role;
-    const roleIcon = ROLE_ICONS[agent.role] || "\uD83E\uDD16";
-    const skills = card.skills || [];
-    const caps = card.capabilities || {};
-    const modelInfo = card.model || agent.model || {};
-    const provider = card.provider || {};
-
-    return h("div", { className: "monitor-modal-overlay", onClick: (e) => { if (e.target === e.currentTarget) onClose(); } },
-      h("div", { className: "monitor-modal" },
-        // Modal header
-        h("div", { className: "monitor-modal-header" },
-          h("div", { className: "monitor-modal-title-row" },
-            h("span", { className: "monitor-agent-icon" }, roleIcon),
-            h("div", null,
-              h("h2", { className: "monitor-modal-title" }, card.name || agent.name),
-              h("div", { className: "monitor-modal-role" }, roleLabel),
+            // Summary cards (clickable filter)
+            h("div", { className: "monitor-summary" },
+                h(SummaryCard, { label: "Agent \u603B\u6570", value: agents.length, cls: "summary-total", active: filter === null, onClick: () => setFilter(null) }),
+                h(SummaryCard, { label: "\u6267\u884C\u4E2D", value: workingCount, cls: "summary-working", active: filter === "working", onClick: () => toggle("working") }),
+                h(SummaryCard, { label: "\u7A7A\u95F2", value: idleCount, cls: "summary-idle", active: filter === "idle", onClick: () => toggle("idle") }),
+                h(SummaryCard, { label: "\u5F85\u547D", value: standbyCount, cls: "summary-standby", active: filter === "standby", onClick: () => toggle("standby") }),
+                h(SummaryCard, { label: "\u6D3B\u8DC3\u8FD0\u884C", value: data.active_runs || 0, cls: "summary-runs summary-info" }),
             ),
-          ),
-          h("button", { className: "monitor-modal-close", onClick: onClose }, "\u00D7"),
-        ),
 
-        // Modal body
-        h("div", { className: "monitor-modal-body" },
-
-          // Description
-          card.description
-            ? h("div", { className: "monitor-modal-section" },
-                h("div", { className: "monitor-modal-section-title" }, "Description"),
-                h("p", { className: "monitor-modal-text" }, card.description),
-              )
-            : null,
-
-          // Model info
-          h("div", { className: "monitor-modal-section" },
-            h("div", { className: "monitor-modal-section-title" }, "Model"),
-            h("div", { className: "monitor-modal-kv-grid" },
-              h("span", { className: "monitor-modal-kv-label" }, "Provider"),
-              h("span", { className: "monitor-modal-kv-value" }, modelInfo.provider || "-"),
-              h("span", { className: "monitor-modal-kv-label" }, "Model"),
-              h("code", { className: "monitor-modal-kv-value monitor-model-tag" }, modelInfo.model || "-"),
-              modelInfo.temperature != null
-                ? [
-                    h("span", { key: "t-l", className: "monitor-modal-kv-label" }, "Temperature"),
-                    h("span", { key: "t-v", className: "monitor-modal-kv-value" }, modelInfo.temperature),
-                  ]
-                : null,
-              modelInfo.maxTokens != null
-                ? [
-                    h("span", { key: "m-l", className: "monitor-modal-kv-label" }, "Max Tokens"),
-                    h("span", { key: "m-v", className: "monitor-modal-kv-value" }, modelInfo.maxTokens),
-                  ]
-                : null,
-            ),
-          ),
-
-          // Capabilities
-          h("div", { className: "monitor-modal-section" },
-            h("div", { className: "monitor-modal-section-title" }, "Capabilities"),
-            h("div", { className: "monitor-modal-caps" },
-              Object.entries(caps).map(([k, v]) =>
-                h("span", { key: k, className: "monitor-modal-cap-tag " + (v ? "cap-on" : "cap-off") },
-                  (v ? "\u2713 " : "\u2717 ") + k,
-                ),
-              ),
-            ),
-          ),
-
-          // Provider
-          provider.organization
-            ? h("div", { className: "monitor-modal-section" },
-                h("div", { className: "monitor-modal-section-title" }, "Provider"),
-                h("div", { className: "monitor-modal-text" }, provider.organization + (provider.url ? " \u00B7 " + provider.url : "")),
-              )
-            : null,
-
-          // Protocol info
-          h("div", { className: "monitor-modal-section" },
-            h("div", { className: "monitor-modal-section-title" }, "Protocol"),
-            h("div", { className: "monitor-modal-kv-grid" },
-              h("span", { className: "monitor-modal-kv-label" }, "Version"),
-              h("span", { className: "monitor-modal-kv-value" }, card.version || "1.0.0"),
-              h("span", { className: "monitor-modal-kv-label" }, "Input Modes"),
-              h("span", { className: "monitor-modal-kv-value" }, (card.defaultInputModes || ["text"]).join(", ")),
-              h("span", { className: "monitor-modal-kv-label" }, "Output Modes"),
-              h("span", { className: "monitor-modal-kv-value" }, (card.defaultOutputModes || ["text"]).join(", ")),
-            ),
-          ),
-
-          // Skills detail table
-          h("div", { className: "monitor-modal-section" },
-            h("div", { className: "monitor-modal-section-title" }, "Skills (" + skills.length + ")"),
-            skills.length > 0
-              ? h("table", { className: "monitor-modal-skills-table" },
-                  h("thead", null,
-                    h("tr", null,
-                      h("th", null, "ID"),
-                      h("th", null, "Name"),
-                      h("th", null, "Description"),
-                    ),
-                  ),
-                  h("tbody", null,
-                    skills.map((s) =>
-                      h("tr", { key: s.id },
-                        h("td", null, h("code", null, s.id)),
-                        h("td", null, s.name),
-                        h("td", null, s.description || "-"),
-                      ),
-                    ),
-                  ),
+            // Agent grid (filtered)
+            filtered.length === 0
+                ? h("div", { className: "monitor-empty" },
+                    filter
+                        ? "\u6CA1\u6709\u5904\u4E8E\u201C" + (STATUS_META[filter] || {}).label + "\u201D\u72B6\u6001\u7684 Agent"
+                        : "\u6682\u65E0\u6D3B\u8DC3 Agent\u3002\u8BF7\u5148\u521B\u5EFA\u9879\u76EE\u5E76\u63D0\u4EA4\u9700\u6C42\u3002",
                 )
-              : h("div", { className: "monitor-field-muted" }, "\u65E0\u6280\u80FD"),
-          ),
-        ),
-      ),
-    );
-  }
+                : h("div", { className: "monitor-grid" },
+                    filtered.map((agent) => h(AgentCard, { key: agent.agent_id, agent: agent, onSelect: setSelected })),
+                ),
 
-  mountReact("monitor-react-root", () => window.React.createElement(MonitorApp));
+            // Detail modal
+            selected ? h(AgentDetailModal, { agent: selected, onClose: () => setSelected(null) }) : null,
+        );
+    }
+
+    function SummaryCard({ label, value, cls, active, onClick }) {
+        const h = window.React.createElement;
+        const classes = "monitor-summary-card " + (cls || "") + (active ? " monitor-summary-active" : "") + (onClick ? " monitor-summary-clickable" : "");
+        return h("div", { className: classes, onClick: onClick || null },
+            h("div", { className: "monitor-summary-value" }, value),
+            h("div", { className: "monitor-summary-label" }, label),
+        );
+    }
+
+    function AgentCard({ agent, onSelect }) {
+        const h = window.React.createElement;
+        const statusMeta = STATUS_META[agent.status] || STATUS_META.standby;
+        const roleLabel = agent.role_display || ROLE_LABELS[agent.role] || agent.role;
+        const roleIcon = ROLE_ICONS[agent.role] || "\uD83E\uDD16";
+        const modelStr = agent.model && agent.model.model ? agent.model.model : "\u672A\u914D\u7F6E";
+        const task = agent.current_task;
+        const isRuntime = agent.source === "runtime";
+
+        return h("div", {
+            className: "monitor-agent-card monitor-agent-card-clickable " + statusMeta.cls,
+            onClick: () => onSelect && onSelect(agent),
+        },
+            // Card header
+            h("div", { className: "monitor-agent-header" },
+                h("span", { className: "monitor-agent-icon" }, roleIcon),
+                h("div", { className: "monitor-agent-identity" },
+                    h("div", { className: "monitor-agent-name" },
+                        agent.name,
+                        isRuntime ? h("span", { className: "monitor-source-tag" }, "Runtime") : null,
+                    ),
+                    h("div", { className: "monitor-agent-role" }, roleLabel),
+                ),
+                h("span", { className: "monitor-agent-status-badge" }, statusMeta.label),
+            ),
+
+            // Card body
+            h("div", { className: "monitor-agent-body" },
+                // Project (only for project-bound agents)
+                agent.project_id
+                    ? h("div", { className: "monitor-agent-field" },
+                        h("span", { className: "monitor-field-label" }, "\u9879\u76EE"),
+                        h("span", { className: "monitor-field-value" },
+                            h("a", { href: "/projects/" + agent.project_id }, agent.project_name),
+                        ),
+                    )
+                    : null,
+                // Model
+                h("div", { className: "monitor-agent-field" },
+                    h("span", { className: "monitor-field-label" }, "\u6A21\u578B"),
+                    h("span", { className: "monitor-field-value monitor-model-tag" }, modelStr),
+                ),
+                // Skills
+                h("div", { className: "monitor-agent-field" },
+                    h("span", { className: "monitor-field-label" }, "\u6280\u80FD"),
+                    h("div", { className: "monitor-skills-list" },
+                        (agent.skills || []).length > 0
+                            ? agent.skills.map((s) => h("span", { key: s, className: "monitor-skill-tag" }, s))
+                            : h("span", { className: "monitor-field-muted" }, "\u65E0"),
+                    ),
+                ),
+            ),
+
+            // Current task
+            task
+                ? h("div", { className: "monitor-agent-task" },
+                    h("div", { className: "monitor-task-header" },
+                        h("span", { className: "monitor-task-pulse" }),
+                        h("span", null, "\u5F53\u524D\u4EFB\u52A1"),
+                    ),
+                    h("div", { className: "monitor-task-name" }, task.display_name || task.task_key),
+                    task.phase
+                        ? h("div", { className: "monitor-task-phase" }, "\u9636\u6BB5: " + task.phase)
+                        : null,
+                )
+                : null,
+        );
+    }
+
+    function AgentDetailModal({ agent, onClose }) {
+        const h = window.React.createElement;
+        const card = agent.agent_card || {};
+        const roleLabel = agent.role_display || ROLE_LABELS[agent.role] || agent.role;
+        const roleIcon = ROLE_ICONS[agent.role] || "\uD83E\uDD16";
+        const skills = card.skills || [];
+        const caps = card.capabilities || {};
+        const modelInfo = card.model || agent.model || {};
+        const provider = card.provider || {};
+
+        return h("div", { className: "monitor-modal-overlay", onClick: (e) => { if (e.target === e.currentTarget) onClose(); } },
+            h("div", { className: "monitor-modal" },
+                // Modal header
+                h("div", { className: "monitor-modal-header" },
+                    h("div", { className: "monitor-modal-title-row" },
+                        h("span", { className: "monitor-agent-icon" }, roleIcon),
+                        h("div", null,
+                            h("h2", { className: "monitor-modal-title" }, card.name || agent.name),
+                            h("div", { className: "monitor-modal-role" }, roleLabel),
+                        ),
+                    ),
+                    h("button", { className: "monitor-modal-close", onClick: onClose }, "\u00D7"),
+                ),
+
+                // Modal body
+                h("div", { className: "monitor-modal-body" },
+
+                    // Description
+                    card.description
+                        ? h("div", { className: "monitor-modal-section" },
+                            h("div", { className: "monitor-modal-section-title" }, "Description"),
+                            h("p", { className: "monitor-modal-text" }, card.description),
+                        )
+                        : null,
+
+                    // Model info
+                    h("div", { className: "monitor-modal-section" },
+                        h("div", { className: "monitor-modal-section-title" }, "Model"),
+                        h("div", { className: "monitor-modal-kv-grid" },
+                            h("span", { className: "monitor-modal-kv-label" }, "Provider"),
+                            h("span", { className: "monitor-modal-kv-value" }, modelInfo.provider || "-"),
+                            h("span", { className: "monitor-modal-kv-label" }, "Model"),
+                            h("code", { className: "monitor-modal-kv-value monitor-model-tag" }, modelInfo.model || "-"),
+                            modelInfo.temperature != null
+                                ? [
+                                    h("span", { key: "t-l", className: "monitor-modal-kv-label" }, "Temperature"),
+                                    h("span", { key: "t-v", className: "monitor-modal-kv-value" }, modelInfo.temperature),
+                                ]
+                                : null,
+                            modelInfo.maxTokens != null
+                                ? [
+                                    h("span", { key: "m-l", className: "monitor-modal-kv-label" }, "Max Tokens"),
+                                    h("span", { key: "m-v", className: "monitor-modal-kv-value" }, modelInfo.maxTokens),
+                                ]
+                                : null,
+                        ),
+                    ),
+
+                    // Capabilities
+                    h("div", { className: "monitor-modal-section" },
+                        h("div", { className: "monitor-modal-section-title" }, "Capabilities"),
+                        h("div", { className: "monitor-modal-caps" },
+                            Object.entries(caps).map(([k, v]) =>
+                                h("span", { key: k, className: "monitor-modal-cap-tag " + (v ? "cap-on" : "cap-off") },
+                                    (v ? "\u2713 " : "\u2717 ") + k,
+                                ),
+                            ),
+                        ),
+                    ),
+
+                    // Provider
+                    provider.organization
+                        ? h("div", { className: "monitor-modal-section" },
+                            h("div", { className: "monitor-modal-section-title" }, "Provider"),
+                            h("div", { className: "monitor-modal-text" }, provider.organization + (provider.url ? " \u00B7 " + provider.url : "")),
+                        )
+                        : null,
+
+                    // Protocol info
+                    h("div", { className: "monitor-modal-section" },
+                        h("div", { className: "monitor-modal-section-title" }, "Protocol"),
+                        h("div", { className: "monitor-modal-kv-grid" },
+                            h("span", { className: "monitor-modal-kv-label" }, "Version"),
+                            h("span", { className: "monitor-modal-kv-value" }, card.version || "1.0.0"),
+                            h("span", { className: "monitor-modal-kv-label" }, "Input Modes"),
+                            h("span", { className: "monitor-modal-kv-value" }, (card.defaultInputModes || ["text"]).join(", ")),
+                            h("span", { className: "monitor-modal-kv-label" }, "Output Modes"),
+                            h("span", { className: "monitor-modal-kv-value" }, (card.defaultOutputModes || ["text"]).join(", ")),
+                        ),
+                    ),
+
+                    // Skills detail table
+                    h("div", { className: "monitor-modal-section" },
+                        h("div", { className: "monitor-modal-section-title" }, "Skills (" + skills.length + ")"),
+                        skills.length > 0
+                            ? h("table", { className: "monitor-modal-skills-table" },
+                                h("thead", null,
+                                    h("tr", null,
+                                        h("th", null, "ID"),
+                                        h("th", null, "Name"),
+                                        h("th", null, "Description"),
+                                    ),
+                                ),
+                                h("tbody", null,
+                                    skills.map((s) =>
+                                        h("tr", { key: s.id },
+                                            h("td", null, h("code", null, s.id)),
+                                            h("td", null, s.name),
+                                            h("td", null, s.description || "-"),
+                                        ),
+                                    ),
+                                ),
+                            )
+                            : h("div", { className: "monitor-field-muted" }, "\u65E0\u6280\u80FD"),
+                    ),
+                ),
+            ),
+        );
+    }
+
+    mountReact("monitor-react-root", () => window.React.createElement(MonitorApp));
 }
 
+// ---------------------------------------------------------------------------
+// Users management page
+// ---------------------------------------------------------------------------
+function setupUsersReact() {
+    const rootNode = document.getElementById("users-react-root");
+    if (!rootNode || !window.React || !window.ReactDOM) return;
+    const h = window.React.createElement;
+
+    function UsersApp() {
+        const [users, setUsers] = window.React.useState([]);
+        const [roles, setRoles] = window.React.useState([]);
+        const [loading, setLoading] = window.React.useState(true);
+        const [error, setError] = window.React.useState("");
+        const [editingUser, setEditingUser] = window.React.useState(null);
+        const [passwordUser, setPasswordUser] = window.React.useState(null);
+        const [showCreate, setShowCreate] = window.React.useState(false);
+        const [me, setMe] = window.React.useState(null);
+
+        async function refresh() {
+            setError("");
+            try {
+                const [u, m] = await Promise.all([
+                    fetchJson("/api/users"),
+                    fetchJson("/api/users/me"),
+                ]);
+                setUsers(Array.isArray(u.users) ? u.users : []);
+                setRoles(Array.isArray(u.roles) ? u.roles : []);
+                setMe(m.user || null);
+            } catch (err) {
+                setError(err instanceof Error ? err.message : "加载失败");
+            } finally {
+                setLoading(false);
+            }
+        }
+
+        window.React.useEffect(() => { refresh(); }, []);
+
+        function roleDisplay(roleKey) {
+            const r = roles.find((x) => x.key === roleKey);
+            if (!r) return roleKey;
+            return currentLang() === "en" ? r.display_name_en : r.display_name_zh;
+        }
+
+        function localeLabel(zh, en) {
+            return currentLang() === "en" ? en : zh;
+        }
+
+        async function deleteUser(user) {
+            if (!window.confirm(localeLabel("确认删除用户 " + user.username + "？", "Delete user " + user.username + "?"))) return;
+            try {
+                await fetchJson("/api/users/" + encodeURIComponent(user.id), { method: "DELETE" });
+                await refresh();
+            } catch (err) {
+                setError(err instanceof Error ? err.message : "删除失败");
+            }
+        }
+
+        async function toggleEnabled(user) {
+            try {
+                await fetchJson("/api/users/" + encodeURIComponent(user.id), {
+                    method: "PUT",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ enabled: !user.enabled }),
+                });
+                await refresh();
+            } catch (err) {
+                setError(err instanceof Error ? err.message : "更新失败");
+            }
+        }
+
+        const createForm = showCreate ? h(UserFormModal, {
+            key: "create",
+            roles: roles,
+            title: localeLabel("新建用户", "Create user"),
+            onClose: () => setShowCreate(false),
+            onSubmit: async (data) => {
+                try {
+                    await fetchJson("/api/users", {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify(data),
+                    });
+                    setShowCreate(false);
+                    await refresh();
+                } catch (err) {
+                    setError(err instanceof Error ? err.message : "创建失败");
+                }
+            },
+            withPassword: true,
+        }) : null;
+
+        const editForm = editingUser ? h(UserFormModal, {
+            key: "edit-" + editingUser.id,
+            roles: roles,
+            title: localeLabel("编辑用户", "Edit user"),
+            initial: editingUser,
+            onClose: () => setEditingUser(null),
+            onSubmit: async (data) => {
+                try {
+                    const payload = {
+                        email: data.email,
+                        display_name: data.display_name,
+                        role: data.role,
+                        enabled: data.enabled,
+                        notes: data.notes,
+                    };
+                    await fetchJson("/api/users/" + encodeURIComponent(editingUser.id), {
+                        method: "PUT",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify(payload),
+                    });
+                    setEditingUser(null);
+                    await refresh();
+                } catch (err) {
+                    setError(err instanceof Error ? err.message : "更新失败");
+                }
+            },
+            withPassword: false,
+        }) : null;
+
+        const passwordForm = passwordUser ? h(PasswordModal, {
+            key: "pw-" + passwordUser.id,
+            user: passwordUser,
+            onClose: () => setPasswordUser(null),
+            onSubmit: async (pw) => {
+                try {
+                    await fetchJson("/api/users/" + encodeURIComponent(passwordUser.id) + "/password", {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify({ password: pw }),
+                    });
+                    setPasswordUser(null);
+                } catch (err) {
+                    setError(err instanceof Error ? err.message : "密码设置失败");
+                }
+            },
+        }) : null;
+
+        return h("div", { className: "dashboard-shell" },
+            h("div", { className: "dashboard-topbar" },
+                h("div", { className: "dashboard-topbar-left" },
+                    h("h1", { className: "dashboard-title" }, localeLabel("用户与角色", "Users & Roles")),
+                    h("div", { className: "dashboard-stats" },
+                        h("span", { className: "stat-chip" }, localeLabel("共 ", "Total ") + users.length),
+                    ),
+                ),
+                h("button", { className: "btn create-project-btn", onClick: () => setShowCreate(true) }, localeLabel("＋ 新建用户", "＋ New user")),
+            ),
+            error ? h("div", { className: "dashboard-error" }, error) : null,
+            h("div", { className: "card", style: { padding: "12px" } },
+                h("h3", { style: { margin: "0 0 8px" } }, localeLabel("角色矩阵", "Role matrix")),
+                h("table", { className: "users-roles-table" },
+                    h("thead", null,
+                        h("tr", null,
+                            h("th", null, localeLabel("角色", "Role")),
+                            h("th", null, localeLabel("权限", "Permissions")),
+                            h("th", null, localeLabel("说明", "Description")),
+                        ),
+                    ),
+                    h("tbody", null,
+                        roles.map((r) => h("tr", { key: r.key },
+                            h("td", null, h("span", { className: "role-tag" }, roleDisplay(r.key))),
+                            h("td", null, (r.permissions || []).join(", ")),
+                            h("td", null, currentLang() === "en" ? r.description_en : r.description_zh),
+                        )),
+                    ),
+                ),
+            ),
+            loading ? h("p", { className: "muted" }, localeLabel("加载中...", "Loading...")) :
+                h("div", { className: "card", style: { marginTop: "16px" } },
+                    h("table", { className: "users-table" },
+                        h("thead", null,
+                            h("tr", null,
+                                h("th", null, localeLabel("用户名", "Username")),
+                                h("th", null, localeLabel("姓名", "Name")),
+                                h("th", null, localeLabel("邮箱", "Email")),
+                                h("th", null, localeLabel("角色", "Role")),
+                                h("th", null, localeLabel("来源", "Provider")),
+                                h("th", null, localeLabel("状态", "Status")),
+                                h("th", null, localeLabel("最近登录", "Last login")),
+                                h("th", null, localeLabel("操作", "Actions")),
+                            ),
+                        ),
+                        h("tbody", null,
+                            users.map((u) => {
+                                const isSelf = me && me.id === u.id;
+                                return h("tr", { key: u.id },
+                                    h("td", null, u.username, isSelf ? h("span", { className: "role-tag", style: { marginLeft: "6px" } }, localeLabel("你", "You")) : null),
+                                    h("td", null, u.display_name || u.username),
+                                    h("td", null, u.email || "-"),
+                                    h("td", null, h("span", { className: "role-tag" }, roleDisplay(u.role))),
+                                    h("td", null, u.provider || "local"),
+                                    h("td", null, u.enabled ? h("span", { className: "status-badge status-success" }, localeLabel("启用", "Enabled")) : h("span", { className: "status-badge status-failed" }, localeLabel("禁用", "Disabled"))),
+                                    h("td", { className: "muted" }, u.last_login_at || "-"),
+                                    h("td", null,
+                                        h("button", { className: "btn secondary btn-sm", onClick: () => setEditingUser(u), style: { marginRight: "4px" } }, localeLabel("编辑", "Edit")),
+                                        u.provider === "local" ? h("button", { className: "btn secondary btn-sm", onClick: () => setPasswordUser(u), style: { marginRight: "4px" } }, localeLabel("改密", "Password")) : null,
+                                        h("button", { className: "btn secondary btn-sm", onClick: () => toggleEnabled(u), style: { marginRight: "4px" } }, u.enabled ? localeLabel("停用", "Disable") : localeLabel("启用", "Enable")),
+                                        !isSelf ? h("button", { className: "btn danger btn-sm", onClick: () => deleteUser(u) }, localeLabel("删除", "Delete")) : null,
+                                    ),
+                                );
+                            }),
+                        ),
+                    ),
+                ),
+            createForm, editForm, passwordForm,
+        );
+    }
+
+    function UserFormModal(props) {
+        const roles = props.roles;
+        const initial = props.initial;
+        const withPassword = props.withPassword;
+        const [data, setData] = window.React.useState(() => ({
+            username: (initial && initial.username) || "",
+            email: (initial && initial.email) || "",
+            display_name: (initial && initial.display_name) || "",
+            role: (initial && initial.role) || "viewer",
+            password: "",
+            enabled: initial ? !!initial.enabled : true,
+            notes: (initial && initial.notes) || "",
+        }));
+        const [err, setErr] = window.React.useState("");
+        const localeLabel = (zh, en) => currentLang() === "en" ? en : zh;
+        return h("div", {
+            className: "modal-overlay",
+            onClick: (e) => { if (e.target === e.currentTarget) props.onClose(); },
+        },
+            h("div", { className: "modal-content" },
+                h("div", { className: "modal-header" },
+                    h("h2", null, props.title),
+                    h("button", { className: "modal-close", onClick: props.onClose }, "×"),
+                ),
+                h("form", {
+                    className: "modal-form",
+                    onSubmit: async (e) => {
+                        e.preventDefault();
+                        setErr("");
+                        try {
+                            await props.onSubmit(data);
+                        } catch (x) {
+                            setErr(x instanceof Error ? x.message : String(x));
+                        }
+                    },
+                },
+                    initial ? null : h("label", null, localeLabel("用户名", "Username")),
+                    initial ? null : h("input", {
+                        required: true,
+                        value: data.username,
+                        onChange: (e) => setData({ ...data, username: e.target.value }),
+                    }),
+                    h("label", null, localeLabel("显示名", "Display name")),
+                    h("input", {
+                        value: data.display_name,
+                        onChange: (e) => setData({ ...data, display_name: e.target.value }),
+                    }),
+                    h("label", null, localeLabel("邮箱", "Email")),
+                    h("input", {
+                        type: "email",
+                        value: data.email,
+                        onChange: (e) => setData({ ...data, email: e.target.value }),
+                    }),
+                    h("label", null, localeLabel("角色", "Role")),
+                    h("select", {
+                        value: data.role,
+                        onChange: (e) => setData({ ...data, role: e.target.value }),
+                    },
+                        roles.map((r) => h("option", { key: r.key, value: r.key }, currentLang() === "en" ? r.display_name_en : r.display_name_zh)),
+                    ),
+                    withPassword ? h("label", null, localeLabel("初始密码", "Initial password")) : null,
+                    withPassword ? h("input", {
+                        type: "password",
+                        required: true,
+                        value: data.password,
+                        onChange: (e) => setData({ ...data, password: e.target.value }),
+                    }) : null,
+                    h("label", { style: { display: "flex", alignItems: "center", gap: "6px", marginTop: "10px" } },
+                        h("input", {
+                            type: "checkbox",
+                            checked: !!data.enabled,
+                            onChange: (e) => setData({ ...data, enabled: e.target.checked }),
+                        }),
+                        localeLabel("启用", "Enabled"),
+                    ),
+                    h("label", null, localeLabel("备注", "Notes")),
+                    h("textarea", {
+                        rows: 2,
+                        value: data.notes,
+                        onChange: (e) => setData({ ...data, notes: e.target.value }),
+                    }),
+                    err ? h("p", { className: "warning" }, err) : null,
+                    h("div", { className: "modal-actions" },
+                        h("button", { type: "button", className: "btn secondary", onClick: props.onClose }, localeLabel("取消", "Cancel")),
+                        h("button", { type: "submit", className: "btn" }, localeLabel("保存", "Save")),
+                    ),
+                ),
+            ),
+        );
+    }
+
+    function PasswordModal(props) {
+        const user = props.user;
+        const [pw, setPw] = window.React.useState("");
+        const [pw2, setPw2] = window.React.useState("");
+        const [err, setErr] = window.React.useState("");
+        const localeLabel = (zh, en) => currentLang() === "en" ? en : zh;
+        return h("div", {
+            className: "modal-overlay",
+            onClick: (e) => { if (e.target === e.currentTarget) props.onClose(); },
+        },
+            h("div", { className: "modal-content" },
+                h("div", { className: "modal-header" },
+                    h("h2", null, localeLabel("修改密码 — ", "Change password — ") + user.username),
+                    h("button", { className: "modal-close", onClick: props.onClose }, "×"),
+                ),
+                h("form", {
+                    className: "modal-form",
+                    onSubmit: async (e) => {
+                        e.preventDefault();
+                        if (pw !== pw2) { setErr(localeLabel("两次密码不一致", "Passwords do not match")); return; }
+                        if (pw.length < 4) { setErr(localeLabel("密码至少 4 位", "Password must be at least 4 chars")); return; }
+                        setErr("");
+                        try {
+                            await props.onSubmit(pw);
+                        } catch (x) {
+                            setErr(x instanceof Error ? x.message : String(x));
+                        }
+                    },
+                },
+                    h("label", null, localeLabel("新密码", "New password")),
+                    h("input", {
+                        type: "password",
+                        required: true,
+                        value: pw,
+                        onChange: (e) => setPw(e.target.value),
+                    }),
+                    h("label", null, localeLabel("确认密码", "Confirm password")),
+                    h("input", {
+                        type: "password",
+                        required: true,
+                        value: pw2,
+                        onChange: (e) => setPw2(e.target.value),
+                    }),
+                    err ? h("p", { className: "warning" }, err) : null,
+                    h("div", { className: "modal-actions" },
+                        h("button", { type: "button", className: "btn secondary", onClick: props.onClose }, localeLabel("取消", "Cancel")),
+                        h("button", { type: "submit", className: "btn" }, localeLabel("保存", "Save")),
+                    ),
+                ),
+            ),
+        );
+    }
+
+    const root = window.ReactDOM.createRoot(rootNode);
+    root.render(h(UsersApp));
+}
+
+// ---------------------------------------------------------------------------
+// Logs viewer page
+// ---------------------------------------------------------------------------
+function setupLogsReact() {
+    const rootNode = document.getElementById("logs-react-root");
+    if (!rootNode || !window.React || !window.ReactDOM) return;
+    const h = window.React.createElement;
+
+    function LogsApp() {
+        const [files, setFiles] = window.React.useState([]);
+        const [logDir, setLogDir] = window.React.useState("");
+        const [filename, setFilename] = window.React.useState("");
+        const [records, setRecords] = window.React.useState([]);
+        const [totalScanned, setTotalScanned] = window.React.useState(0);
+        const [loading, setLoading] = window.React.useState(false);
+        const [error, setError] = window.React.useState("");
+        const [analysis, setAnalysis] = window.React.useState("");
+        const [analyzing, setAnalyzing] = window.React.useState(false);
+        const [filters, setFilters] = window.React.useState({
+            level: "",
+            logger: "",
+            q: "",
+            since: "",
+            until: "",
+            limit: 500,
+        });
+        const [focus, setFocus] = window.React.useState("");
+        const [selected, setSelected] = window.React.useState(new Set());
+        const [autoRefresh, setAutoRefresh] = window.React.useState(false);
+        const [me, setMe] = window.React.useState(null);
+        const localeLabel = (zh, en) => currentLang() === "en" ? en : zh;
+
+        async function refreshFiles() {
+            try {
+                const data = await fetchJson("/api/logs/files");
+                setFiles(Array.isArray(data.files) ? data.files : []);
+                setLogDir(String(data.log_dir || ""));
+                if (!filename && data.files && data.files.length) {
+                    setFilename(data.files[0].name);
+                }
+            } catch (err) {
+                setError(err instanceof Error ? err.message : "加载失败");
+            }
+        }
+
+        async function loadRecords() {
+            if (!filename) return;
+            setLoading(true); setError("");
+            try {
+                const params = new URLSearchParams({ filename });
+                if (filters.level) params.set("level", filters.level);
+                if (filters.logger) params.set("logger", filters.logger);
+                if (filters.q) params.set("q", filters.q);
+                if (filters.since) params.set("since", filters.since);
+                if (filters.until) params.set("until", filters.until);
+                params.set("limit", String(filters.limit || 500));
+                const data = await fetchJson("/api/logs/tail?" + params.toString());
+                setRecords(Array.isArray(data.records) ? data.records : []);
+                setTotalScanned(Number(data.total_scanned || 0));
+                setSelected(new Set());
+            } catch (err) {
+                setError(err instanceof Error ? err.message : "加载失败");
+            } finally {
+                setLoading(false);
+            }
+        }
+
+        window.React.useEffect(() => {
+            refreshFiles();
+            fetchJson("/api/users/me").then((d) => setMe(d.user || null)).catch(() => { });
+        }, []);
+        window.React.useEffect(() => { loadRecords(); }, [filename]);
+        window.React.useEffect(() => {
+            if (!autoRefresh) return;
+            const id = window.setInterval(loadRecords, 5000);
+            return () => window.clearInterval(id);
+        }, [autoRefresh, filename, filters]);
+
+        function toggleSelect(idx) {
+            setSelected((prev) => {
+                const next = new Set(prev);
+                if (next.has(idx)) next.delete(idx); else next.add(idx);
+                return next;
+            });
+        }
+        function selectAll() {
+            setSelected(new Set(records.map((_, i) => i)));
+        }
+        function selectNone() { setSelected(new Set()); }
+
+        async function runAnalysis() {
+            let text = "";
+            if (selected.size) {
+                text = Array.from(selected).sort((a, b) => a - b).map((i) => records[i].raw).join("\n");
+            } else {
+                text = records.map((r) => r.raw).join("\n");
+            }
+            if (!text.trim()) {
+                setError(localeLabel("没有日志内容可分析", "No log content to analyze"));
+                return;
+            }
+            setAnalysis(""); setAnalyzing(true); setError("");
+            try {
+                const data = await fetchJson("/api/logs/analyze", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ text: text, focus: focus }),
+                });
+                setAnalysis(String(data.analysis || ""));
+            } catch (err) {
+                setError(err instanceof Error ? err.message : "分析失败");
+            } finally {
+                setAnalyzing(false);
+            }
+        }
+
+        function levelClass(level) {
+            const l = String(level || "").toUpperCase();
+            if (l === "ERROR" || l === "CRITICAL" || l === "FATAL") return "log-row-error";
+            if (l === "WARNING" || l === "WARN") return "log-row-warn";
+            if (l === "DEBUG") return "log-row-debug";
+            return "log-row-info";
+        }
+
+        const canAnalyze = !!(me && (((me.permissions || []).includes("analyze_logs")) || me.role === "super_admin"));
+
+        return h("div", { className: "logs-shell" },
+            h("div", { className: "dashboard-topbar" },
+                h("div", { className: "dashboard-topbar-left" },
+                    h("h1", { className: "dashboard-title" }, localeLabel("系统日志", "System logs")),
+                    h("div", { className: "dashboard-stats" },
+                        h("span", { className: "stat-chip" }, localeLabel("扫描行数 ", "Scanned ") + totalScanned),
+                        h("span", { className: "stat-chip" }, localeLabel("显示 ", "Shown ") + records.length),
+                        logDir ? h("span", { className: "stat-chip" }, logDir) : null,
+                    ),
+                ),
+                h("div", null,
+                    h("label", { style: { marginRight: "10px" } },
+                        h("input", { type: "checkbox", checked: autoRefresh, onChange: (e) => setAutoRefresh(e.target.checked) }),
+                        " " + localeLabel("自动刷新 (5秒)", "Auto refresh (5s)"),
+                    ),
+                    h("button", { className: "btn secondary", onClick: loadRecords, disabled: loading }, loading ? localeLabel("加载中...", "Loading...") : localeLabel("🔄 刷新", "🔄 Refresh")),
+                ),
+            ),
+            error ? h("div", { className: "dashboard-error" }, error) : null,
+            h("div", { className: "card logs-filters" },
+                h("div", { className: "logs-filter-row" },
+                    h("label", null, localeLabel("日志文件", "File")),
+                    h("select", {
+                        value: filename,
+                        onChange: (e) => setFilename(e.target.value),
+                    },
+                        files.map((f) => h("option", { key: f.name, value: f.name }, f.name + " (" + (f.size / 1024).toFixed(1) + " KB)")),
+                    ),
+                    h("label", null, localeLabel("级别", "Level")),
+                    h("select", {
+                        value: filters.level,
+                        onChange: (e) => setFilters({ ...filters, level: e.target.value }),
+                    },
+                        h("option", { value: "" }, localeLabel("全部", "All")),
+                        h("option", { value: "DEBUG" }, "DEBUG+"),
+                        h("option", { value: "INFO" }, "INFO+"),
+                        h("option", { value: "WARNING" }, "WARNING+"),
+                        h("option", { value: "ERROR" }, "ERROR+"),
+                        h("option", { value: "CRITICAL" }, "CRITICAL"),
+                    ),
+                    h("label", null, localeLabel("Logger", "Logger")),
+                    h("input", {
+                        placeholder: "aise.runtime",
+                        value: filters.logger,
+                        onChange: (e) => setFilters({ ...filters, logger: e.target.value }),
+                    }),
+                    h("label", null, localeLabel("关键字", "Search")),
+                    h("input", {
+                        placeholder: localeLabel("支持子串匹配", "substring match"),
+                        value: filters.q,
+                        onChange: (e) => setFilters({ ...filters, q: e.target.value }),
+                    }),
+                    h("label", null, localeLabel("起始", "Since")),
+                    h("input", {
+                        type: "datetime-local",
+                        value: filters.since,
+                        onChange: (e) => setFilters({ ...filters, since: e.target.value }),
+                    }),
+                    h("label", null, localeLabel("结束", "Until")),
+                    h("input", {
+                        type: "datetime-local",
+                        value: filters.until,
+                        onChange: (e) => setFilters({ ...filters, until: e.target.value }),
+                    }),
+                    h("label", null, localeLabel("限制", "Limit")),
+                    h("input", {
+                        type: "number",
+                        min: "10",
+                        max: "5000",
+                        value: filters.limit,
+                        onChange: (e) => setFilters({ ...filters, limit: Number(e.target.value) || 500 }),
+                    }),
+                    h("button", { className: "btn", onClick: loadRecords }, localeLabel("筛选", "Apply")),
+                ),
+            ),
+            h("div", { className: "card", style: { marginTop: "12px" } },
+                h("div", { style: { display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "8px" } },
+                    h("div", null,
+                        h("button", { className: "btn secondary btn-sm", onClick: selectAll, style: { marginRight: "6px" } }, localeLabel("全选", "Select all")),
+                        h("button", { className: "btn secondary btn-sm", onClick: selectNone }, localeLabel("全不选", "Clear")),
+                        h("span", { className: "muted", style: { marginLeft: "12px" } }, localeLabel("已选 ", "Selected ") + selected.size),
+                    ),
+                ),
+                h("div", { className: "log-viewer" },
+                    records.length === 0 ? h("p", { className: "muted" }, localeLabel("暂无日志", "No logs")) :
+                        records.map((r, idx) => h("div", {
+                            key: idx,
+                            className: "log-row " + levelClass(r.level) + (selected.has(idx) ? " log-row-selected" : ""),
+                            onClick: () => toggleSelect(idx),
+                        },
+                            h("span", { className: "log-col-ts" }, r.timestamp || ""),
+                            h("span", { className: "log-col-level log-level-" + (r.level || "INFO").toLowerCase() }, r.level || ""),
+                            h("span", { className: "log-col-logger" }, r.logger || ""),
+                            h("span", { className: "log-col-message" }, r.message || r.raw || ""),
+                        )),
+                ),
+            ),
+            canAnalyze ? h("div", { className: "card", style: { marginTop: "12px" } },
+                h("h3", { style: { margin: "0 0 8px" } }, localeLabel("LLM 智能分析", "LLM analysis")),
+                h("p", { className: "muted", style: { margin: "0 0 8px" } },
+                    localeLabel(
+                        "将当前筛选结果（或勾选的行）发送给 rd_director 进行根因分析。",
+                        "Send the current filter (or selected lines) to rd_director for root-cause analysis.",
+                    )),
+                h("label", null, localeLabel("关注点（可选）", "Focus (optional)")),
+                h("input", {
+                    placeholder: localeLabel("例如：为什么 developer dispatch 经常失败？", "e.g. why do developer dispatches fail?"),
+                    value: focus,
+                    onChange: (e) => setFocus(e.target.value),
+                }),
+                h("div", { style: { marginTop: "8px" } },
+                    h("button", { className: "btn", onClick: runAnalysis, disabled: analyzing }, analyzing ? localeLabel("分析中...", "Analyzing...") : localeLabel("🧠 开始分析", "🧠 Analyze")),
+                ),
+                analysis ? h("div", { className: "log-analysis" },
+                    h("pre", null, analysis),
+                ) : null,
+            ) : null,
+        );
+    }
+
+    const root = window.ReactDOM.createRoot(rootNode);
+    root.render(h(LogsApp));
+}
+
+// Bootstrap order matters: i18next.init() is async because its HTTP
+// backend fetches ``/static/locales/<lng>/translation.json``. Mounting
+// React before that resolves means every ``t("run.xxx")`` call returns
+// the raw key, which is exactly what users saw on the project-detail /
+// run-detail pages before this fix.
 document.addEventListener("DOMContentLoaded", () => {
-  // Wait for i18next to finish loading its resource files before
-  // mounting any React tree. First paint therefore has the correct
-  // translations — no flash of raw ``stage.xxx`` keys.
-  initI18n().finally(() => {
-    setupDashboardReact();
-    setupProjectReact();
-    setupRunReact();
-    setupTaskReact();
-    setupLoginReact();
-    setupModelsConfigPage();
-    setupMonitorReact();
-  });
+    const mountAll = () => {
+        setupDashboardReact();
+        setupProjectReact();
+        setupRunReact();
+        setupTaskReact();
+        setupLoginReact();
+        setupModelsConfigPage();
+        setupMonitorReact();
+        setupUsersReact();
+        setupLogsReact();
+    };
+    Promise.resolve(initI18n()).then(mountAll, mountAll);
 });

--- a/src/aise/web/static/main.css
+++ b/src/aise/web/static/main.css
@@ -3147,3 +3147,102 @@ button.flow-composite-card:hover,
   background: rgba(100, 116, 139, 0.10);
   border: 1px solid rgba(100, 116, 139, 0.25);
 }
+
+/* ------------------------------------------------------------------ */
+/* Users management page                                                */
+/* ------------------------------------------------------------------ */
+
+.users-table, .users-roles-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+}
+.users-table th, .users-table td,
+.users-roles-table th, .users-roles-table td {
+  padding: 8px 10px;
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+  text-align: left;
+  vertical-align: middle;
+}
+.users-table th, .users-roles-table th {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.72rem;
+  color: #9aa4b2;
+  font-weight: 600;
+}
+.users-roles-table td:first-child { width: 140px; }
+.btn-sm { font-size: 0.78rem; padding: 4px 10px; }
+
+/* ------------------------------------------------------------------ */
+/* Logs viewer page                                                     */
+/* ------------------------------------------------------------------ */
+
+.logs-shell { padding: 0; }
+.logs-filters .logs-filter-row {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, auto) minmax(0, 1fr));
+  gap: 6px 12px;
+  align-items: center;
+}
+.logs-filters .logs-filter-row label {
+  font-size: 0.78rem;
+  color: #9aa4b2;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+.logs-filters .logs-filter-row input,
+.logs-filters .logs-filter-row select {
+  min-width: 100px;
+}
+.logs-filters .logs-filter-row button {
+  grid-column: span 2;
+  justify-self: start;
+}
+
+.log-viewer {
+  max-height: 60vh;
+  overflow-y: auto;
+  background: rgba(0,0,0,0.25);
+  border-radius: 6px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.78rem;
+}
+.log-row {
+  display: grid;
+  grid-template-columns: 170px 80px 160px 1fr;
+  padding: 2px 8px;
+  gap: 10px;
+  cursor: pointer;
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+  white-space: nowrap;
+}
+.log-row:hover { background: rgba(255,255,255,0.04); }
+.log-row-selected { background: rgba(14,165,233,0.10); }
+.log-col-ts { color: #94a3b8; }
+.log-col-level { font-weight: 600; text-transform: uppercase; font-size: 0.72rem; }
+.log-col-logger { color: #a5b4fc; }
+.log-col-message { white-space: normal; word-break: break-word; }
+.log-level-debug { color: #64748b; }
+.log-level-info { color: #38bdf8; }
+.log-level-warning, .log-level-warn { color: #f59e0b; }
+.log-level-error { color: #ef4444; }
+.log-level-critical, .log-level-fatal { color: #ec4899; }
+.log-row-error { background: rgba(239, 68, 68, 0.06); }
+.log-row-warn { background: rgba(245, 158, 11, 0.06); }
+
+.log-analysis {
+  margin-top: 12px;
+  background: rgba(14, 165, 233, 0.06);
+  border: 1px solid rgba(14, 165, 233, 0.2);
+  border-radius: 6px;
+  padding: 10px 14px;
+}
+.log-analysis pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.82rem;
+  color: #e5e7eb;
+}

--- a/src/aise/web/templates/layout.html
+++ b/src/aise/web/templates/layout.html
@@ -27,6 +27,19 @@
             <span class="sidebar-link-icon">🖥️</span>
             <span>Monitor</span>
           </a>
+          {% set _perms = (user.permissions if user else []) or [] %}
+          {% if user and ('view_logs' in _perms or user.role == 'super_admin') %}
+          <a class="sidebar-link{{ ' active' if request.url.path.startswith('/logs') }}" href="/logs">
+            <span class="sidebar-link-icon">📜</span>
+            <span>Logs</span>
+          </a>
+          {% endif %}
+          {% if user and ('manage_users' in _perms or user.role == 'super_admin') %}
+          <a class="sidebar-link{{ ' active' if request.url.path.startswith('/users') }}" href="/users">
+            <span class="sidebar-link-icon">👥</span>
+            <span>Users</span>
+          </a>
+          {% endif %}
           <a class="sidebar-link{{ ' active' if request.url.path.startswith('/config') }}" href="/config/global/models">
             <span class="sidebar-link-icon">⚙️</span>
             <span>Settings</span>
@@ -79,7 +92,7 @@
        language is authoritative. -->
   <script src="https://unpkg.com/i18next@23.11.5/dist/umd/i18next.min.js"></script>
   <script src="https://unpkg.com/i18next-http-backend@2.5.2/i18nextHttpBackend.min.js"></script>
-  <script src="/static/app.js?v=20260421c"></script>
+  <script src="/static/app.js?v=20260421e"></script>
   {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/src/aise/web/templates/logs.html
+++ b/src/aise/web/templates/logs.html
@@ -1,0 +1,4 @@
+{% extends "layout.html" %}
+{% block content %}
+<section id="logs-react-root"></section>
+{% endblock %}

--- a/src/aise/web/templates/users.html
+++ b/src/aise/web/templates/users.html
@@ -1,0 +1,4 @@
+{% extends "layout.html" %}
+{% block content %}
+<section id="users-react-root"></section>
+{% endblock %}

--- a/src/aise/web/user_store.py
+++ b/src/aise/web/user_store.py
@@ -487,9 +487,7 @@ class UserStore:
                 raise ValueError(f"User not found: {user_id}")
             if user.role == "super_admin":
                 other_admins = [
-                    u
-                    for u in self._state.users.values()
-                    if u.id != user.id and u.role == "super_admin" and u.enabled
+                    u for u in self._state.users.values() if u.id != user.id and u.role == "super_admin" and u.enabled
                 ]
                 if not other_admins:
                     raise ValueError("Cannot delete the last super_admin")

--- a/src/aise/web/user_store.py
+++ b/src/aise/web/user_store.py
@@ -1,0 +1,603 @@
+"""Persistent user / role management for the AISE web console.
+
+This module replaces the previous session-only, env-var-configured
+admin with a proper, persistent user store:
+
+- Users are stored in ``<projects_root>/users.json``.
+- Passwords are hashed with PBKDF2-HMAC-SHA256 (stdlib only — no
+  dependency on passlib/bcrypt). Each password uses its own salt.
+- Roles are predefined (super_admin / admin / developer / viewer) and
+  encode a set of permissions. Users are tagged with ONE role.
+- A bootstrap super_admin is created on first start from the env vars
+  ``AISE_ADMIN_USERNAME`` and ``AISE_ADMIN_PASSWORD`` (same variables
+  the legacy local-login used) so existing operators don't lose
+  access. If the store already has a super_admin, the env-var bootstrap
+  is skipped — manual user changes win.
+
+The store is thread-safe via an internal ``RLock``.
+"""
+
+from __future__ import annotations
+
+import hmac
+import json
+import os
+import secrets
+import threading
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from hashlib import pbkdf2_hmac
+from pathlib import Path
+from typing import Any
+
+from ..utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Predefined permission keys. Kept flat so frontend code can present a
+# simple "role → permissions" matrix without tree-walking.
+PERM_MANAGE_USERS = "manage_users"
+PERM_MANAGE_SYSTEM = "manage_system"  # global config, agents, models
+PERM_VIEW_LOGS = "view_logs"
+PERM_ANALYZE_LOGS = "analyze_logs"
+PERM_MANAGE_PROJECTS = "manage_projects"  # create / delete projects
+PERM_RUN_PROJECTS = "run_projects"  # submit requirements, restart runs
+PERM_VIEW_PROJECTS = "view_projects"
+
+ALL_PERMISSIONS: tuple[str, ...] = (
+    PERM_MANAGE_USERS,
+    PERM_MANAGE_SYSTEM,
+    PERM_VIEW_LOGS,
+    PERM_ANALYZE_LOGS,
+    PERM_MANAGE_PROJECTS,
+    PERM_RUN_PROJECTS,
+    PERM_VIEW_PROJECTS,
+)
+
+# Built-in roles. Users can be assigned one of these. Intentionally
+# small — a 4-role matrix is enough to cover the console's real needs
+# (full admin, project admin, developer, read-only viewer). Roles are
+# hard-coded rather than dynamic because the UI surfaces them in
+# dropdowns / permission matrices and a dynamic role model would drag
+# in a whole RBAC editor screen that nobody asked for.
+ROLE_DEFINITIONS: dict[str, dict[str, Any]] = {
+    "super_admin": {
+        "display_name_zh": "超级管理员",
+        "display_name_en": "Super Admin",
+        "description_zh": "拥有所有权限，包含用户管理、系统配置、日志查看、日志分析、项目管理等。",
+        "description_en": "Full access — user management, system config, logs, analysis, projects.",
+        "permissions": list(ALL_PERMISSIONS),
+    },
+    "admin": {
+        "display_name_zh": "管理员",
+        "display_name_en": "Admin",
+        "description_zh": "系统配置、项目管理、日志查看及分析，不能管理用户。",
+        "description_en": "System config, project management, logs, analysis. Cannot manage users.",
+        "permissions": [
+            PERM_MANAGE_SYSTEM,
+            PERM_VIEW_LOGS,
+            PERM_ANALYZE_LOGS,
+            PERM_MANAGE_PROJECTS,
+            PERM_RUN_PROJECTS,
+            PERM_VIEW_PROJECTS,
+        ],
+    },
+    "developer": {
+        "display_name_zh": "开发人员",
+        "display_name_en": "Developer",
+        "description_zh": "创建项目、下发需求，查看日志，不能管理用户或修改全局配置。",
+        "description_en": "Create/run projects, view logs. No user management or system config.",
+        "permissions": [
+            PERM_VIEW_LOGS,
+            PERM_MANAGE_PROJECTS,
+            PERM_RUN_PROJECTS,
+            PERM_VIEW_PROJECTS,
+        ],
+    },
+    "viewer": {
+        "display_name_zh": "只读访客",
+        "display_name_en": "Viewer",
+        "description_zh": "仅能查看项目和执行记录。",
+        "description_en": "Read-only access to projects and runs.",
+        "permissions": [PERM_VIEW_PROJECTS],
+    },
+}
+
+
+_PBKDF2_ITERATIONS = 260_000
+_PBKDF2_HASH = "sha256"
+
+
+def hash_password(password: str, *, salt: bytes | None = None) -> str:
+    """Hash a password using PBKDF2-HMAC-SHA256.
+
+    Returns a compact ``pbkdf2_sha256$<iter>$<hex_salt>$<hex_hash>``
+    string so the format is self-describing and can later be migrated
+    to bcrypt / argon2 without breaking existing records.
+    """
+    if salt is None:
+        salt = secrets.token_bytes(16)
+    digest = pbkdf2_hmac(_PBKDF2_HASH, password.encode("utf-8"), salt, _PBKDF2_ITERATIONS)
+    return f"pbkdf2_sha256${_PBKDF2_ITERATIONS}${salt.hex()}${digest.hex()}"
+
+
+def verify_password(password: str, encoded: str) -> bool:
+    """Constant-time verification against a stored ``pbkdf2_sha256$…`` hash."""
+    try:
+        algo, iter_str, salt_hex, digest_hex = encoded.split("$", 3)
+    except ValueError:
+        return False
+    if algo != "pbkdf2_sha256":
+        return False
+    try:
+        iterations = int(iter_str)
+        salt = bytes.fromhex(salt_hex)
+        expected = bytes.fromhex(digest_hex)
+    except ValueError:
+        return False
+    computed = pbkdf2_hmac(_PBKDF2_HASH, password.encode("utf-8"), salt, iterations)
+    return hmac.compare_digest(computed, expected)
+
+
+@dataclass
+class User:
+    """A stored user record."""
+
+    id: str
+    username: str
+    email: str
+    display_name: str
+    role: str
+    enabled: bool
+    password_hash: str
+    provider: str  # "local" / "google" / "microsoft" etc.
+    created_at: str
+    updated_at: str
+    last_login_at: str = ""
+    # External identity id for OAuth users (sub claim). Empty for local.
+    external_id: str = ""
+    notes: str = ""
+
+    def to_dict(self, *, include_password_hash: bool = False) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "id": self.id,
+            "username": self.username,
+            "email": self.email,
+            "display_name": self.display_name,
+            "role": self.role,
+            "enabled": self.enabled,
+            "provider": self.provider,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "last_login_at": self.last_login_at,
+            "external_id": self.external_id,
+            "notes": self.notes,
+        }
+        if include_password_hash:
+            data["password_hash"] = self.password_hash
+        return data
+
+
+@dataclass
+class _StoreState:
+    users: dict[str, User] = field(default_factory=dict)
+
+    def by_username(self, username: str) -> User | None:
+        lookup = username.strip().lower()
+        for u in self.users.values():
+            if u.username.lower() == lookup:
+                return u
+        return None
+
+    def by_email(self, email: str) -> User | None:
+        lookup = email.strip().lower()
+        if not lookup:
+            return None
+        for u in self.users.values():
+            if u.email.lower() == lookup:
+                return u
+        return None
+
+
+class UserStore:
+    """Thread-safe JSON-backed user store."""
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+        self._state = _StoreState()
+        self._lock = threading.RLock()
+        self._load()
+        self._bootstrap_admin_if_empty()
+
+    # -- Role helpers --------------------------------------------------------
+
+    @staticmethod
+    def role_exists(role: str) -> bool:
+        return role in ROLE_DEFINITIONS
+
+    @staticmethod
+    def permissions_for(role: str) -> list[str]:
+        defn = ROLE_DEFINITIONS.get(role)
+        if not defn:
+            return []
+        return list(defn.get("permissions", []))
+
+    @staticmethod
+    def list_role_definitions() -> list[dict[str, Any]]:
+        return [
+            {
+                "key": key,
+                "display_name_zh": defn["display_name_zh"],
+                "display_name_en": defn["display_name_en"],
+                "description_zh": defn["description_zh"],
+                "description_en": defn["description_en"],
+                "permissions": list(defn["permissions"]),
+            }
+            for key, defn in ROLE_DEFINITIONS.items()
+        ]
+
+    @staticmethod
+    def list_all_permissions() -> list[str]:
+        return list(ALL_PERMISSIONS)
+
+    # -- Persistence ---------------------------------------------------------
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            return
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.warning("Failed to load user store %s: %s", self._path, exc)
+            return
+        if not isinstance(data, dict):
+            return
+        users_data = data.get("users", [])
+        if not isinstance(users_data, list):
+            return
+        for entry in users_data:
+            if not isinstance(entry, dict):
+                continue
+            user_id = str(entry.get("id", "")).strip()
+            username = str(entry.get("username", "")).strip()
+            if not user_id or not username:
+                continue
+            role = str(entry.get("role", "viewer"))
+            if role not in ROLE_DEFINITIONS:
+                role = "viewer"
+            self._state.users[user_id] = User(
+                id=user_id,
+                username=username,
+                email=str(entry.get("email", "")),
+                display_name=str(entry.get("display_name", username)),
+                role=role,
+                enabled=bool(entry.get("enabled", True)),
+                password_hash=str(entry.get("password_hash", "")),
+                provider=str(entry.get("provider", "local")),
+                created_at=str(entry.get("created_at", _now_iso())),
+                updated_at=str(entry.get("updated_at", _now_iso())),
+                last_login_at=str(entry.get("last_login_at", "")),
+                external_id=str(entry.get("external_id", "")),
+                notes=str(entry.get("notes", "")),
+            )
+
+    def _save_locked(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "version": 1,
+            "users": [u.to_dict(include_password_hash=True) for u in self._state.users.values()],
+        }
+        tmp = self._path.with_suffix(f"{self._path.suffix}.{uuid.uuid4().hex}.tmp")
+        tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        tmp.replace(self._path)
+
+    def _bootstrap_admin_if_empty(self) -> None:
+        """Create an initial super_admin if the store has no super_admin yet.
+
+        Uses ``AISE_ADMIN_USERNAME`` / ``AISE_ADMIN_PASSWORD`` so legacy
+        operators can keep logging in. Falls back to ``admin`` /
+        ``123456`` (same defaults as the old local-login hardcode).
+        """
+        with self._lock:
+            for u in self._state.users.values():
+                if u.role == "super_admin" and u.enabled:
+                    return
+            username = (os.environ.get("AISE_ADMIN_USERNAME") or "admin").strip() or "admin"
+            password = os.environ.get("AISE_ADMIN_PASSWORD") or "123456"
+            now = _now_iso()
+            existing = self._state.by_username(username)
+            if existing is not None:
+                existing.role = "super_admin"
+                existing.enabled = True
+                existing.updated_at = now
+            else:
+                user = User(
+                    id=f"u_{uuid.uuid4().hex[:10]}",
+                    username=username,
+                    email=f"{username}@aise.local",
+                    display_name="System Admin",
+                    role="super_admin",
+                    enabled=True,
+                    password_hash=hash_password(password),
+                    provider="local",
+                    created_at=now,
+                    updated_at=now,
+                )
+                self._state.users[user.id] = user
+            try:
+                self._save_locked()
+            except Exception as exc:
+                logger.warning("Failed to persist bootstrap admin: %s", exc)
+            logger.info("Bootstrap super_admin ensured: username=%s", username)
+
+    # -- CRUD ----------------------------------------------------------------
+
+    def list_users(self) -> list[User]:
+        with self._lock:
+            items = list(self._state.users.values())
+        items.sort(key=lambda u: (u.role != "super_admin", u.username.lower()))
+        return items
+
+    def get_user(self, user_id: str) -> User | None:
+        with self._lock:
+            return self._state.users.get(user_id)
+
+    def get_user_by_username(self, username: str) -> User | None:
+        with self._lock:
+            return self._state.by_username(username)
+
+    def get_user_by_external(self, provider: str, external_id: str, email: str = "") -> User | None:
+        """Match an OAuth callback to a stored user.
+
+        Tries ``(provider, external_id)`` first, then falls back to
+        matching by email so returning OAuth users don't get duplicated
+        just because the external ID changed format.
+        """
+        provider = provider.strip().lower()
+        external_id = external_id.strip()
+        email = email.strip().lower()
+        with self._lock:
+            for u in self._state.users.values():
+                if u.provider.lower() == provider and external_id and u.external_id == external_id:
+                    return u
+            if email:
+                for u in self._state.users.values():
+                    if u.email.lower() == email:
+                        return u
+        return None
+
+    def create_user(
+        self,
+        *,
+        username: str,
+        email: str,
+        display_name: str,
+        role: str,
+        password: str,
+        enabled: bool = True,
+        provider: str = "local",
+        external_id: str = "",
+        notes: str = "",
+    ) -> User:
+        username = username.strip()
+        if not username:
+            raise ValueError("username is required")
+        if role not in ROLE_DEFINITIONS:
+            raise ValueError(f"Unknown role: {role}")
+        if provider == "local" and not password:
+            raise ValueError("password is required for local users")
+        with self._lock:
+            if self._state.by_username(username) is not None:
+                raise ValueError(f"Username already exists: {username}")
+            if email and self._state.by_email(email) is not None:
+                raise ValueError(f"Email already exists: {email}")
+            now = _now_iso()
+            user = User(
+                id=f"u_{uuid.uuid4().hex[:10]}",
+                username=username,
+                email=email.strip(),
+                display_name=(display_name.strip() or username),
+                role=role,
+                enabled=enabled,
+                password_hash=hash_password(password) if password else "",
+                provider=provider.strip() or "local",
+                created_at=now,
+                updated_at=now,
+                external_id=external_id.strip(),
+                notes=notes.strip(),
+            )
+            self._state.users[user.id] = user
+            self._save_locked()
+            logger.info("User created: id=%s username=%s role=%s", user.id, user.username, user.role)
+            return user
+
+    def update_user(
+        self,
+        user_id: str,
+        *,
+        email: str | None = None,
+        display_name: str | None = None,
+        role: str | None = None,
+        enabled: bool | None = None,
+        notes: str | None = None,
+        external_id: str | None = None,
+    ) -> User:
+        with self._lock:
+            user = self._state.users.get(user_id)
+            if user is None:
+                raise ValueError(f"User not found: {user_id}")
+            if role is not None:
+                if role not in ROLE_DEFINITIONS:
+                    raise ValueError(f"Unknown role: {role}")
+                if user.role == "super_admin" and role != "super_admin":
+                    # Prevent orphaning — leave at least one super_admin.
+                    other_admins = [
+                        u
+                        for u in self._state.users.values()
+                        if u.id != user.id and u.role == "super_admin" and u.enabled
+                    ]
+                    if not other_admins:
+                        raise ValueError("Cannot demote the last super_admin")
+                user.role = role
+            if email is not None:
+                new_email = email.strip()
+                if new_email and new_email.lower() != user.email.lower():
+                    existing = self._state.by_email(new_email)
+                    if existing and existing.id != user.id:
+                        raise ValueError(f"Email already exists: {new_email}")
+                user.email = new_email
+            if display_name is not None:
+                user.display_name = display_name.strip() or user.username
+            if enabled is not None:
+                if not enabled and user.role == "super_admin":
+                    other_admins = [
+                        u
+                        for u in self._state.users.values()
+                        if u.id != user.id and u.role == "super_admin" and u.enabled
+                    ]
+                    if not other_admins:
+                        raise ValueError("Cannot disable the last super_admin")
+                user.enabled = enabled
+            if notes is not None:
+                user.notes = notes
+            if external_id is not None:
+                user.external_id = external_id.strip()
+            user.updated_at = _now_iso()
+            self._save_locked()
+            logger.info("User updated: id=%s", user.id)
+            return user
+
+    def set_password(self, user_id: str, password: str) -> None:
+        if not password:
+            raise ValueError("password is required")
+        with self._lock:
+            user = self._state.users.get(user_id)
+            if user is None:
+                raise ValueError(f"User not found: {user_id}")
+            user.password_hash = hash_password(password)
+            user.updated_at = _now_iso()
+            self._save_locked()
+            logger.info("Password set: id=%s", user.id)
+
+    def delete_user(self, user_id: str) -> None:
+        with self._lock:
+            user = self._state.users.get(user_id)
+            if user is None:
+                raise ValueError(f"User not found: {user_id}")
+            if user.role == "super_admin":
+                other_admins = [
+                    u
+                    for u in self._state.users.values()
+                    if u.id != user.id and u.role == "super_admin" and u.enabled
+                ]
+                if not other_admins:
+                    raise ValueError("Cannot delete the last super_admin")
+            del self._state.users[user_id]
+            self._save_locked()
+            logger.info("User deleted: id=%s username=%s", user_id, user.username)
+
+    def authenticate(self, username: str, password: str) -> User | None:
+        with self._lock:
+            user = self._state.by_username(username)
+            if user is None or not user.enabled or user.provider != "local":
+                return None
+            if not verify_password(password, user.password_hash):
+                return None
+            user.last_login_at = _now_iso()
+            try:
+                self._save_locked()
+            except Exception as exc:
+                logger.debug("Failed to persist last_login_at: %s", exc)
+            return user
+
+    def record_external_login(
+        self,
+        *,
+        provider: str,
+        external_id: str,
+        email: str,
+        display_name: str,
+    ) -> User:
+        """Upsert a user from an OAuth callback.
+
+        Returns the stored User record (existing or newly created). The
+        caller passes the result into ``session_payload`` to build the
+        session dict.
+        """
+        provider = provider.strip() or "local"
+        email = email.strip()
+        display_name = display_name.strip() or email or provider
+        with self._lock:
+            user = self.get_user_by_external(provider, external_id, email)
+            if user is not None:
+                user.provider = provider
+                if email and user.email.lower() != email.lower():
+                    user.email = email
+                if display_name and display_name != user.display_name:
+                    user.display_name = display_name
+                if external_id:
+                    user.external_id = external_id
+                user.enabled = True
+                user.last_login_at = _now_iso()
+                user.updated_at = _now_iso()
+                self._save_locked()
+                return user
+            # First-time OAuth user. Default role is ``viewer`` — admins
+            # promote them via the user management UI.
+            username_base = (email.split("@")[0] if email else provider).strip() or provider
+            username = username_base
+            suffix = 1
+            while self._state.by_username(username) is not None:
+                suffix += 1
+                username = f"{username_base}{suffix}"
+            now = _now_iso()
+            user = User(
+                id=f"u_{uuid.uuid4().hex[:10]}",
+                username=username,
+                email=email,
+                display_name=display_name,
+                role="viewer",
+                enabled=True,
+                password_hash="",
+                provider=provider,
+                created_at=now,
+                updated_at=now,
+                last_login_at=now,
+                external_id=external_id,
+            )
+            self._state.users[user.id] = user
+            self._save_locked()
+            logger.info("OAuth user created: id=%s username=%s provider=%s", user.id, user.username, provider)
+            return user
+
+
+def session_payload(user: User) -> dict[str, Any]:
+    """Build the ``request.session['user']`` dict for a given User.
+
+    Embeds ``permissions`` so route handlers can gate on them without
+    re-reading the store on every request.
+    """
+    return {
+        "id": user.id,
+        "name": user.display_name or user.username,
+        "username": user.username,
+        "email": user.email,
+        "provider": user.provider,
+        "role": user.role,
+        "permissions": UserStore.permissions_for(user.role),
+    }
+
+
+def has_permission(session_user: dict[str, Any] | None, permission: str) -> bool:
+    if not session_user:
+        return False
+    perms = session_user.get("permissions") or []
+    if permission in perms:
+        return True
+    # super_admin gets everything even if perms list is stale.
+    return session_user.get("role") == "super_admin"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()


### PR DESCRIPTION
## Summary

Three independent web-console features shipped together:

- **Agile development flow** — `ProjectConfig.process_type` (waterfall | agile), new agile phase prompts (Sprint Planning → Execution → Review → Retrospective → Delivery) + incremental variant, process selector in the New Project modal, Agile/Waterfall badge on the run-detail page. Rewrote `agile.process.md` to reference the real agents (`product_manager`/`architect`/`developer`/`qa_engineer`/`project_manager`).
- **User & role management** — `src/aise/web/user_store.py` with persistent JSON storage, PBKDF2 password hashing, four built-in roles (`super_admin`/`admin`/`developer`/`viewer`) mapping to seven permissions. Bootstraps a super_admin from `AISE_ADMIN_USERNAME`/`PASSWORD`. Local/dev/OAuth/localhost-auto login all route through the store. New `/users` page + `/api/users` CRUD + `/api/roles` + `require_permission()` gating on existing project / config mutation APIs.
- **Log viewer with LLM analysis** — `src/aise/web/log_service.py` lists rotated log files, parses plain + JSON formats, supports level/logger/keyword/time-range filters (with path-traversal guard), and ships a selected excerpt to `rd_director` (fallback `project_manager`) for a structured Markdown root-cause report. New `/logs` page + `/api/logs/files` + `/api/logs/tail` + `/api/logs/analyze`.

Layout changes: sidebar adds **Logs** / **Users** links only for users whose role grants the matching permission. Project-detail page now surfaces `＋ 新增增量需求` when a baseline exists (previously an auto-redirect hid the entry entirely).

## Test plan

- [x] `ruff check src/` — clean
- [x] `python -m compileall src/aise` — clean
- [x] `node --check src/aise/web/static/app.js` — clean
- [x] Jinja template parse for all 10 templates — clean
- [x] `pytest tests/ --ignore=tests/test_e2e --ignore=tests/test_github` — **1049 passed / 53 skipped / 0 failures**
- [x] Live server smoke test: agile project creation persists `process_type=agile`; `/api/users` CRUD works + permission gates return 403 for unprivileged users; `/api/logs/analyze` returns a real 6-section Markdown report from `rd_director`.
- [ ] Manual browser walkthrough on the live console (dashboard → new agile project, users page, logs page, LLM analyze).

🤖 Generated with [Claude Code](https://claude.com/claude-code)