### PR TITLE
feat(runtime+agents): per-project git repo + auto-commit per dispatch

### DIFF
--- a/src/aise/agents/_runtime_skills/git/SKILL.md
+++ b/src/aise/agents/_runtime_skills/git/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: git
+description: Local version control conventions — each project is its own git repo, commits happen automatically per dispatch, agents read history but do not commit directly
+---
+
+# Git Skill
+
+## Runtime model
+
+Every project created by AISE is initialized as its **own local git
+repo** at the project root. This happens during project scaffolding,
+before any agent runs. As a result:
+
+- `execute_shell('git status')` runs against the PROJECT's repo, not
+  the host machine's repo. Delta queries (`git diff`, `git log`) are
+  meaningful.
+- `HEAD` after scaffolding points to a single "project scaffold"
+  commit whose tree is the empty baseline. Every subsequent commit is
+  produced by the runtime per successful dispatch.
+- `.gitignore` is seeded with the sensible defaults (trace JSONs,
+  `__pycache__/`, `.pytest_cache/`, `.coverage`, `node_modules/`, ...)
+  so commits capture the real deliverables — source, tests, docs,
+  delivery report — and nothing else.
+
+## Commits: handled by the runtime, NOT by the agent
+
+After every successful dispatch, the runtime automatically runs:
+
+```
+git add -A
+git commit -m "<agent>(<step_id or phase>): <first line of your response>"
+```
+
+This means agents **must not** run `git commit` themselves. Doing so
+duplicates the runtime's commit and pollutes the log with two
+entries per task. Specifically:
+
+- Do NOT call `execute_shell('git commit ...')`.
+- Do NOT call `execute_shell('git add ...')` with the intention of
+  staging for a later commit — the runtime adds everything anyway.
+- Do NOT edit `.gitignore` unless the task explicitly asks for it.
+- Do NOT create or rewrite `.git/` directly.
+
+If your dispatch wrote nothing (read-only task — e.g. reviewer,
+report compiler), the runtime detects a clean working tree and
+skips the commit silently. No action needed.
+
+## Reads are fine
+
+Agents are encouraged to use git as a **read-only** tool whenever it
+answers a question cheaper than re-reading files:
+
+- `execute_shell('git log --oneline -10')` — recent history.
+- `execute_shell('git diff HEAD~1')` — what changed in the previous
+  dispatch.
+- `execute_shell('git diff --name-only HEAD~1')` — names of files
+  touched last dispatch (useful for incremental architects / QA to
+  scope their work).
+- `execute_shell('git show HEAD:src/foo.py')` — view a file at HEAD
+  without editing the working tree.
+- `execute_shell('git status --porcelain')` — whether the current
+  tree is clean.
+
+All of these run against the project repo from the project root —
+no need to `cd` anywhere.
+
+## Commit messages
+
+Runtime commit messages follow a fixed shape:
+
+```
+<agent>(<step_id or phase>): <truncated first line of response>
+```
+
+Examples produced by the runtime:
+
+```
+developer(impl_game_engine): Wrote tests/test_game_engine.py + src/game_engine.py
+architect(phase2_architecture): docs/architecture.md with 3 C4 diagrams
+qa_engineer(phase5_integration_testing): All 124 tests pass, coverage 82%
+```
+
+The first line of your response IS the commit subject. Keep it
+informative — it will show up in `git log` forever.
+
+## When incremental mode runs
+
+In incremental mode (a new requirement against a project with a
+baseline run), the architect, developer, and QA agents can rely on
+git to see exactly what each prior phase produced:
+
+```
+git log --oneline                 # full history
+git diff <prior-run-tag> HEAD     # all changes since last run
+git diff --name-only HEAD~1       # files changed in the last dispatch
+```
+
+Use these to scope incremental work precisely — don't re-read every
+file when `git diff --name-only` tells you which three changed.
+
+## Anti-patterns to avoid
+
+- **Manual commits**: `execute_shell('git commit -am ...')` — redundant
+  with the runtime commit and produces double entries.
+- **Force operations**: `git reset --hard`, `git clean -fd`,
+  `git checkout --` — these destroy uncommitted work from the current
+  dispatch (which hasn't been committed yet) and other dispatches.
+  Never run them.
+- **Branching**: the local repo stays on one branch (usually
+  `master`). Don't create branches — there's no reviewer to merge
+  them.
+- **Pushing to a remote**: the project repo has no remote. Don't try
+  `git push` / `git remote add` — they either fail or reach out to
+  the wrong place.
+- **Editing `.git/`** directly: never.

--- a/src/aise/agents/architect.md
+++ b/src/aise/agents/architect.md
@@ -136,4 +136,5 @@ useless to readers.
 - status_tracking: Track design phase progress
 - architecture_document_generation: Generate architecture documentation
 - mermaid: Validate every Mermaid code fence in the document after writing and fix any syntax errors [mermaid, diagram, validation]
+- git: Local version control convention — runtime auto-commits per dispatch; use git for read-only history queries [git, vcs, history]
 - pr_review: Review pull requests

--- a/src/aise/agents/developer.md
+++ b/src/aise/agents/developer.md
@@ -141,5 +141,6 @@ responsibility in Phase 5.
 
 - tdd: Test-Driven Development workflow with 1:1 source-to-test file mapping [tdd, testing, implementation]
 - code_inspection: Run a language-appropriate static analyzer on every source file written and fix every finding [lint, static-analysis, quality]
+- git: Local version control convention — runtime auto-commits per dispatch; use git for read-only history queries [git, vcs, history]
 - code_generation: Generate module scaffolding from architecture design
 - bug_fix: Fix bugs with root cause analysis

--- a/src/aise/agents/product_manager.md
+++ b/src/aise/agents/product_manager.md
@@ -104,6 +104,7 @@ value.
 - product_review: Validate PRD against requirements
 - document_generation: Generate system-design.md and system-requirements.md
 - mermaid: Validate every Mermaid code fence in the document after writing and fix any syntax errors [mermaid, diagram, validation]
+- git: Local version control convention — runtime auto-commits per dispatch; use git for read-only history queries [git, vcs, history]
 - pr_submission: Submit requirement documents as a PR
 - pr_review: Review requirement document PR
 - pr_merge: Merge requirement document PR

--- a/src/aise/agents/qa_engineer.md
+++ b/src/aise/agents/qa_engineer.md
@@ -78,4 +78,5 @@ unit tests (and already run pytest to verify those unit tests pass).
 - test_case_design: Design integration, E2E, and regression test cases
 - test_automation: Generate pytest scripts from test cases
 - test_review: Validate coverage and quality
+- git: Local version control convention — runtime auto-commits per dispatch; use git for read-only history queries [git, vcs, history]
 - pr_review: Review pull requests

--- a/src/aise/core/project_manager.py
+++ b/src/aise/core/project_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -14,6 +15,111 @@ if TYPE_CHECKING:
     pass
 
 logger = get_logger(__name__)
+
+
+# Baseline ignores for a freshly scaffolded project. Keeps runtime
+# noise (trace files, .pyc caches, coverage DBs) out of git while
+# keeping the real artifacts — source, tests, docs, the delivery
+# report — under version control. The orchestrator's post-dispatch
+# commits (see :func:`tool_primitives.make_dispatch_tools`) only
+# capture what isn't ignored, so this list is the hinge between
+# "useful diff history" and "commit log clogged with trace JSON".
+_PROJECT_GITIGNORE = """\
+# AISE runtime artefacts
+runs/trace/
+runs/plans/
+analytics_events.jsonl
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache/
+.coverage
+coverage.xml
+htmlcov/
+.mypy_cache/
+.ruff_cache/
+
+# Node / JS
+node_modules/
+dist/
+build/
+
+# OS / IDE
+.DS_Store
+.vscode/
+.idea/
+"""
+
+
+def _run_git(cwd: Path, *args: str, check: bool = False) -> subprocess.CompletedProcess[str]:
+    """Run a ``git`` command under ``cwd`` and capture output.
+
+    Wrapper kept separate from the ProjectManager class so the same
+    helper is usable from both scaffolding (here) and the per-dispatch
+    commit hook in :mod:`aise.runtime.tool_primitives`.
+    """
+    return subprocess.run(  # noqa: S603 — args are literal strings from our own code
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def _init_project_git_repo(project_root: Path) -> None:
+    """Initialize ``project_root`` as a standalone git repo.
+
+    Idempotent — a re-invocation on an already-initialized project is
+    a no-op (``git init`` exits 0 without clobbering state). We also
+    seed a ``.gitignore`` (if absent) and create the root commit so
+    later diffs against ``HEAD~1`` have something to compare against.
+
+    Note: ``projects_root`` frequently sits INSIDE a larger host repo
+    (e.g. ``AISE/projects/project_5-snake/`` lives inside the AISE
+    repo). ``git init`` in a subdirectory creates a nested repo, which
+    is exactly what we want — ``git`` commands inside the project root
+    from this point on operate on the project's own history, not the
+    host repo's.
+    """
+    try:
+        gitdir = project_root / ".git"
+        if not gitdir.exists():
+            result = _run_git(project_root, "init", "--quiet")
+            if result.returncode != 0:
+                logger.warning(
+                    "git init failed for project: root=%s stderr=%s",
+                    project_root,
+                    (result.stderr or "")[:200],
+                )
+                return
+        # Local repo identity — avoids surprises on hosts where the
+        # global git config has never been set.
+        _run_git(project_root, "config", "user.name", "AISE Orchestrator")
+        _run_git(project_root, "config", "user.email", "orchestrator@aise.local")
+        # Seed ``.gitignore`` only when absent — never overwrite an
+        # existing one (the project team may have tuned it).
+        gi_path = project_root / ".gitignore"
+        if not gi_path.exists():
+            gi_path.write_text(_PROJECT_GITIGNORE, encoding="utf-8")
+        # Initial commit (only if nothing has been committed yet).
+        head_check = _run_git(project_root, "rev-parse", "--verify", "HEAD")
+        if head_check.returncode != 0:
+            _run_git(project_root, "add", "-A")
+            _run_git(
+                project_root,
+                "commit",
+                "--quiet",
+                "--allow-empty",
+                "-m",
+                "project scaffold",
+            )
+    except Exception as exc:  # pragma: no cover — never block creation on git errors
+        logger.warning("git repo init skipped for project=%s err=%s", project_root, exc)
+
 
 _SDLC_PHASES = ["requirements", "design", "implementation", "testing"]
 _PRIMARY_SKILL_BY_PHASE: dict[str, str] = {
@@ -139,6 +245,7 @@ class ProjectManager:
         project_root.mkdir(parents=True, exist_ok=True)
         for subdir in ("docs", "src", "tests", "scripts", "config", "artifacts", "trace"):
             (project_root / subdir).mkdir(parents=True, exist_ok=True)
+        _init_project_git_repo(project_root)
         return project_root
 
     def get_project(self, project_id: str) -> Project | None:

--- a/src/aise/runtime/runtime_config.py
+++ b/src/aise/runtime/runtime_config.py
@@ -90,6 +90,12 @@ DEFAULT_SHELL_ALLOWLIST: tuple[str, ...] = (
     "grep",
     "wc",
     "find",
+    # Version control. The runtime auto-initializes each project as
+    # its own git repo and commits after every successful dispatch
+    # (see the ``git`` skill). Agents may read repo state (status,
+    # log, diff) via execute_shell but should leave commits to the
+    # runtime.
+    "git",
 )
 
 DEFAULT_SHELL_TIMEOUT_SECONDS = 120

--- a/src/aise/runtime/tool_primitives.py
+++ b/src/aise/runtime/tool_primitives.py
@@ -118,6 +118,95 @@ def _artifact_shortfalls(
     return shortfalls
 
 
+def _autocommit_dispatch_changes(
+    project_root: Path | None,
+    *,
+    agent_name: str,
+    step_id: str,
+    phase: str,
+    summary: str,
+) -> dict[str, str]:
+    """Stage + commit whatever a dispatch wrote, as one commit per task.
+
+    The project root is initialized as its own git repo by
+    :func:`aise.core.project_manager._init_project_git_repo` at
+    creation time. This helper runs immediately after a successful
+    dispatch and produces a commit with the shape::
+
+        <agent>(<step_id or phase>): <truncated first line of response>
+
+    Returns a small status dict so the event log / UI can surface it:
+
+    - ``{"status": "no-project"}`` — session has no ``project_root``.
+    - ``{"status": "not-a-repo"}`` — project root isn't a git repo
+      (e.g. an older project scaffolded before this feature existed).
+      Silent; we don't try to init one on the fly.
+    - ``{"status": "nothing-to-commit"}`` — dispatch was read-only
+      (the agent only called read_file / execute, no writes).
+    - ``{"status": "committed", "sha": "<7-char sha>", "message": "..."}``
+      — the happy path.
+    - ``{"status": "error", "error": "..."}`` — git command failed;
+      commit skipped, the run continues regardless.
+
+    Never raises — a broken git setup must not block a run.
+    """
+    if project_root is None:
+        return {"status": "no-project"}
+    if not (project_root / ".git").exists():
+        return {"status": "not-a-repo"}
+    try:
+        status = subprocess.run(  # noqa: S603 — args are literal strings from our own code
+            ["git", "status", "--porcelain"],
+            cwd=str(project_root),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if status.returncode != 0:
+            return {"status": "error", "error": (status.stderr or "")[:200]}
+        if not (status.stdout or "").strip():
+            return {"status": "nothing-to-commit"}
+        subprocess.run(  # noqa: S603
+            ["git", "add", "-A"],
+            cwd=str(project_root),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        # Compose a commit message. Format:
+        #   <agent>(<step_id or phase or "dispatch">): <first line>
+        # Keeping the first line ≤72 chars is the git convention.
+        scope = (step_id or phase or "dispatch").strip() or "dispatch"
+        first_line = (summary or "").strip().splitlines()[0] if (summary or "").strip() else ""
+        # Truncate the composed subject to 72 chars total (leaving room
+        # for "<agent>(<scope>): " prefix).
+        prefix = f"{agent_name}({scope}): "
+        remaining = max(0, 72 - len(prefix))
+        subject = prefix + (first_line[:remaining] if first_line else "no-op")
+        commit = subprocess.run(  # noqa: S603
+            ["git", "commit", "--quiet", "-m", subject],
+            cwd=str(project_root),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if commit.returncode != 0:
+            return {"status": "error", "error": (commit.stderr or "")[:200]}
+        sha_proc = subprocess.run(  # noqa: S603
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=str(project_root),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        sha = (sha_proc.stdout or "").strip()
+        return {"status": "committed", "sha": sha, "message": subject}
+    except subprocess.TimeoutExpired:
+        return {"status": "error", "error": "git command timed out"}
+    except Exception as exc:  # pragma: no cover — defensive
+        return {"status": "error", "error": str(exc)[:200]}
+
+
 def _build_retry_prompt(original_task: str, previous_response: str) -> str:
     """Compose the context-augmented retry prompt for a dispatch."""
     prev = previous_response.strip()
@@ -463,6 +552,18 @@ def make_dispatch_tools(ctx: ToolContext) -> list[BaseTool]:
 
             output_len = len(result)
             preview = result[:500] + "..." if output_len > 500 else result
+            # Auto-commit any filesystem changes the dispatch produced
+            # to the project's local git repo. Deterministic: doesn't
+            # rely on the agent remembering to commit. One commit per
+            # successful dispatch, tagged with agent + step_id so the
+            # log reads as a phase-by-phase timeline.
+            commit_info = _autocommit_dispatch_changes(
+                ctx.project_root,
+                agent_name=agent_name,
+                step_id=step_id,
+                phase=phase,
+                summary=preview,
+            )
             response_msg = {
                 "taskId": task_id,
                 "from": agent_name,
@@ -474,15 +575,17 @@ def make_dispatch_tools(ctx: ToolContext) -> list[BaseTool]:
                     "output_preview": preview,
                     "output_length": output_len,
                     "retries": retries_used,
+                    "commit": commit_info,
                 },
             }
             ctx.emit(response_msg)
             logger.info(
-                "Task completed: task=%s from=%s output=%d chars retries=%d",
+                "Task completed: task=%s from=%s output=%d chars retries=%d commit=%s",
                 task_id,
                 agent_name,
                 output_len,
                 retries_used,
+                (commit_info or {}).get("sha") or (commit_info or {}).get("status", "skipped"),
             )
             return json.dumps(response_msg, ensure_ascii=False)
         except Exception as exc:

--- a/tests/test_runtime/test_git_autocommit.py
+++ b/tests/test_runtime/test_git_autocommit.py
@@ -1,0 +1,326 @@
+"""Regression guards for the git-auto-commit convention.
+
+Every project created by AISE is initialized as its own local git
+repo at scaffold time. After every successful dispatch, the runtime
+stages + commits whatever the agent wrote with a deterministic
+``<agent>(<scope>): <subject>`` message.
+
+These tests pin both halves:
+
+- :class:`TestInitProjectGitRepo` — ``_init_project_git_repo``
+  creates a real repo with the baseline ``.gitignore`` + initial
+  scaffold commit, and re-running is idempotent.
+- :class:`TestAutocommitDispatchChanges` — the five documented
+  status branches of ``_autocommit_dispatch_changes`` each produce
+  the right shape, and the commit subject follows
+  ``<agent>(<scope>): <first-line>`` with ≤72-char clamping.
+- :class:`TestGitSkillWiredEverywhere` — the skill file exists and
+  the four agents that produce filesystem artifacts
+  (developer / architect / product_manager / qa_engineer) declare
+  ``git`` in their ``## Skills`` block.
+- :class:`TestShellAllowlistIncludesGit` — the shell primitive's
+  allowlist carries ``git`` so agents can run read-only queries
+  (``git log``, ``git diff``, ``git status``) via ``execute_shell``.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from aise.core.project_manager import (
+    _PROJECT_GITIGNORE,
+    _init_project_git_repo,
+)
+from aise.runtime.runtime_config import DEFAULT_SHELL_ALLOWLIST
+from aise.runtime.tool_primitives import _autocommit_dispatch_changes
+
+
+def _have_git() -> bool:
+    return shutil.which("git") is not None
+
+
+pytestmark = pytest.mark.skipif(not _have_git(), reason="git binary not on PATH")
+
+
+def _run_git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _init_project_git_repo
+# ---------------------------------------------------------------------------
+
+
+class TestInitProjectGitRepo:
+    def test_creates_real_repo(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        project.mkdir()
+        _init_project_git_repo(project)
+        assert (project / ".git").is_dir()
+        head = _run_git(project, "rev-parse", "HEAD")
+        assert head.returncode == 0
+        assert head.stdout.strip(), "HEAD must point at a real commit"
+
+    def test_seeds_gitignore(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        project.mkdir()
+        _init_project_git_repo(project)
+        gi = project / ".gitignore"
+        assert gi.is_file()
+        body = gi.read_text(encoding="utf-8")
+        for needle in ("runs/trace/", "__pycache__/", ".coverage"):
+            assert needle in body, f"baseline .gitignore must exclude {needle!r}"
+        assert body == _PROJECT_GITIGNORE
+
+    def test_does_not_overwrite_existing_gitignore(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        project.mkdir()
+        # Team has already tuned .gitignore before we ran.
+        custom = "custom/\n# project-specific ignores\n"
+        (project / ".gitignore").write_text(custom, encoding="utf-8")
+        _init_project_git_repo(project)
+        assert (project / ".gitignore").read_text(encoding="utf-8") == custom, (
+            "existing .gitignore must not be clobbered by the scaffold"
+        )
+
+    def test_idempotent_when_called_twice(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        project.mkdir()
+        _init_project_git_repo(project)
+        first_head = _run_git(project, "rev-parse", "HEAD").stdout.strip()
+        _init_project_git_repo(project)  # second invocation
+        second_head = _run_git(project, "rev-parse", "HEAD").stdout.strip()
+        assert first_head == second_head, "re-running scaffold must not create new commits"
+
+    def test_local_identity_configured(self, tmp_path: Path) -> None:
+        """Local user.name + user.email — avoids 'please tell me who
+        you are' on hosts without global git config."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        _init_project_git_repo(project)
+        name = _run_git(project, "config", "user.name").stdout.strip()
+        email = _run_git(project, "config", "user.email").stdout.strip()
+        assert name == "AISE Orchestrator"
+        assert email == "orchestrator@aise.local"
+
+
+# ---------------------------------------------------------------------------
+# _autocommit_dispatch_changes
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def initialized_project(tmp_path: Path) -> Path:
+    project = tmp_path / "proj"
+    project.mkdir()
+    _init_project_git_repo(project)
+    return project
+
+
+class TestAutocommitDispatchChanges:
+    def test_no_project_root_skips(self) -> None:
+        info = _autocommit_dispatch_changes(
+            None,
+            agent_name="developer",
+            step_id="impl_x",
+            phase="implementation",
+            summary="done",
+        )
+        assert info == {"status": "no-project"}
+
+    def test_not_a_repo_skips(self, tmp_path: Path) -> None:
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        info = _autocommit_dispatch_changes(
+            plain,
+            agent_name="developer",
+            step_id="impl_x",
+            phase="",
+            summary="done",
+        )
+        assert info == {"status": "not-a-repo"}
+
+    def test_nothing_to_commit_when_working_tree_is_clean(self, initialized_project: Path) -> None:
+        info = _autocommit_dispatch_changes(
+            initialized_project,
+            agent_name="developer",
+            step_id="readonly",
+            phase="",
+            summary="read-only pass",
+        )
+        assert info == {"status": "nothing-to-commit"}
+
+    def test_commits_changes_with_deterministic_subject(self, initialized_project: Path) -> None:
+        (initialized_project / "src").mkdir(exist_ok=True)
+        (initialized_project / "src" / "mod.py").write_text("print('hi')\n", encoding="utf-8")
+        info = _autocommit_dispatch_changes(
+            initialized_project,
+            agent_name="developer",
+            step_id="impl_mod",
+            phase="implementation",
+            summary="Wrote src/mod.py\nDetails follow...",
+        )
+        assert info["status"] == "committed"
+        assert len(info["sha"]) >= 4
+        # Subject format: ``<agent>(<scope>): <first line>``
+        assert info["message"].startswith("developer(impl_mod): ")
+        # First line of response was "Wrote src/mod.py" (subsequent
+        # lines are not part of the subject).
+        assert "Wrote src/mod.py" in info["message"]
+
+    def test_commit_subject_clamped_to_72_chars(self, initialized_project: Path) -> None:
+        (initialized_project / "src").mkdir(exist_ok=True)
+        (initialized_project / "src" / "mod.py").write_text("x\n", encoding="utf-8")
+        long_first_line = "x" * 200  # way over 72 chars
+        info = _autocommit_dispatch_changes(
+            initialized_project,
+            agent_name="developer",
+            step_id="impl_mod",
+            phase="",
+            summary=long_first_line,
+        )
+        assert info["status"] == "committed"
+        assert len(info["message"]) <= 72, (
+            f"commit subject must be ≤72 chars, got {len(info['message'])}: {info['message']!r}"
+        )
+        assert info["message"].startswith("developer(impl_mod): ")
+
+    def test_scope_falls_back_to_phase_then_dispatch(self, initialized_project: Path) -> None:
+        # No step_id, no phase → "dispatch".
+        (initialized_project / "src").mkdir(exist_ok=True)
+        (initialized_project / "src" / "a.py").write_text("x\n", encoding="utf-8")
+        info = _autocommit_dispatch_changes(
+            initialized_project,
+            agent_name="developer",
+            step_id="",
+            phase="",
+            summary="Hello",
+        )
+        assert info["status"] == "committed"
+        assert info["message"].startswith("developer(dispatch): ")
+        # Phase used when step_id is blank.
+        (initialized_project / "src" / "b.py").write_text("x\n", encoding="utf-8")
+        info = _autocommit_dispatch_changes(
+            initialized_project,
+            agent_name="architect",
+            step_id="",
+            phase="phase_2_design",
+            summary="Wrote architecture",
+        )
+        assert info["status"] == "committed"
+        assert info["message"].startswith("architect(phase_2_design): ")
+
+    def test_empty_summary_still_commits(self, initialized_project: Path) -> None:
+        (initialized_project / "src").mkdir(exist_ok=True)
+        (initialized_project / "src" / "c.py").write_text("y\n", encoding="utf-8")
+        info = _autocommit_dispatch_changes(
+            initialized_project,
+            agent_name="qa_engineer",
+            step_id="integration",
+            phase="",
+            summary="",
+        )
+        assert info["status"] == "committed"
+        # Empty summary yields a "no-op" placeholder subject, never an empty one.
+        assert info["message"].endswith("no-op")
+
+    def test_never_raises_on_git_failure(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Bust the ``.git`` directory mid-flight — the function must
+        swallow the error and return ``status=error`` rather than
+        blocking the run."""
+        (initialized_project / "src").mkdir(exist_ok=True)
+        (initialized_project / "src" / "x.py").write_text("x\n", encoding="utf-8")
+        # Corrupt ``.git`` in a way that breaks ``git add``/``git commit``.
+        shutil.rmtree(initialized_project / ".git" / "objects")
+        info = _autocommit_dispatch_changes(
+            initialized_project,
+            agent_name="developer",
+            step_id="impl_x",
+            phase="",
+            summary="done",
+        )
+        # Either ``error`` (most hosts) or ``nothing-to-commit`` (if
+        # git somehow recovers) — both are acceptable non-raising
+        # outcomes. The invariant is that no exception bubbles out.
+        assert info["status"] in ("error", "nothing-to-commit", "committed")
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: ProjectManager.create_project -> dispatch commit
+# ---------------------------------------------------------------------------
+
+
+class TestProjectManagerCreatesGitRepo:
+    def test_newly_created_project_is_a_git_repo(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from aise.core.project_manager import ProjectManager
+
+        monkeypatch.chdir(tmp_path)
+        pm = ProjectManager(projects_root=tmp_path / "projects")
+        project_id = pm.create_project("Test Project")
+        project = pm.get_project(project_id)
+        assert project is not None
+        root = Path(project.project_root)
+        assert (root / ".git").is_dir(), "ProjectManager.create_project must initialize the project as a git repo"
+        assert (root / ".gitignore").is_file()
+        # Initial scaffold commit is in place.
+        head = _run_git(root, "rev-parse", "HEAD")
+        assert head.returncode == 0 and head.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# Skill + agent.md wiring
+# ---------------------------------------------------------------------------
+
+
+class TestGitSkillWiredEverywhere:
+    AGENTS_DIR = Path(__file__).resolve().parents[2] / "src" / "aise" / "agents"
+
+    def test_skill_file_exists(self) -> None:
+        skill = self.AGENTS_DIR / "_runtime_skills" / "git" / "SKILL.md"
+        assert skill.is_file()
+        body = skill.read_text(encoding="utf-8")
+        # Key conventions the skill must communicate.
+        assert "auto" in body.lower() and "commit" in body.lower()
+        # Agents must be told NOT to commit themselves.
+        assert "Do NOT call `execute_shell('git commit" in body or "must not" in body.lower()
+        # Read-only queries are fine.
+        assert "git log" in body
+        assert "git diff" in body
+
+    @pytest.mark.parametrize(
+        "agent_file",
+        ["developer.md", "architect.md", "product_manager.md", "qa_engineer.md"],
+    )
+    def test_agent_declares_git_skill(self, agent_file: str) -> None:
+        path = self.AGENTS_DIR / agent_file
+        body = path.read_text(encoding="utf-8")
+        # Must appear in the ``## Skills`` block as ``- git: …``.
+        assert "\n- git:" in body, (
+            f"{agent_file} must declare ``git`` in its ## Skills list — "
+            "otherwise the skill body is filtered out by "
+            "``_load_inline_skill_content`` and the agent won't see the "
+            "auto-commit convention"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestShellAllowlistIncludesGit:
+    def test_git_on_allowlist(self) -> None:
+        assert "git" in DEFAULT_SHELL_ALLOWLIST, (
+            "``git`` must be on the shell allowlist so agents can run "
+            "read-only queries via execute_shell (git log / diff / status)"
+        )


### PR DESCRIPTION
## Summary

Every new project is now initialized as its own local git repo at scaffold time, and after every successful dispatch the runtime commits whatever the agent wrote with a deterministic message. Agents get a new `git` skill that documents the convention.

## Motivation

On `project_5-snake` (run_772c67907e, 2026-04-22): Phase 6 delivery instructed the PM to run `git status` / `git diff` to detect incremental changes. But `projects/project_5-snake/` wasn't its own repo — it sat inside the AISE host repo, so `git status` returned the AISE repo's unrelated diff. PM burned 40 LLM calls thrashing on variations (`cd /home/...`, `pwd`, `git rev-parse --show-toplevel`), eventually hit an absolute-host-path policy rejection and aborted Phase 6 with no delivery report.

Root cause: projects had no version control of their own. This PR fixes that — projects are real repos and `git` commands inside their root do what the orchestrator expected. Bonus: users now get a readable history of what each phase / each agent produced.

## Changes

- **`core/project_manager.py`** — `_init_project_git_repo()`: `git init`, seeded `.gitignore` (runtime artefacts, `__pycache__`, `.coverage`, IDE junk), local `user.name` / `user.email`, "project scaffold" root commit. Idempotent, never raises.
- **`runtime/tool_primitives.py`** — `_autocommit_dispatch_changes()`: after a successful `dispatch_task`, `git add -A` + `git commit` with subject `<agent>(<scope>): <first-line-of-response>` clamped to 72 chars. Returns a status dict (`committed` / `nothing-to-commit` / `not-a-repo` / `no-project` / `error`) carried on the `task_response` payload.
- **`runtime/runtime_config.py`** — `git` added to `DEFAULT_SHELL_ALLOWLIST` so agents can still run read-only queries via `execute_shell` (`git log`, `git diff`, `git show HEAD:<file>`).
- **`agents/_runtime_skills/git/SKILL.md`** — new skill documenting the runtime model: every project is its own repo; agents must NOT run `git commit` / `git add` / `git reset --hard` themselves; read-only queries encouraged.
- **Agent wiring** — developer / architect / product_manager / qa_engineer declare `git` in their `## Skills` block.

## Test plan

- [x] `tests/test_runtime/test_git_autocommit.py` — 20 new cases covering repo init (5), autocommit status branches + subject clamp + scope fallback (7), project-manager end-to-end (1), per-agent skill wiring (5), shell allowlist (1). All gated on `shutil.which("git")`.
- [x] Full suite: 660 passed, 53 skipped locally (CI will re-verify 829-ish with runtime tests unskipped).
- [x] Ruff + format clean.

## Scope notes

- Pre-existing projects scaffolded before this change are NOT retroactively initialized — the `not-a-repo` status branch handles them gracefully. `git init` them manually if you want them tracked.
- No UI changes here; commit info lands in the `task_response` payload under `commit`, the web UI can surface it in a follow-up.
- Phase 6's delta-detection prompt (the original symptom) isn't edited in this PR — now that projects are real repos, the existing `git status` / `git diff` commands in that prompt start working as intended on the next incremental run.