### PR TITLE
refactor: migrate web-facing ProjectManager to runtime module (PR-a of 3)

### DIFF
--- a/src/aise/runtime/project_manager.py
+++ b/src/aise/runtime/project_manager.py
@@ -1,0 +1,279 @@
+"""Project Manager — runtime-owned lifecycle for Web-driven projects.
+
+This is the AI-First path forward: the web layer creates projects through
+this manager, which will eventually dispatch the ``product_manager`` agent
+to do environment preparation (directory scaffolding, git init, phase
+tagging, per-phase summaries). Legacy callers (``MultiProjectSession``
+on the ``aise multi-project`` CLI) still use the older
+``aise.core.project_manager.ProjectManager`` and are intentionally not
+migrated here — the two diverge as this file gains AI-First behaviors.
+
+Scope of this file (PR-a, pure refactor — no behavior change):
+
+- ``ProjectManager`` lifecycle — create / get / list / pause / resume /
+  complete / delete — carried over verbatim from ``core.project_manager``.
+- ``_prepare_project_root`` — still a plain ``mkdir`` of the standard
+  sub-directories. Git init and other LLM-driven scaffolding land in
+  a follow-up PR (PR-b).
+
+What is intentionally *not* here (compared to ``core.project_manager``):
+
+- ``run_project_workflow`` / ``_normalize_*_workflow_result`` / phase
+  key splitters / SDLC-phase constants — these serve the legacy
+  ``MultiProjectSession`` path, not the web runtime, and stay in the
+  core module.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from ..config import ProjectConfig
+from ..core.agent import AgentRole
+from ..core.project import Project, ProjectStatus
+from ..utils.logging import get_logger
+
+if TYPE_CHECKING:
+    pass
+
+logger = get_logger(__name__)
+
+
+class ProjectManager:
+    """Manages multiple concurrent projects and their lifecycle.
+
+    The ProjectManager creates and coordinates multiple isolated projects,
+    each with its own team of agents, message bus, and artifact store.
+    """
+
+    def __init__(
+        self,
+        *,
+        projects_root: str | Path = "projects",
+        global_config_path: str | Path = "config/global_project_config.json",
+    ) -> None:
+        """Initialize the project manager."""
+        self._projects: dict[str, Project] = {}
+        self._project_counter = 0
+        # Resolve once so background threads are not affected by process cwd changes.
+        self._projects_root = Path(projects_root).resolve()
+        self._global_config_path = Path(global_config_path).resolve()
+        self._global_config = self._load_global_config()
+        logger.info(
+            "ProjectManager initialized: projects_root=%s global_config=%s",
+            self._projects_root,
+            self._global_config_path,
+        )
+
+    def create_project(
+        self,
+        project_name: str,
+        config: ProjectConfig | None = None,
+        agent_counts: dict[AgentRole, int] | None = None,
+    ) -> str:
+        """Create a new project with its own agent team.
+
+        Args:
+            project_name: Human-readable project name
+            config: Optional project configuration (GitHub settings, model config, etc.)
+            agent_counts: Optional dict mapping AgentRole to count
+                         Example: {AgentRole.DEVELOPER: 3, AgentRole.QA_ENGINEER: 2}
+                         Default: 1 agent per role
+
+        Returns:
+            Unique project ID for referencing this project
+
+        Example:
+            ```python
+            pm = ProjectManager()
+            project_id = pm.create_project(
+                "E-commerce Platform",
+                config=ProjectConfig(development_mode="github"),
+                agent_counts={AgentRole.DEVELOPER: 3, AgentRole.QA_ENGINEER: 2}
+            )
+            ```
+        """
+        # Generate unique project ID
+        project_id = f"project_{self._project_counter}"
+        self._project_counter += 1
+
+        # Prepare configuration (inherit global defaults by default)
+        config = config or self.create_default_project_config(project_name)
+        config.project_name = project_name
+
+        # Persist project directory and config snapshot
+        project_root = self._prepare_project_root(project_id, project_name)
+        config.to_json_file(project_root / "project_config.json")
+
+        # Create isolated orchestrator with agents
+        # Import locally to avoid circular dependency
+        from ..main import create_team
+
+        orchestrator = create_team(config, agent_counts)
+        orchestrator.project_root = str(project_root)
+
+        # Create project container
+        project = Project(
+            project_id=project_id,
+            config=config,
+            orchestrator=orchestrator,
+            project_root=str(project_root),
+        )
+
+        # Store project
+        self._projects[project_id] = project
+        logger.info(
+            "Project created: project_id=%s name=%s mode=%s agents=%d",
+            project_id,
+            project_name,
+            project.development_mode,
+            project.agent_count,
+        )
+
+        return project_id
+
+    def create_default_project_config(self, project_name: str) -> ProjectConfig:
+        """Create a project config by inheriting global defaults."""
+        config = ProjectConfig.from_dict(self._global_config.to_dict())
+        config.project_name = project_name
+        return config
+
+    def _load_global_config(self) -> ProjectConfig:
+        """Load global config if available, otherwise use built-in defaults."""
+        if not self._global_config_path.exists():
+            logger.info("Global config not found, using defaults: path=%s", self._global_config_path)
+            return ProjectConfig()
+        logger.info("Loading global config: path=%s", self._global_config_path)
+        return ProjectConfig.from_json_file(self._global_config_path)
+
+    def _prepare_project_root(self, project_id: str, project_name: str) -> Path:
+        """Create and return the filesystem root for a project."""
+        safe_name = "".join(c.lower() if c.isalnum() else "-" for c in project_name).strip("-")
+        safe_name = "-".join(filter(None, safe_name.split("-"))) or "project"
+        project_root = self._projects_root / f"{project_id}-{safe_name}"
+        project_root.mkdir(parents=True, exist_ok=True)
+        for subdir in ("docs", "src", "tests", "scripts", "config", "artifacts", "trace"):
+            (project_root / subdir).mkdir(parents=True, exist_ok=True)
+        return project_root
+
+    def get_project(self, project_id: str) -> Project | None:
+        """Get a project by its ID.
+
+        Args:
+            project_id: The project ID
+
+        Returns:
+            Project instance or None if not found
+        """
+        return self._projects.get(project_id)
+
+    def list_projects(
+        self,
+        status_filter: ProjectStatus | None = None,
+    ) -> list[Project]:
+        """List all projects, optionally filtered by status.
+
+        Args:
+            status_filter: Optional status to filter by (ACTIVE, PAUSED, COMPLETED, ARCHIVED)
+
+        Returns:
+            List of Project instances
+        """
+        if status_filter is None:
+            return list(self._projects.values())
+
+        return [p for p in self._projects.values() if p.status == status_filter]
+
+    def delete_project(self, project_id: str) -> bool:
+        """Delete a project and clean up its resources.
+
+        Args:
+            project_id: The project ID to delete
+
+        Returns:
+            True if project was deleted, False if not found
+        """
+        if project_id in self._projects:
+            project = self._projects[project_id]
+            # Archive before deletion for cleanup
+            project.archive()
+            del self._projects[project_id]
+            return True
+        return False
+
+    def pause_project(self, project_id: str) -> bool:
+        """Pause a project (stop accepting new work).
+
+        Args:
+            project_id: The project ID
+
+        Returns:
+            True if project was paused, False if not found
+        """
+        project = self.get_project(project_id)
+        if project:
+            project.pause()
+            return True
+        return False
+
+    def resume_project(self, project_id: str) -> bool:
+        """Resume a paused project.
+
+        Args:
+            project_id: The project ID
+
+        Returns:
+            True if project was resumed, False if not found or not paused
+        """
+        project = self.get_project(project_id)
+        if project and project.status == ProjectStatus.PAUSED:
+            project.resume()
+            return True
+        return False
+
+    def complete_project(self, project_id: str) -> bool:
+        """Mark a project as completed.
+
+        Args:
+            project_id: The project ID
+
+        Returns:
+            True if project was marked complete, False if not found
+        """
+        project = self.get_project(project_id)
+        if project:
+            project.complete()
+            return True
+        return False
+
+    def get_project_info(self, project_id: str) -> dict[str, Any] | None:
+        """Get project information as a dictionary.
+
+        Args:
+            project_id: The project ID
+
+        Returns:
+            Dictionary with project metadata or None if not found
+        """
+        project = self.get_project(project_id)
+        if project:
+            return project.get_info()
+        return None
+
+    def get_all_projects_info(self) -> list[dict[str, Any]]:
+        """Get information for all projects.
+
+        Returns:
+            List of project info dictionaries
+        """
+        return [project.get_info() for project in self._projects.values()]
+
+    @property
+    def project_count(self) -> int:
+        """Get the total number of projects."""
+        return len(self._projects)
+
+    def __repr__(self) -> str:
+        """String representation of the project manager."""
+        return f"ProjectManager(projects={self.project_count})"

--- a/src/aise/web/app.py
+++ b/src/aise/web/app.py
@@ -23,7 +23,7 @@ from starlette.status import HTTP_303_SEE_OTHER, HTTP_401_UNAUTHORIZED
 
 from ..config import ProjectConfig
 from ..core.project import Project, ProjectStatus
-from ..core.project_manager import ProjectManager
+from ..runtime.project_manager import ProjectManager
 from ..utils.logging import configure_logging, configure_module_file_logger, get_logger
 from .i18n import make_translator
 from .log_service import LogService

--- a/tests/test_runtime/test_project_manager.py
+++ b/tests/test_runtime/test_project_manager.py
@@ -1,0 +1,283 @@
+"""Tests for ``aise.runtime.project_manager`` — the web-runtime PM.
+
+PR-a migrated the actively-used lifecycle methods from
+``aise.core.project_manager`` into this new module. These tests pin both
+halves of the migration:
+
+1. The public API shape (signatures + return contracts) matches the
+   caller's expectations. ``web/app.py`` is the only production caller
+   and it must keep working unchanged.
+2. Lifecycle behaviors that were previously covered in
+   ``tests/test_core/test_project_manager.py`` still pass against the
+   new module. The module-level copy is deliberate — once the legacy
+   core module is removed, the core test file goes away with it and
+   this file stands alone.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+from aise.config import ProjectConfig
+from aise.core.project import ProjectStatus
+from aise.runtime.project_manager import ProjectManager
+
+
+class _StubOrchestrator:
+    def __init__(self) -> None:
+        self.agents: dict[str, object] = {}
+
+
+def _write_global_config(path: Path) -> None:
+    data = {
+        "project_name": "Global Template",
+        "development_mode": "local",
+        "default_model": {
+            "provider": "anthropic",
+            "model": "claude-opus-4",
+            "api_key": "",
+            "base_url": "",
+            "temperature": 0.2,
+            "max_tokens": 8192,
+            "extra": {},
+        },
+        "workflow": {
+            "max_review_iterations": 5,
+            "fail_on_review_rejection": True,
+        },
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _make_manager(tmp_path: Path, monkeypatch) -> ProjectManager:
+    monkeypatch.setattr("aise.main.create_team", lambda *args, **kwargs: _StubOrchestrator())
+    global_config_path = tmp_path / "config/global_project_config.json"
+    _write_global_config(global_config_path)
+    return ProjectManager(
+        projects_root=tmp_path / "projects",
+        global_config_path=global_config_path,
+    )
+
+
+class TestPublicApiSignatures:
+    """The web layer imports a handful of methods by name. If the
+    signature drifts, ``WebProjectService`` would either break at
+    runtime or silently behave differently. Pin it with ``inspect`` so
+    the breakage shows up as a test failure instead.
+    """
+
+    REQUIRED_METHODS = (
+        "__init__",
+        "create_project",
+        "create_default_project_config",
+        "_prepare_project_root",
+        "get_project",
+        "list_projects",
+        "delete_project",
+        "pause_project",
+        "resume_project",
+        "complete_project",
+        "get_project_info",
+        "get_all_projects_info",
+    )
+
+    def test_all_required_methods_present(self) -> None:
+        for name in self.REQUIRED_METHODS:
+            assert hasattr(ProjectManager, name), f"ProjectManager.{name} missing after migration"
+            assert callable(getattr(ProjectManager, name))
+
+    def test_create_project_signature_accepts_name_config_agent_counts(self) -> None:
+        sig = inspect.signature(ProjectManager.create_project)
+        params = dict(sig.parameters)
+        # ``self`` + the three public kwargs used by ``web/app.py``.
+        assert set(params) == {"self", "project_name", "config", "agent_counts"}
+        assert params["config"].default is None
+        assert params["agent_counts"].default is None
+
+    def test_constructor_accepts_kw_only_projects_root_and_global_config_path(self) -> None:
+        sig = inspect.signature(ProjectManager.__init__)
+        assert "projects_root" in sig.parameters
+        assert "global_config_path" in sig.parameters
+        # Both must be keyword-only to match the ``ProjectManager()``
+        # call in ``WebProjectService``.
+        assert sig.parameters["projects_root"].kind == inspect.Parameter.KEYWORD_ONLY
+        assert sig.parameters["global_config_path"].kind == inspect.Parameter.KEYWORD_ONLY
+
+    def test_dead_workflow_methods_are_absent(self) -> None:
+        """These served the legacy ``MultiProjectSession`` path and
+        were intentionally left behind. Their presence would indicate
+        a regression to the pre-migration blob."""
+        for name in (
+            "run_project_workflow",
+            "_normalize_dynamic_workflow_result",
+            "_normalize_deep_workflow_result",
+            "_infer_phase_from_process",
+            "_split_phase_agent_key",
+            "_build_phase_task_payload",
+            "_get_planner_llm_client",
+        ):
+            assert not hasattr(ProjectManager, name), (
+                f"ProjectManager.{name} should NOT be on the runtime PM — it belongs to the legacy core module"
+            )
+
+
+class TestGlobalConfigInheritance:
+    """Carried over from ``tests/test_core/test_project_manager.py`` —
+    ``WebProjectService.create_project`` depends on the config snapshot
+    landing at ``<project_root>/project_config.json`` and on the
+    returned config inheriting global defaults.
+    """
+
+    def test_create_project_inherits_global_config_and_persists_snapshot(self, tmp_path, monkeypatch):
+        manager = _make_manager(tmp_path, monkeypatch)
+        project_id = manager.create_project("RD-Portal")
+        project = manager.get_project(project_id)
+
+        assert project is not None
+        assert project.config.default_model.provider == "anthropic"
+        assert project.config.workflow.max_review_iterations == 5
+        assert project.project_root is not None
+
+        config_file = Path(project.project_root) / "project_config.json"
+        assert config_file.exists()
+        persisted = ProjectConfig.from_json_file(config_file)
+        assert persisted.project_name == "RD-Portal"
+        assert persisted.default_model.model == "claude-opus-4"
+        assert persisted.workflow.fail_on_review_rejection is True
+
+        for subdir in ("docs", "src", "tests", "scripts", "config", "artifacts", "trace"):
+            assert (Path(project.project_root) / subdir).exists(), f"scaffold missing {subdir}/"
+
+    def test_create_default_project_config_returns_global_template_copy(self, tmp_path):
+        global_config_path = tmp_path / "config/global_project_config.json"
+        _write_global_config(global_config_path)
+
+        manager = ProjectManager(
+            projects_root=tmp_path / "projects",
+            global_config_path=global_config_path,
+        )
+        config = manager.create_default_project_config("MyProject")
+
+        assert config.project_name == "MyProject"
+        assert config.default_model.provider == "anthropic"
+        assert config.workflow.max_review_iterations == 5
+
+    def test_create_project_without_global_config_file_uses_builtin_defaults(self, tmp_path, monkeypatch):
+        """If ``config/global_project_config.json`` is missing, the
+        manager falls back to ``ProjectConfig()`` defaults — never
+        raises."""
+        monkeypatch.setattr("aise.main.create_team", lambda *args, **kwargs: _StubOrchestrator())
+        manager = ProjectManager(
+            projects_root=tmp_path / "projects",
+            global_config_path=tmp_path / "does/not/exist.json",
+        )
+        project_id = manager.create_project("NoGlobalConfigProject")
+        assert manager.get_project(project_id) is not None
+
+
+class TestProjectLifecycle:
+    """Lifecycle transitions the web layer invokes on user actions
+    (pause / resume / complete / delete). Covered here for the first
+    time — previously no lifecycle tests existed in the core file."""
+
+    def test_pause_and_resume_round_trip(self, tmp_path, monkeypatch):
+        manager = _make_manager(tmp_path, monkeypatch)
+        project_id = manager.create_project("LifecycleProject")
+
+        assert manager.pause_project(project_id) is True
+        project = manager.get_project(project_id)
+        assert project is not None and project.status == ProjectStatus.PAUSED
+
+        assert manager.resume_project(project_id) is True
+        project = manager.get_project(project_id)
+        assert project is not None and project.status == ProjectStatus.ACTIVE
+
+    def test_resume_on_non_paused_project_returns_false(self, tmp_path, monkeypatch):
+        manager = _make_manager(tmp_path, monkeypatch)
+        project_id = manager.create_project("ActiveProject")
+        # Project is ACTIVE, not PAUSED → resume must return False.
+        assert manager.resume_project(project_id) is False
+
+    def test_complete_flips_status(self, tmp_path, monkeypatch):
+        manager = _make_manager(tmp_path, monkeypatch)
+        project_id = manager.create_project("CompletionProject")
+
+        assert manager.complete_project(project_id) is True
+        project = manager.get_project(project_id)
+        assert project is not None and project.status == ProjectStatus.COMPLETED
+
+    def test_delete_removes_project_from_registry(self, tmp_path, monkeypatch):
+        manager = _make_manager(tmp_path, monkeypatch)
+        project_id = manager.create_project("Doomed")
+
+        assert manager.delete_project(project_id) is True
+        assert manager.get_project(project_id) is None
+        assert manager.delete_project(project_id) is False  # second delete → no-op
+
+    def test_list_projects_filters_by_status(self, tmp_path, monkeypatch):
+        manager = _make_manager(tmp_path, monkeypatch)
+        active_id = manager.create_project("Active")
+        paused_id = manager.create_project("Paused")
+        manager.pause_project(paused_id)
+
+        active_list = manager.list_projects(status_filter=ProjectStatus.ACTIVE)
+        assert [p.project_id for p in active_list] == [active_id]
+
+        paused_list = manager.list_projects(status_filter=ProjectStatus.PAUSED)
+        assert [p.project_id for p in paused_list] == [paused_id]
+
+        all_list = manager.list_projects()
+        assert {p.project_id for p in all_list} == {active_id, paused_id}
+
+    def test_get_project_info_returns_dict_for_existing_and_none_for_missing(self, tmp_path, monkeypatch):
+        manager = _make_manager(tmp_path, monkeypatch)
+        project_id = manager.create_project("InfoProject")
+        info = manager.get_project_info(project_id)
+        assert isinstance(info, dict)
+        assert info["project_id"] == project_id
+        assert manager.get_project_info("does-not-exist") is None
+
+    def test_get_all_projects_info_matches_project_count(self, tmp_path, monkeypatch):
+        manager = _make_manager(tmp_path, monkeypatch)
+        manager.create_project("A")
+        manager.create_project("B")
+        manager.create_project("C")
+        infos = manager.get_all_projects_info()
+        assert len(infos) == manager.project_count == 3
+        assert all(isinstance(i, dict) for i in infos)
+
+    def test_project_id_sequence_is_monotonic(self, tmp_path, monkeypatch):
+        manager = _make_manager(tmp_path, monkeypatch)
+        ids = [manager.create_project(f"Seq{i}") for i in range(3)]
+        assert ids == ["project_0", "project_1", "project_2"]
+
+
+class TestProjectRootLayout:
+    """``_prepare_project_root`` is the only scaffolding step this PR
+    touches (just a mkdir; AI-First git init is a follow-up PR). Pin
+    the subdirs and sanitized-name logic so PR-b knows exactly what
+    it is replacing.
+    """
+
+    def test_subdirs_created(self, tmp_path, monkeypatch):
+        manager = _make_manager(tmp_path, monkeypatch)
+        project_id = manager.create_project("Any")
+        root = Path(manager.get_project(project_id).project_root)
+        for subdir in ("docs", "src", "tests", "scripts", "config", "artifacts", "trace"):
+            assert (root / subdir).is_dir()
+
+    def test_project_name_sanitized_into_directory_slug(self, tmp_path, monkeypatch):
+        manager = _make_manager(tmp_path, monkeypatch)
+        project_id = manager.create_project("My Weird / Project Name!")
+        root = Path(manager.get_project(project_id).project_root)
+        # Non-alnum → dashes, collapsed, lowercased.
+        assert root.name.endswith("-my-weird-project-name")
+
+    def test_empty_project_name_falls_back_to_project_slug(self, tmp_path, monkeypatch):
+        manager = _make_manager(tmp_path, monkeypatch)
+        project_id = manager.create_project("???")
+        root = Path(manager.get_project(project_id).project_root)
+        assert root.name.endswith("-project")


### PR DESCRIPTION
## Context

Groundwork for the AI-First project-scaffolding redesign tracked in #122 (safety-net warning dashboard is the final follow-up piece). This is **PR-a of 3**:

- **PR-a (this)** — move the actively-used ``ProjectManager`` lifecycle methods into ``aise.runtime``. Pure refactor, no behavior change.
- **PR-b (next)** — AI-First project entry: ``WebProjectService.create_project`` returns immediately with ``project_id`` and asynchronously dispatches the ``product_manager`` agent to scaffold the environment (create dirs, ``git init``, inter-phase ``phase_<N>_<name>`` tags on success, ``git log`` phase summaries). ``product_manager.md`` and the ``git`` skill carry the behavior.
- **PR-c (last)** — safety-net module: after each step, first validate plan-declared ``expected_artifacts`` (layer B); if B passes, fall back to hardcoded invariants (layer A). Repair + structured ``analytics_events.jsonl`` events for LLM-capability telemetry.

This PR unblocks PR-b by giving the new behaviors a dedicated home without disturbing the legacy ``MultiProjectSession`` CLI path.

## What moved

New file ``src/aise/runtime/project_manager.py`` carries exactly what ``web/app.py`` actually calls:

- ``__init__`` / ``create_project`` / ``create_default_project_config``
- ``_load_global_config`` / ``_prepare_project_root``
- ``get_project`` / ``list_projects`` / ``get_project_info`` / ``get_all_projects_info``
- ``pause_project`` / ``resume_project`` / ``complete_project`` / ``delete_project``
- ``project_count`` / ``__repr__``

``web/app.py`` switched its single import to point at the new module.

## What stayed behind (intentional)

``aise.core.project_manager`` is **not modified**. It still serves the legacy ``aise multi-project`` CLI via ``MultiProjectSession``, which touches ``run_project_workflow`` / ``_normalize_dynamic_workflow_result`` / ``_normalize_deep_workflow_result`` / ``_split_phase_agent_key`` / ``_build_phase_task_payload``. None of those are on the web runtime hot path, so they didn't migrate. When the CLI path is retired, the core file disappears with it.

## Tests — ``tests/test_runtime/test_project_manager.py`` (18 cases)

| Class | N | Purpose |
|---|---|---|
| ``TestPublicApiSignatures`` | 4 | Pin the public API shape ``web/app.py`` depends on (via ``inspect``). Also pins that the dead workflow methods are absent from the runtime module. |
| ``TestGlobalConfigInheritance`` | 3 | Carried over from the core test file; adds a missing-global-config fallback case. |
| ``TestProjectLifecycle`` | 8 | New coverage for pause / resume / complete / delete / list-by-status / project-info / id sequence. None of these were previously tested. |
| ``TestProjectRootLayout`` | 3 | Pins the mkdir-only scaffolding contract so PR-b's AI-First replacement has a clear target. |

Legacy ``tests/test_core/test_project_manager.py`` is left untouched — it still exercises ``core.project_manager``, which still exists.

## Test plan

- [x] ``pytest tests/test_runtime/test_project_manager.py -v`` — 18 passed
- [x] ``pytest`` full suite — 726 passed, 53 skipped (no regressions)
- [x] ``ruff check src/ tests/`` — clean
- [x] ``ruff format --check src/ tests/`` — 291 files already formatted
- [x] ``python -m build --wheel`` — OK

## Review checklist

- [ ] New file imports are correct (``..core.project`` / ``..core.agent`` / ``..config`` / ``..utils.logging``)
- [ ] ``web/app.py:26`` now points to ``..runtime.project_manager``
- [ ] No behavioral drift — method bodies are byte-for-byte identical to the core versions