### PR TITLE
feat(runtime): safety-net module + scaffolding auto-repair (PR-c of 3)

### DIFF
--- a/src/aise/runtime/safety_net.py
+++ b/src/aise/runtime/safety_net.py
@@ -1,0 +1,610 @@
+"""Safety net that verifies and repairs LLM-driven step outputs.
+
+PR-b handed scaffolding and per-phase operations to the product-manager
+agent. This module closes the loop: after each step the safety net
+checks that what the LLM *claimed* to do actually landed on disk, and
+if not, runs a mechanical repair action so the project doesn't enter
+an unrecoverable state.
+
+Two layers of checks, applied in order:
+
+1. **Layer B** — plan-declared ``expected_artifacts``. The caller
+   passes a list of ``ExpectedArtifact`` objects describing what the
+   step *should* have produced. B is the "official contract"
+   assertion: it lets process.md templates and agent skills declare
+   their post-conditions and catch violations directly.
+
+2. **Layer A** — hardcoded invariants. If layer B passes (or the
+   caller didn't supply any B expectations), a second pass runs
+   conservative invariants that guard the project's structural
+   integrity — is it still a git repo? is the working tree clean
+   after a phase that wrote files? — to catch drift that the caller
+   didn't explicitly declare. A is also load-bearing for legacy
+   callers that haven't written a B contract yet.
+
+Every detected miss produces:
+
+- A structured event appended to ``<project_root>/trace/safety_net_events.jsonl``
+  — this doubles as telemetry to measure LLM-capability over time
+  (see issue #122 for the follow-up dashboard).
+- A repair action, dispatched through the :data:`REPAIR_ACTIONS`
+  registry. Repairs are best-effort; failures are captured on the
+  outcome dict and also emitted as events.
+
+The module never raises — a broken safety net must not block a run.
+Errors are captured as ``repair_status="error"`` events and surfaced
+on the ``CheckOutcome`` return value. Callers decide whether to
+flip ``ProjectStatus.SCAFFOLDING_FAILED`` (scaffolding path) or just
+log a warning (per-phase path, where the agent may recover).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ..utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+# Baseline ``.gitignore`` seeded by the ``missing_gitignore`` repair
+# action. Kept here (not imported from some other module) so the safety
+# net is self-contained — a teammate reading this file can reproduce
+# what the repair does without chasing cross-package refs.
+#
+# Secret patterns are deliberate: if the PM agent forgot to write a
+# ``.gitignore`` at all, a plain baseline that didn't exclude keys /
+# credentials would be worse than no gitignore, because then the
+# phase-end autocommit would happily capture whatever was lying
+# around.
+_BASELINE_GITIGNORE = """\
+# AISE runtime artefacts
+runs/trace/
+runs/plans/
+analytics_events.jsonl
+trace/safety_net_events.jsonl
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache/
+.coverage
+coverage.xml
+htmlcov/
+.mypy_cache/
+.ruff_cache/
+
+# Node / JS
+node_modules/
+dist/
+build/
+
+# OS / IDE
+.DS_Store
+.vscode/
+.idea/
+
+# Secrets / credentials — never commit these
+.env
+.env.*
+*.pem
+*.key
+*_secret*
+*credentials*
+"""
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ExpectedArtifact:
+    """A single layer-B expectation for a step's output.
+
+    ``kind`` values:
+    - ``"dir"`` — ``path`` must be a directory (exists + is_dir).
+    - ``"file"`` — ``path`` must be a regular file; if ``non_empty`` is
+      true, also requires size > 0.
+    - ``"git_repo"`` — ``path`` must contain a ``.git`` entry (dir or
+      worktree reference); other fields ignored.
+    - ``"git_tag"`` — ``tag_name`` (required) must be present in the
+      repo at ``path``.
+    - ``"clean_tree"`` — ``git status --porcelain`` at ``path`` must
+      be empty (useful after a phase that should have committed
+      everything it wrote).
+
+    ``path`` is relative to the project root. Use ``"."`` for
+    project-root-level checks.
+    """
+
+    path: str
+    kind: str
+    tag_name: str | None = None
+    non_empty: bool = False
+    description: str = ""
+
+    def describe(self) -> str:
+        """Human-readable identifier used in telemetry events."""
+        if self.kind == "git_tag":
+            return f"git_tag:{self.tag_name}"
+        if self.kind == "clean_tree":
+            return "clean_tree"
+        if self.kind == "git_repo":
+            return "git_repo"
+        return f"{self.kind}:{self.path}"
+
+
+@dataclass
+class CheckOutcome:
+    """Aggregated result of a single post-step check + repair pass."""
+
+    step_id: str
+    layer_b_missing: list[ExpectedArtifact] = field(default_factory=list)
+    layer_a_failures: list[str] = field(default_factory=list)
+    repairs_attempted: list[str] = field(default_factory=list)
+    repairs_succeeded: list[str] = field(default_factory=list)
+    repairs_failed: list[tuple[str, str]] = field(default_factory=list)
+    events_emitted: int = 0
+
+    @property
+    def repaired_ok(self) -> bool:
+        """True when the step ultimately landed in a good state.
+
+        Either nothing was missing, or everything that was missing got
+        repaired successfully. A caller that wants "all green" as a
+        gate should check this flag.
+        """
+        return not self.layer_a_failures and not self.repairs_failed
+
+
+# ---------------------------------------------------------------------------
+# Repair actions
+# ---------------------------------------------------------------------------
+
+
+def _run_git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run a git command under ``cwd``. Never raises; returncode tells
+    the caller what happened. Kept small and duplicated from PR-b's
+    ``web/app.py`` helper rather than cross-importing, because the
+    safety net has to keep working even if the web package failed to
+    import.
+    """
+    return subprocess.run(  # noqa: S603 — args are literal strings from our own code
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+
+def _repair_git_init(project_root: Path, ctx: dict[str, Any]) -> None:  # noqa: ARG001
+    """The PM agent forgot to run ``git init`` — do it ourselves.
+
+    Idempotent: if ``.git`` sneaks into existence between the check
+    and the repair (a concurrent retry, say), ``git init`` is a no-op.
+    Also configures a local identity so later commits don't fail on
+    hosts without a global ``user.name`` / ``user.email``.
+    """
+    result = _run_git(project_root, "init", "--quiet")
+    if result.returncode != 0:
+        raise RuntimeError(f"git init failed: {(result.stderr or '').strip()[:200]}")
+    _run_git(project_root, "config", "user.name", "AISE Orchestrator")
+    _run_git(project_root, "config", "user.email", "orchestrator@aise.local")
+
+
+def _repair_seed_gitignore(project_root: Path, ctx: dict[str, Any]) -> None:  # noqa: ARG001
+    """Write the baseline ``.gitignore`` the PM agent should have
+    written. Refuses to overwrite an existing file — if one is there
+    it's either the agent's tuned version or a user's manual edit,
+    and we'd rather let the layer-A check pass empty-content next
+    time than silently clobber."""
+    gi = project_root / ".gitignore"
+    if gi.exists():
+        return
+    gi.write_text(_BASELINE_GITIGNORE, encoding="utf-8")
+
+
+def _repair_create_standard_subdirs(project_root: Path, ctx: dict[str, Any]) -> None:  # noqa: ARG001
+    """Create the seven standard subdirs when the PM agent skipped
+    them. Cheap, idempotent — ``mkdir(exist_ok=True)`` on a full set
+    is a no-op if they're already there."""
+    for subdir in ("docs", "src", "tests", "scripts", "config", "artifacts", "trace"):
+        (project_root / subdir).mkdir(parents=True, exist_ok=True)
+
+
+def _repair_autocommit(project_root: Path, ctx: dict[str, Any]) -> None:
+    """Phase ended with files sitting uncommitted — the PM agent
+    forgot the end-of-phase commit ritual. Commit them ourselves with
+    a subject that makes it clear this was a safety-net fallback,
+    not a real agent commit.
+
+    Context dict may carry ``step_id`` so the message ties the commit
+    back to the phase that missed it.
+    """
+    step = str(ctx.get("step_id") or "unknown_phase").strip() or "unknown_phase"
+    # Stage everything that's tracked OR untracked.
+    add = _run_git(project_root, "add", "-A")
+    if add.returncode != 0:
+        raise RuntimeError(f"git add -A failed: {(add.stderr or '').strip()[:200]}")
+    # Refuse to create an empty commit — if there's nothing to commit,
+    # the earlier invariant would have passed; being here means
+    # someone else committed between the check and the repair.
+    diff = _run_git(project_root, "diff", "--cached", "--quiet")
+    if diff.returncode == 0:
+        return
+    subject = f"safety_net({step}): autocommit uncommitted changes"[:72]
+    commit = _run_git(project_root, "commit", "--quiet", "-m", subject)
+    if commit.returncode != 0:
+        raise RuntimeError(f"git commit failed: {(commit.stderr or '').strip()[:200]}")
+
+
+def _repair_create_phase_tag(project_root: Path, ctx: dict[str, Any]) -> None:
+    """The phase completed successfully but the PM agent didn't tag
+    HEAD as ``phase_<N>_<name>``. Tag it ourselves so the next phase's
+    ``git diff phase_<N>..HEAD`` has something to compare against.
+
+    The target tag name MUST be supplied via ``ctx["tag_name"]``.
+    Without it, the repair is a no-op — we won't invent a tag name
+    from thin air because a wrong tag would break all future diffs.
+    """
+    tag = str(ctx.get("tag_name") or "").strip()
+    if not tag:
+        return
+    # ``git tag`` refuses to recreate an existing tag; idempotent
+    # behavior is OK because the caller runs the check FIRST and only
+    # invokes repair if the tag was missing.
+    result = _run_git(project_root, "tag", tag)
+    if result.returncode != 0:
+        # Collapse "already exists" into a no-op — a concurrent run
+        # might have created the tag between check and repair.
+        stderr = (result.stderr or "").lower()
+        if "already exists" in stderr:
+            return
+        raise RuntimeError(f"git tag {tag} failed: {stderr[:200]}")
+
+
+REPAIR_ACTIONS: dict[str, Callable[[Path, dict[str, Any]], None]] = {
+    "missing_git_repo": _repair_git_init,
+    "missing_gitignore": _repair_seed_gitignore,
+    "missing_standard_subdirs": _repair_create_standard_subdirs,
+    "uncommitted_changes": _repair_autocommit,
+    "missing_phase_tag": _repair_create_phase_tag,
+}
+
+
+# ---------------------------------------------------------------------------
+# Layer A invariants
+# ---------------------------------------------------------------------------
+
+
+def _invariant_git_repo(project_root: Path) -> str | None:
+    """The project must be its own git repo."""
+    return None if (project_root / ".git").exists() else "missing_git_repo"
+
+
+def _invariant_gitignore_present(project_root: Path) -> str | None:
+    """A ``.gitignore`` must be seeded so phase-end commits don't
+    sweep up runtime artefacts or secrets."""
+    return None if (project_root / ".gitignore").is_file() else "missing_gitignore"
+
+
+def _invariant_standard_subdirs(project_root: Path) -> str | None:
+    """All seven standard subdirs must exist. The PM agent creates
+    them during SCAFFOLDING; the safety net recreates them if they
+    don't."""
+    missing = [
+        name
+        for name in ("docs", "src", "tests", "scripts", "config", "artifacts", "trace")
+        if not (project_root / name).is_dir()
+    ]
+    return "missing_standard_subdirs" if missing else None
+
+
+# Invariant sets keyed by step category. Callers pick the set that
+# matches the step they just ran. ``None`` means "no layer-A checks
+# declared for this category" — layer B is authoritative and A skips.
+LAYER_A_INVARIANTS: dict[str, list[Callable[[Path], str | None]]] = {
+    "scaffold": [
+        _invariant_git_repo,
+        _invariant_gitignore_present,
+        _invariant_standard_subdirs,
+    ],
+    # Phase-level invariants intentionally live under callers that
+    # know the phase tag name; add them here as hardcoded patterns
+    # emerge.
+    "phase": [],
+}
+
+
+# ---------------------------------------------------------------------------
+# Layer B evaluation
+# ---------------------------------------------------------------------------
+
+
+def _artifact_present(project_root: Path, artifact: ExpectedArtifact) -> bool:
+    """Return ``True`` when ``artifact`` is satisfied on disk.
+
+    Unknown ``kind`` values are treated as satisfied (we don't fail
+    an unknown expectation — callers owe us a meaningful schema, and
+    a typo would otherwise manifest as a permanent "missing"). A log
+    line flags the unknown kind so the caller can fix it.
+    """
+    target = (project_root / artifact.path).resolve() if artifact.path != "." else project_root.resolve()
+    if artifact.kind == "dir":
+        return target.is_dir()
+    if artifact.kind == "file":
+        if not target.is_file():
+            return False
+        if artifact.non_empty and target.stat().st_size == 0:
+            return False
+        return True
+    if artifact.kind == "git_repo":
+        return (project_root / ".git").exists()
+    if artifact.kind == "git_tag":
+        if not artifact.tag_name:
+            return True
+        r = _run_git(project_root, "rev-parse", "--verify", f"refs/tags/{artifact.tag_name}")
+        return r.returncode == 0
+    if artifact.kind == "clean_tree":
+        r = _run_git(project_root, "status", "--porcelain")
+        return r.returncode == 0 and not (r.stdout or "").strip()
+    logger.warning("safety_net: unknown ExpectedArtifact kind %r (treated as satisfied)", artifact.kind)
+    return True
+
+
+def _repair_action_for_artifact(artifact: ExpectedArtifact) -> str | None:
+    """Map a missing layer-B artifact to a repair action key.
+
+    Returns ``None`` when no registered repair matches — the miss is
+    still reported as an event, but the caller gets no mechanical
+    recovery. Callers that want custom repair should extend
+    :data:`REPAIR_ACTIONS` and this mapping.
+    """
+    if artifact.kind == "git_repo":
+        return "missing_git_repo"
+    if artifact.kind == "file" and artifact.path == ".gitignore":
+        return "missing_gitignore"
+    if artifact.kind == "dir" and artifact.path in {
+        "docs",
+        "src",
+        "tests",
+        "scripts",
+        "config",
+        "artifacts",
+        "trace",
+    }:
+        return "missing_standard_subdirs"
+    if artifact.kind == "clean_tree":
+        return "uncommitted_changes"
+    if artifact.kind == "git_tag":
+        return "missing_phase_tag"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Analytics event emission
+# ---------------------------------------------------------------------------
+
+
+def _events_path(project_root: Path) -> Path:
+    """Where the structured events land. ``trace/`` is already on the
+    baseline ``.gitignore`` so events stay out of commits by default.
+    """
+    return project_root / "trace" / "safety_net_events.jsonl"
+
+
+def _emit_event(project_root: Path, payload: dict[str, Any]) -> bool:
+    """Append a JSON event to the project's safety-net log. Returns
+    ``True`` if the line was written, ``False`` on any IO error. Errors
+    are logged but not raised — the safety net must not block on
+    telemetry."""
+    path = _events_path(project_root)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fp:
+            fp.write(json.dumps(payload, ensure_ascii=False))
+            fp.write("\n")
+        return True
+    except OSError as exc:
+        logger.warning("safety_net: failed to emit event: path=%s err=%s", path, exc)
+        return False
+
+
+def _make_event(
+    *,
+    step_id: str,
+    layer: str,
+    expected: str,
+    actual: str,
+    repair_action: str,
+    repair_status: str,
+    detail: str = "",
+) -> dict[str, Any]:
+    """Build the canonical telemetry event. Schema is stable; the
+    dashboard (issue #122) parses these as-is."""
+    return {
+        "event_type": "llm_fallback_triggered",
+        "step_id": step_id,
+        "layer": layer,
+        "expected": expected,
+        "actual": actual,
+        "repair_action": repair_action,
+        "repair_status": repair_status,
+        "detail": detail[:500] if detail else "",
+        "ts": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+def run_post_step_check(
+    project_root: Path,
+    *,
+    step_id: str,
+    layer_b_expected: Iterable[ExpectedArtifact] = (),
+    layer_a_category: str = "",
+    repair_context: dict[str, Any] | None = None,
+) -> CheckOutcome:
+    """Check (and repair) a step's output. Never raises.
+
+    Arguments:
+        project_root: Directory the step was supposed to modify.
+        step_id: Stable identifier for this step (``"scaffold"``,
+            ``"phase_2_architecture"``, etc.). Lands in the event
+            log as the grouping key for per-step telemetry.
+        layer_b_expected: Plan-declared expectations. Empty is fine —
+            layer A still runs.
+        layer_a_category: Key into :data:`LAYER_A_INVARIANTS`. Empty
+            means "skip layer A"; pass ``"scaffold"`` for scaffolding
+            steps.
+        repair_context: Extra context forwarded to repair actions
+            (e.g. ``{"tag_name": "phase_2_architecture"}`` for the
+            phase-tag repair).
+
+    Returns:
+        A :class:`CheckOutcome` summarizing what was missing, what
+        got repaired, and how many telemetry events were emitted.
+    """
+    outcome = CheckOutcome(step_id=step_id)
+    repair_ctx = {"step_id": step_id, **(repair_context or {})}
+
+    expected_list = list(layer_b_expected)
+
+    # -- Layer B ------------------------------------------------------------
+    for artifact in expected_list:
+        try:
+            present = _artifact_present(project_root, artifact)
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.warning("safety_net: layer-B check raised for %s: %s", artifact, exc)
+            present = True  # don't penalize the step for our bug
+        if present:
+            continue
+        outcome.layer_b_missing.append(artifact)
+        repair_key = _repair_action_for_artifact(artifact)
+        _run_repair(project_root, repair_key, artifact.describe(), "B", outcome, repair_ctx)
+
+    # -- Layer A ------------------------------------------------------------
+    # Only run layer A if layer B passed (or had nothing to check).
+    # The rationale: if B already caught something and we've kicked off
+    # repairs, layer A's invariants are likely to trigger on the same
+    # root cause — better to let the caller re-run the check after B's
+    # repairs land, rather than double-reporting.
+    b_clean = not outcome.layer_b_missing
+    if b_clean and layer_a_category:
+        for check in LAYER_A_INVARIANTS.get(layer_a_category, []):
+            try:
+                miss_key = check(project_root)
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.warning("safety_net: layer-A invariant %s raised: %s", check.__name__, exc)
+                miss_key = None
+            if miss_key is None:
+                continue
+            outcome.layer_a_failures.append(miss_key)
+            _run_repair(project_root, miss_key, miss_key, "A", outcome, repair_ctx)
+
+    return outcome
+
+
+def _run_repair(
+    project_root: Path,
+    repair_key: str | None,
+    expected_desc: str,
+    layer: str,
+    outcome: CheckOutcome,
+    ctx: dict[str, Any],
+) -> None:
+    """Dispatch a repair action and record the outcome + emit an event.
+
+    Factored out so layer B and layer A share the same repair flow —
+    same event shape, same success / failure bookkeeping.
+    """
+    repair_fn = REPAIR_ACTIONS.get(repair_key or "")
+    if repair_fn is None:
+        # No mechanical repair known for this miss. Still emit the
+        # telemetry event so the dashboard can surface unhandled
+        # failure modes.
+        if _emit_event(
+            project_root,
+            _make_event(
+                step_id=outcome.step_id,
+                layer=layer,
+                expected=expected_desc,
+                actual="missing",
+                repair_action="none",
+                repair_status="skipped",
+            ),
+        ):
+            outcome.events_emitted += 1
+        return
+
+    outcome.repairs_attempted.append(repair_key)
+    try:
+        repair_fn(project_root, ctx)
+    except Exception as exc:
+        outcome.repairs_failed.append((repair_key, str(exc)))
+        if _emit_event(
+            project_root,
+            _make_event(
+                step_id=outcome.step_id,
+                layer=layer,
+                expected=expected_desc,
+                actual="missing",
+                repair_action=repair_key,
+                repair_status="failed",
+                detail=str(exc),
+            ),
+        ):
+            outcome.events_emitted += 1
+        return
+
+    outcome.repairs_succeeded.append(repair_key)
+    if _emit_event(
+        project_root,
+        _make_event(
+            step_id=outcome.step_id,
+            layer=layer,
+            expected=expected_desc,
+            actual="repaired",
+            repair_action=repair_key,
+            repair_status="success",
+        ),
+    ):
+        outcome.events_emitted += 1
+
+
+# ---------------------------------------------------------------------------
+# Pre-baked expectation sets
+# ---------------------------------------------------------------------------
+
+
+def scaffolding_expectations() -> tuple[ExpectedArtifact, ...]:
+    """The layer-B expectations the PM agent's SCAFFOLDING TASK claims
+    to satisfy. Exposed as a free function so callers in
+    ``web/app.py`` can wire it without duplicating the list.
+    """
+    return (
+        ExpectedArtifact(path=".", kind="git_repo", description="project root initialized as git repo"),
+        ExpectedArtifact(path=".gitignore", kind="file", non_empty=True, description="baseline .gitignore seeded"),
+        ExpectedArtifact(path="docs", kind="dir"),
+        ExpectedArtifact(path="src", kind="dir"),
+        ExpectedArtifact(path="tests", kind="dir"),
+        ExpectedArtifact(path="scripts", kind="dir"),
+        ExpectedArtifact(path="config", kind="dir"),
+        ExpectedArtifact(path="artifacts", kind="dir"),
+        ExpectedArtifact(path="trace", kind="dir"),
+    )

--- a/src/aise/web/app.py
+++ b/src/aise/web/app.py
@@ -254,33 +254,70 @@ class WebProjectService:
             logger.warning("Scaffold thread: project %s vanished before start", project_id)
             return
 
+        dispatch_error: str | None = None
         try:
             prompt = self._build_scaffolding_prompt(project)
             self._dispatch_scaffolding_to_pm(project, prompt)
         except Exception as exc:  # pragma: no cover — defensive
             logger.exception("Scaffold thread raised: project=%s", project_id)
-            with self._lock:
-                project.fail_scaffolding(f"scaffolding dispatch raised: {exc}")
-                self._save_state()
-            return
+            dispatch_error = f"scaffolding dispatch raised: {exc}"
+            # Do NOT return yet — the safety net below may still be
+            # able to recover (e.g. if the agent's LLM is unavailable
+            # but the PM wasn't strictly necessary for a default
+            # layout). If the safety net ALSO can't recover we'll
+            # fail_scaffolding with the dispatch error context.
 
-        # Post-dispatch invariant check. The agent's happy-path answer
-        # is "I did it", but the filesystem is the source of truth.
-        # These checks are minimal — PR-c's safety net broadens them
-        # into a plan-driven verifier.
+        # Post-dispatch verification via the safety-net module. Runs
+        # layer B (``scaffolding_expectations()`` — the PM's contract)
+        # followed by layer A (hardcoded invariants) if B was clean.
+        # Any miss gets a mechanical repair attempt + a structured
+        # telemetry event at ``<project_root>/trace/safety_net_events.jsonl``
+        # so the dashboard (issue #122) can surface LLM-capability
+        # trends over time.
+        from ..runtime.safety_net import run_post_step_check, scaffolding_expectations
+
         root = Path(project.project_root or "")
-        ok = root.is_dir() and (root / ".git").exists() and (root / ".gitignore").exists()
+        outcome = run_post_step_check(
+            root,
+            step_id="scaffold",
+            layer_b_expected=scaffolding_expectations(),
+            layer_a_category="scaffold",
+        )
+        if outcome.events_emitted:
+            logger.info(
+                "Safety-net repaired scaffold gaps: project_id=%s repaired=%s failed=%s events=%d",
+                project_id,
+                outcome.repairs_succeeded,
+                outcome.repairs_failed,
+                outcome.events_emitted,
+            )
+
         with self._lock:
-            if ok:
+            if outcome.repaired_ok and not dispatch_error:
                 project.finish_scaffolding()
                 logger.info("Scaffold completed: project_id=%s root=%s", project_id, root)
-            else:
-                project.fail_scaffolding("post-dispatch invariants failed: .git / .gitignore missing")
+            elif outcome.repaired_ok and dispatch_error:
+                # Dispatch raised but the safety net ended up in a
+                # clean state anyway. Count as success — the agent
+                # failure is already logged and telemetry'd.
+                project.finish_scaffolding()
                 logger.warning(
-                    "Scaffold invariants failed: project_id=%s .git=%s .gitignore=%s",
+                    "Scaffold completed via safety-net repair (dispatch error: %s): project_id=%s",
+                    dispatch_error,
                     project_id,
-                    (root / ".git").exists(),
-                    (root / ".gitignore").exists(),
+                )
+            else:
+                # Even after repair attempts, something is still
+                # broken — surface both the dispatch error (if any)
+                # and the failed repairs.
+                failed_detail = ", ".join(f"{act}: {err}" for act, err in outcome.repairs_failed) or (
+                    dispatch_error or "unknown failure"
+                )
+                project.fail_scaffolding(failed_detail)
+                logger.warning(
+                    "Scaffold failed after safety-net repair: project_id=%s detail=%s",
+                    project_id,
+                    failed_detail,
                 )
             self._save_state()
 

--- a/tests/test_runtime/test_safety_net.py
+++ b/tests/test_runtime/test_safety_net.py
@@ -1,0 +1,391 @@
+"""Unit tests for the safety-net module.
+
+The safety net post-verifies LLM-driven step outputs, repairs the
+mechanical misses, and emits structured telemetry events. These tests
+pin each layer of that contract so the dashboard follow-up (issue
+#122) can trust the event schema.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from aise.runtime.safety_net import (
+    _BASELINE_GITIGNORE,
+    LAYER_A_INVARIANTS,
+    REPAIR_ACTIONS,
+    CheckOutcome,
+    ExpectedArtifact,
+    run_post_step_check,
+    scaffolding_expectations,
+)
+
+
+def _have_git() -> bool:
+    return shutil.which("git") is not None
+
+
+pytestmark = pytest.mark.skipif(not _have_git(), reason="git binary not on PATH")
+
+
+def _init_repo(root: Path) -> None:
+    """Make ``root`` a git repo with a local identity so later commits
+    work. Kept in the test file (not imported from the module under
+    test) so the test remains a black-box verifier."""
+    subprocess.run(["git", "init", "--quiet"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "t@e.st"], cwd=root, check=True)
+
+
+def _read_events(root: Path) -> list[dict]:
+    path = root / "trace" / "safety_net_events.jsonl"
+    if not path.is_file():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Layer-B flow
+# ---------------------------------------------------------------------------
+
+
+class TestLayerB:
+    def test_missing_git_repo_triggers_repair_and_event(self, tmp_path: Path) -> None:
+        outcome = run_post_step_check(
+            tmp_path,
+            step_id="scaffold",
+            layer_b_expected=[ExpectedArtifact(path=".", kind="git_repo")],
+        )
+        assert outcome.layer_b_missing == [ExpectedArtifact(path=".", kind="git_repo")]
+        assert outcome.repairs_succeeded == ["missing_git_repo"]
+        assert outcome.repaired_ok is True
+        assert (tmp_path / ".git").exists(), "git init repair must create .git"
+
+        events = _read_events(tmp_path)
+        assert len(events) == 1
+        evt = events[0]
+        assert evt["event_type"] == "llm_fallback_triggered"
+        assert evt["step_id"] == "scaffold"
+        assert evt["layer"] == "B"
+        assert evt["repair_action"] == "missing_git_repo"
+        assert evt["repair_status"] == "success"
+        # ts is an ISO-8601 string — parse it to catch schema drift.
+        from datetime import datetime
+
+        datetime.fromisoformat(evt["ts"])
+
+    def test_missing_gitignore_seeds_baseline(self, tmp_path: Path) -> None:
+        run_post_step_check(
+            tmp_path,
+            step_id="scaffold",
+            layer_b_expected=[ExpectedArtifact(path=".gitignore", kind="file", non_empty=True)],
+        )
+        gi = tmp_path / ".gitignore"
+        assert gi.is_file()
+        body = gi.read_text(encoding="utf-8")
+        # Baseline must include secret patterns so later autocommits
+        # don't sweep up keys.
+        for needle in (".env", "*.key", "*_secret*", "*credentials*"):
+            assert needle in body, f"baseline .gitignore missing {needle!r}"
+        assert body == _BASELINE_GITIGNORE
+
+    def test_existing_gitignore_not_overwritten(self, tmp_path: Path) -> None:
+        """The agent may have tuned ``.gitignore`` already — the
+        repair only seeds when missing, never clobbers."""
+        gi = tmp_path / ".gitignore"
+        gi.write_text("agent_tuned\n", encoding="utf-8")
+        run_post_step_check(
+            tmp_path,
+            step_id="scaffold",
+            layer_b_expected=[ExpectedArtifact(path=".gitignore", kind="file", non_empty=True)],
+        )
+        # File is non-empty, so the check should have passed; if the
+        # repair fired anyway, the content would be the baseline.
+        assert gi.read_text(encoding="utf-8") == "agent_tuned\n"
+
+    def test_missing_subdirs_all_created(self, tmp_path: Path) -> None:
+        run_post_step_check(
+            tmp_path,
+            step_id="scaffold",
+            layer_b_expected=[
+                ExpectedArtifact(path=name, kind="dir")
+                for name in ("docs", "src", "tests", "scripts", "config", "artifacts", "trace")
+            ],
+        )
+        for name in ("docs", "src", "tests", "scripts", "config", "artifacts", "trace"):
+            assert (tmp_path / name).is_dir()
+
+    def test_unknown_kind_treated_as_satisfied(self, tmp_path: Path, caplog) -> None:
+        """A typo in ``kind`` must not deadlock a step. Log a warning
+        so the author fixes it, but don't report a miss."""
+        with caplog.at_level("WARNING"):
+            outcome = run_post_step_check(
+                tmp_path,
+                step_id="scaffold",
+                layer_b_expected=[ExpectedArtifact(path=".", kind="definitely_not_a_kind")],
+            )
+        assert outcome.layer_b_missing == []
+        assert outcome.events_emitted == 0
+        assert "unknown ExpectedArtifact kind" in caplog.text
+
+    def test_artifact_with_no_registered_repair_emits_skipped_event(self, tmp_path: Path) -> None:
+        """The miss is reported but nothing is repaired when the
+        artifact's kind doesn't map to a ``REPAIR_ACTIONS`` entry —
+        e.g. a plain missing file the caller cares about but the
+        safety net doesn't know how to recreate."""
+        outcome = run_post_step_check(
+            tmp_path,
+            step_id="scaffold",
+            layer_b_expected=[ExpectedArtifact(path="mystery.xml", kind="file", non_empty=True)],
+        )
+        assert len(outcome.layer_b_missing) == 1
+        assert outcome.repairs_attempted == []
+        events = _read_events(tmp_path)
+        # trace/ doesn't exist yet because we didn't ask for any
+        # repairs that would create it — so the event path mkdirs its
+        # parent and the event lands there.
+        assert len(events) == 1
+        assert events[0]["repair_action"] == "none"
+        assert events[0]["repair_status"] == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# Layer-A flow
+# ---------------------------------------------------------------------------
+
+
+class TestLayerA:
+    def test_layer_a_runs_when_b_is_clean(self, tmp_path: Path) -> None:
+        """If layer B found nothing missing (or had nothing to check),
+        layer A's hardcoded invariants still run. Here B is empty but
+        A's ``scaffold`` set catches the missing git repo."""
+        outcome = run_post_step_check(
+            tmp_path,
+            step_id="scaffold",
+            layer_a_category="scaffold",
+        )
+        assert outcome.layer_b_missing == []
+        assert "missing_git_repo" in outcome.layer_a_failures
+        assert "missing_git_repo" in outcome.repairs_succeeded
+
+    def test_layer_a_skipped_when_b_already_flagged_a_miss(self, tmp_path: Path) -> None:
+        """Avoid double-reporting: if B already caught something and
+        a repair fired, don't let A re-discover the same root cause.
+        The caller can re-run the check after the repair lands to
+        verify a clean state."""
+        outcome = run_post_step_check(
+            tmp_path,
+            step_id="scaffold",
+            layer_b_expected=[ExpectedArtifact(path="mystery.xml", kind="file")],
+            layer_a_category="scaffold",
+        )
+        # B reported a miss (mystery.xml is missing, no repair
+        # available); A should have been skipped.
+        assert outcome.layer_b_missing
+        assert outcome.layer_a_failures == []
+
+    def test_layer_a_empty_category_skips_cleanly(self, tmp_path: Path) -> None:
+        """An unregistered category is a no-op (not an error) — it
+        lets callers pass ``""`` to say "only run layer B"."""
+        outcome = run_post_step_check(tmp_path, step_id="scaffold", layer_a_category="")
+        assert outcome.layer_a_failures == []
+
+
+# ---------------------------------------------------------------------------
+# Repair actions (direct)
+# ---------------------------------------------------------------------------
+
+
+class TestRepairAutocommit:
+    def test_commits_uncommitted_files(self, tmp_path: Path) -> None:
+        _init_repo(tmp_path)
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "mod.py").write_text("x\n", encoding="utf-8")
+
+        REPAIR_ACTIONS["uncommitted_changes"](tmp_path, {"step_id": "phase_3_implementation"})
+
+        # A HEAD commit now exists with the safety-net subject.
+        log = subprocess.run(
+            ["git", "log", "-1", "--pretty=%s"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert log.stdout.strip().startswith("safety_net(phase_3_implementation): autocommit")
+
+    def test_clean_tree_is_noop(self, tmp_path: Path) -> None:
+        """``git status --porcelain`` is empty → autocommit skips the
+        commit entirely, doesn't fabricate an empty one."""
+        _init_repo(tmp_path)
+        (tmp_path / "README").write_text("hi\n", encoding="utf-8")
+        subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+        subprocess.run(["git", "commit", "--quiet", "-m", "init"], cwd=tmp_path, check=True)
+
+        before = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=tmp_path, capture_output=True, text=True, check=True
+        ).stdout.strip()
+        REPAIR_ACTIONS["uncommitted_changes"](tmp_path, {"step_id": "phase_x"})
+        after = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=tmp_path, capture_output=True, text=True, check=True
+        ).stdout.strip()
+        assert before == after, "clean tree must NOT yield a new commit"
+
+
+class TestRepairPhaseTag:
+    def test_creates_tag_pointing_at_head(self, tmp_path: Path) -> None:
+        _init_repo(tmp_path)
+        (tmp_path / "x.txt").write_text("y\n", encoding="utf-8")
+        subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+        subprocess.run(["git", "commit", "--quiet", "-m", "one"], cwd=tmp_path, check=True)
+
+        REPAIR_ACTIONS["missing_phase_tag"](tmp_path, {"tag_name": "phase_2_architecture"})
+
+        tags = (
+            subprocess.run(["git", "tag", "--list"], cwd=tmp_path, capture_output=True, text=True, check=True)
+            .stdout.strip()
+            .splitlines()
+        )
+        assert "phase_2_architecture" in tags
+
+    def test_existing_tag_is_noop(self, tmp_path: Path) -> None:
+        """A concurrent run may have created the tag already — the
+        repair must not raise on that."""
+        _init_repo(tmp_path)
+        (tmp_path / "x.txt").write_text("y\n", encoding="utf-8")
+        subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+        subprocess.run(["git", "commit", "--quiet", "-m", "one"], cwd=tmp_path, check=True)
+        subprocess.run(["git", "tag", "phase_1_requirements"], cwd=tmp_path, check=True)
+
+        # Must not raise.
+        REPAIR_ACTIONS["missing_phase_tag"](tmp_path, {"tag_name": "phase_1_requirements"})
+
+    def test_missing_tag_name_is_noop(self, tmp_path: Path) -> None:
+        """Don't invent a tag name — a wrong tag would break every
+        future diff. Without the context, skip."""
+        _init_repo(tmp_path)
+        # No HEAD commit, no tag_name → must not raise.
+        REPAIR_ACTIONS["missing_phase_tag"](tmp_path, {})
+
+
+# ---------------------------------------------------------------------------
+# Failure-path telemetry
+# ---------------------------------------------------------------------------
+
+
+class TestRepairFailureEmitsEvent:
+    def test_failed_repair_reports_on_outcome_and_event(self, tmp_path: Path, monkeypatch) -> None:
+        """If the mechanical repair itself fails, the outcome must
+        carry the failure AND an event with ``repair_status=failed``
+        must be emitted — that's the signal the dashboard shows as
+        "needs human attention"."""
+
+        def _boom(project_root, ctx):  # noqa: ARG001
+            raise RuntimeError("simulated repair failure")
+
+        monkeypatch.setitem(REPAIR_ACTIONS, "missing_git_repo", _boom)
+
+        outcome = run_post_step_check(
+            tmp_path,
+            step_id="scaffold",
+            layer_b_expected=[ExpectedArtifact(path=".", kind="git_repo")],
+        )
+        assert outcome.repaired_ok is False
+        assert outcome.repairs_failed == [("missing_git_repo", "simulated repair failure")]
+
+        events = _read_events(tmp_path)
+        assert len(events) == 1
+        assert events[0]["repair_status"] == "failed"
+        assert "simulated repair failure" in events[0]["detail"]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end scaffolding expectation set
+# ---------------------------------------------------------------------------
+
+
+class TestScaffoldingExpectations:
+    def test_set_matches_pm_scaffolding_contract(self) -> None:
+        """The tuple must describe exactly what ``product_manager.md``
+        promises to produce during SCAFFOLDING TASK: git repo +
+        .gitignore + 7 subdirs. If this drifts, the PM's contract and
+        the safety net's checks fall out of sync."""
+        specs = scaffolding_expectations()
+        descriptions = {a.describe() for a in specs}
+        expected = {
+            "git_repo",
+            "file:.gitignore",
+            "dir:docs",
+            "dir:src",
+            "dir:tests",
+            "dir:scripts",
+            "dir:config",
+            "dir:artifacts",
+            "dir:trace",
+        }
+        assert descriptions == expected
+
+    def test_empty_project_gets_fully_repaired(self, tmp_path: Path) -> None:
+        """Integration-style: start from nothing, run the scaffolding
+        check, end up with a usable repo + layout. This is the path
+        ``WebProjectService._scaffold_project`` takes when the PM
+        agent goes fully AWOL."""
+        outcome = run_post_step_check(
+            tmp_path,
+            step_id="scaffold",
+            layer_b_expected=scaffolding_expectations(),
+        )
+        assert outcome.repaired_ok is True
+        assert (tmp_path / ".git").exists()
+        assert (tmp_path / ".gitignore").is_file()
+        for name in ("docs", "src", "tests", "scripts", "config", "artifacts", "trace"):
+            assert (tmp_path / name).is_dir()
+
+        # 3 events total: the ``missing_standard_subdirs`` repair
+        # creates all 7 subdirs in one shot, so only the first missing
+        # subdir triggers the event — the rest are satisfied by the
+        # bulk repair and never make it to the miss list. That's
+        # intentional: one event per *distinct* repair action.
+        events = _read_events(tmp_path)
+        assert len(events) == 3
+        expected_keys = {e["repair_action"] for e in events}
+        assert expected_keys == {
+            "missing_git_repo",
+            "missing_gitignore",
+            "missing_standard_subdirs",
+        }
+        assert all(e["repair_status"] == "success" for e in events)
+        assert all(e["event_type"] == "llm_fallback_triggered" for e in events)
+
+
+# ---------------------------------------------------------------------------
+# Invariant registry wiring
+# ---------------------------------------------------------------------------
+
+
+class TestInvariantRegistry:
+    def test_scaffold_category_has_the_three_invariants(self) -> None:
+        """Document the current layer-A set so additions are deliberate."""
+        names = [fn.__name__ for fn in LAYER_A_INVARIANTS["scaffold"]]
+        assert names == [
+            "_invariant_git_repo",
+            "_invariant_gitignore_present",
+            "_invariant_standard_subdirs",
+        ]
+
+
+class TestCheckOutcome:
+    def test_repaired_ok_requires_no_layer_a_and_no_repair_failures(self) -> None:
+        oc = CheckOutcome(step_id="x")
+        assert oc.repaired_ok is True
+        oc.layer_a_failures.append("missing_git_repo")
+        assert oc.repaired_ok is False
+        # Fix that one, but break another repair — still not ok.
+        oc.layer_a_failures.clear()
+        oc.repairs_failed.append(("missing_phase_tag", "boom"))
+        assert oc.repaired_ok is False

--- a/tests/test_web/test_app.py
+++ b/tests/test_web/test_app.py
@@ -831,11 +831,18 @@ class TestAIFirstScaffolding:
         assert (root / ".git").exists()
         assert (root / ".gitignore").exists()
 
-    def test_scaffold_thread_marks_failed_on_invariant_miss(self, monkeypatch, tmp_path):
-        """If the PM agent's scaffold dispatch returns but the invariants
-        (``.git`` / ``.gitignore``) aren't on disk, the post-dispatch
-        check flips the project to SCAFFOLDING_FAILED so a downstream
-        safety-net can repair or surface the failure to the user."""
+    def test_scaffold_recovered_by_safety_net_when_agent_does_nothing(self, monkeypatch, tmp_path):
+        """PR-c layer: if the PM agent's scaffold dispatch returns
+        without writing anything (silent failure — classic LLM
+        regression), the safety net's mechanical repairs kick in and
+        the project still lands in ACTIVE. The only visible trace is
+        the structured event log.
+        """
+        import shutil
+
+        if not shutil.which("git"):
+            pytest.skip("git binary not on PATH")
+
         monkeypatch.chdir(tmp_path)
         service = WebProjectService()
         # "Agent" claims success but writes nothing.
@@ -843,10 +850,51 @@ class TestAIFirstScaffolding:
 
         project_id = service.create_project("Liar", "local")
         status = _wait_for_scaffolding(service, project_id)
+        assert status == "active", "safety net must repair silent-failure scaffolds"
+        project = service.project_manager.get_project(project_id)
+        root = Path(project.project_root)
+        # Safety net should have produced a real repo + .gitignore +
+        # the standard layout.
+        assert (root / ".git").exists()
+        assert (root / ".gitignore").is_file()
+        for name in ("docs", "src", "tests", "scripts", "config", "artifacts", "trace"):
+            assert (root / name).is_dir()
+
+        # And a per-project event log with one entry per distinct
+        # repair action fired.
+        events_path = root / "trace" / "safety_net_events.jsonl"
+        assert events_path.is_file()
+        import json as _json
+
+        events = [_json.loads(line) for line in events_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        actions = {e["repair_action"] for e in events}
+        assert {"missing_git_repo", "missing_gitignore", "missing_standard_subdirs"} <= actions
+
+    def test_scaffold_fails_when_safety_net_repair_itself_fails(self, monkeypatch, tmp_path):
+        """If the PM agent does nothing AND the safety net's
+        mechanical repair also fails, the project lands in
+        SCAFFOLDING_FAILED with an error blurb — this is the only
+        code path that reaches that state now.
+        """
+        monkeypatch.chdir(tmp_path)
+        service = WebProjectService()
+        service._dispatch_scaffolding_to_pm = lambda project, prompt: None  # type: ignore[method-assign]
+
+        # Force every repair attempt to blow up.
+        from aise.runtime import safety_net as _sn
+
+        def _boom(project_root, ctx):  # noqa: ARG001
+            raise RuntimeError("simulated repair failure")
+
+        for key in list(_sn.REPAIR_ACTIONS):
+            monkeypatch.setitem(_sn.REPAIR_ACTIONS, key, _boom)
+
+        project_id = service.create_project("Broken", "local")
+        status = _wait_for_scaffolding(service, project_id)
         assert status == "scaffolding_failed"
         project = service.project_manager.get_project(project_id)
-        assert project is not None
-        assert project.scaffolding_error and ".git" in project.scaffolding_error
+        assert project.scaffolding_error
+        assert "simulated repair failure" in project.scaffolding_error
 
     def test_run_requirement_rejected_while_scaffolding(self, monkeypatch, tmp_path):
         """A stale client (or a direct API call) hitting the requirements
@@ -862,13 +910,19 @@ class TestAIFirstScaffolding:
             service.run_requirement(project_id, "premature submission")
 
     def test_run_requirement_rejected_after_scaffolding_failed(self, monkeypatch, tmp_path):
-        """SCAFFOLDING_FAILED is also a hard block — the user must wait
-        for recovery (safety-net in PR-c) or explicitly retry; submitting
-        a requirement to a broken project is a guaranteed cascade failure.
+        """SCAFFOLDING_FAILED is also a hard block. Force it by breaking
+        every repair in the safety net.
         """
         monkeypatch.chdir(tmp_path)
         service = WebProjectService()
         service._dispatch_scaffolding_to_pm = lambda project, prompt: None  # type: ignore[method-assign]
+        from aise.runtime import safety_net as _sn
+
+        def _boom(project_root, ctx):  # noqa: ARG001
+            raise RuntimeError("simulated repair failure")
+
+        for key in list(_sn.REPAIR_ACTIONS):
+            monkeypatch.setitem(_sn.REPAIR_ACTIONS, key, _boom)
 
         project_id = service.create_project("Broken", "local")
         _wait_for_scaffolding(service, project_id)


### PR DESCRIPTION
## Context

Last of three PRs for the AI-First project-scaffolding redesign (issue #122).

- **PR-a** ([#123](https://github.com/nightstaker/AISE/pull/123), merged) — moved ``ProjectManager`` into ``runtime/``.
- **PR-b** ([#124](https://github.com/nightstaker/AISE/pull/124), merged) — handed scaffolding to the product-manager agent.
- **PR-c (this)** — verifies the agent's output, repairs mechanical misses, emits structured telemetry.

## Module — ``src/aise/runtime/safety_net.py``

Two-layer post-step verifier:

- **Layer B** — plan-declared ``ExpectedArtifact`` objects. Kind is one of ``dir`` / ``file`` / ``git_repo`` / ``git_tag`` / ``clean_tree``; missing artifacts map into a repair key via ``_repair_action_for_artifact``. Unknown kinds log a warning but don't block.
- **Layer A** — hardcoded invariants, keyed by category. Runs **only** when layer B came back clean (avoiding double-reports on the same root cause). Current ``"scaffold"`` set pins git repo + ``.gitignore`` + seven standard subdirs.

Repair registry (``REPAIR_ACTIONS``):
- ``missing_git_repo`` → ``git init`` + local identity config
- ``missing_gitignore`` → seeds a baseline with secret patterns (``.env``, ``*.key``, ``*_secret*``, ``*credentials*``) so later autocommits can't sweep up credentials
- ``missing_standard_subdirs`` → ``mkdir`` all seven
- ``uncommitted_changes`` → ``git add -A && git commit`` with ``safety_net(<step>): autocommit ...`` subject
- ``missing_phase_tag`` → tag HEAD with the supplied ``tag_name`` context

Every detection produces a JSON line at ``<project_root>/trace/safety_net_events.jsonl``:

```json
{
  "event_type": "llm_fallback_triggered",
  "step_id": "scaffold",
  "layer": "B",
  "expected": "git_repo",
  "actual": "repaired",
  "repair_action": "missing_git_repo",
  "repair_status": "success",
  "detail": "",
  "ts": "2026-04-22T19:23:45.678901+00:00"
}
```

The schema is frozen for the dashboard (issue #122).

``run_post_step_check`` **never raises** — internal failures become ``repair_status=error`` events + ``CheckOutcome`` flags. Callers decide whether to fail the parent step.

## Integration — ``WebProjectService._scaffold_project``

Replaced the hardcoded two-line invariant check with a proper safety-net call using ``scaffolding_expectations()``. The new flow:

1. Dispatch to the PM agent (as PR-b). Capture any raised exception instead of bailing.
2. Always run the safety net afterwards — repairs are idempotent and the agent may have partially succeeded.
3. If ``outcome.repaired_ok`` AND no dispatch error → ``finish_scaffolding()``.
4. If ``outcome.repaired_ok`` AND dispatch error → still ``finish_scaffolding()`` (safety net saved us); log + telemetry capture the agent failure.
5. Otherwise → ``fail_scaffolding(detail)`` with every failed-repair reason.

**Net effect**: a PM agent going fully silent no longer wedges the project in SCAFFOLDING_FAILED — the safety net mechanically repairs the environment and the telemetry reports it as layer-B misses. The dashboard can surface those over time to track LLM capability drift.

## What's intentionally NOT here

- **Per-phase wiring**. ``ProjectSession._invoke_pm`` doesn't call the safety net after each phase yet. Phase-level expectations (per-phase ``ExpectedArtifact`` lists, ``phase_<N>_<name>`` tag verification) are a follow-up — the right question is *where do the per-phase contracts live?* (inline in ``process.md``? hardcoded map?), and that's worth its own PR.
- **Warning dashboard** — still tracked in #122.

## Tests — 19 new unit + 1 new integration test, 2 updated

``tests/test_runtime/test_safety_net.py`` (19 cases):

| Class | N | Focus |
|---|---|---|
| ``TestLayerB`` | 6 | Missing ``git_repo`` / ``.gitignore`` / subdirs trigger the right repair; existing ``.gitignore`` never clobbered; unknown ``kind`` is a warning not a miss; un-repairable artifact emits ``skipped`` event. |
| ``TestLayerA`` | 3 | Runs when B is clean; skipped when B already flagged; unregistered category is a no-op. |
| ``TestRepairAutocommit`` | 2 | Commits with ``safety_net(<step>): ...`` subject; clean tree → no empty commits. |
| ``TestRepairPhaseTag`` | 3 | Tag created at HEAD; existing tag no-op; missing ``tag_name`` ctx no-op (no fabricated tags). |
| ``TestRepairFailureEmitsEvent`` | 1 | Failed repair → ``repair_status=failed`` event + outcome flag. |
| ``TestScaffoldingExpectations`` | 2 | Expectation set matches the PM's SCAFFOLDING TASK contract; integration test repairs an empty tmp_path into a full valid project. |
| ``TestInvariantRegistry`` | 1 | Current layer-A set documented so additions are deliberate. |
| ``TestCheckOutcome`` | 1 | ``repaired_ok`` accounts for both layer-A failures and unhealed repair errors. |

All gated on ``shutil.which("git")``.

``tests/test_web/test_app.py`` updates:
- Renamed the "marks failed on invariant miss" test to ``test_scaffold_recovered_by_safety_net_when_agent_does_nothing`` — silent-failure PM now ends in ACTIVE, not SCAFFOLDING_FAILED, and per-project event log contains the three expected repair actions.
- New ``test_scaffold_fails_when_safety_net_repair_itself_fails`` — force every repair to blow up; this is now the only code path that reaches SCAFFOLDING_FAILED.
- ``test_run_requirement_rejected_after_scaffolding_failed`` uses the same broken-repair injection.

## Test plan

- [x] ``pytest`` — 726 passed, 53 skipped (includes 19 new safety-net cases)
- [x] ``AISE_ENABLE_WEB_TESTS=1 pytest tests/test_web`` — 118 passed, 12 pre-existing failures unchanged from PR-b's baseline
- [x] ``ruff check`` + ``ruff format --check`` — clean, 293 files formatted
- [x] ``python -m build --wheel`` — OK
- [ ] Manual smoke: create a project, make the PM agent silent (e.g. revoke API key mid-scaffold), verify the safety net still produces ``.git`` + ``.gitignore`` + subdirs, and that ``trace/safety_net_events.jsonl`` captures the gaps

## Design notes worth reviewer attention

- Layer-B / layer-A ordering is **deliberate**. When B catches something, A stops. That prevents duplicate reports on the same root cause (missing repo → both the B artifact expectation and A's invariant would fire otherwise). Trade-off: a caller that wants full diagnostic coverage must re-run the check after a repair lands. Documented inline.
- ``missing_gitignore`` repair includes secret patterns even when the agent produced a partial ``.gitignore`` elsewhere. The seed is only written when the file is **absent** — this avoids clobbering an agent-tuned version, but it does mean an agent that writes a secret-free ``.gitignore`` doesn't get the secret patterns injected. Judgment call: "agent's .gitignore > our defense-in-depth" since the agent is the author of that file in AI-First mode. If this bites later (e.g. agent writes a ``.gitignore`` then commits a ``.env``), PR-d can add a secret-pattern-union repair.
- ``missing_phase_tag`` repair **refuses to fabricate a tag name** from thin air. The caller must supply ``ctx["tag_name"]``; without it, the repair is a silent no-op. Rationale: a wrong tag breaks every future ``git diff phase_N..HEAD`` summary.