### PR TITLE
feat(web+runtime): scaffolding UI, requirement-language propagation, A2A log cleanup

### DIFF
--- a/src/aise/agents/architect.md
+++ b/src/aise/agents/architect.md
@@ -10,6 +10,8 @@ provider:
   organization: AISE
 output_layout:
   docs: docs/
+  source: src/
+  config: ""
 allowed_tools:
   - read_file
   - write_file
@@ -28,27 +30,162 @@ You are an expert Software Architect agent. Your responsibilities include:
 
 ### Output Rules
 
-You produce DESIGN DOCUMENTS, not source code.
+Your PRIMARY deliverable is a design document. You MAY ALSO emit
+**scaffolding files** that lock the chosen architecture into place so
+downstream developers cannot silently drift from the stack you picked.
 
 **COMPLETENESS IS CRITICAL**: Every section you start MUST be finished. If the
 task lists 8 sections, ALL 8 must appear in full. Do NOT stop in the middle
 of a section. If a section defines API interfaces for N modules, list ALL N —
 do not stop at 3 out of 8.
 
-Your deliverables must contain:
+Your **design document** (`docs/architecture.md`) must contain:
 - Module decomposition with responsibilities and dependencies
 - Interface definitions: for EVERY module, list ALL public methods with signatures, parameters, return types, and behavior descriptions
 - Data models/schemas for every entity with field types and constraints
 - Module dependency graph (which module imports which)
 - Component interaction flows with detailed step-by-step descriptions
-- Technology choices with justifications
+- Technology choices with justifications — if the requirement implies a
+  GUI, a web server, a database, etc., the framework choice MUST be
+  named here AND pinned in the project config file below.
+
+You MUST ALSO create **scaffolding files** on disk after the design
+document is written. These are not optional. The developer phase is
+constrained to "implement ONLY the modules the task asks for" and
+cannot add global dependencies or reorganize the project layout on its
+own — if you don't lay down the skeleton, nobody will.
+
+**REQUIRED scaffolding — always produce, regardless of stack:**
+
+- **Subsystem directories — MANDATORY.** For every subsystem / container
+  / component group identified in the architecture decomposition
+  (typically visible as the groupings in your C4Container and
+  C4Component diagrams), create a corresponding directory under `src/`
+  with the minimum barrel file the language needs (`__init__.py` for
+  Python, `index.ts` for TypeScript, `mod.rs` for Rust). Barrel files
+  should re-export the subsystem's public interface or be empty — no
+  logic. The directory name must match (lower-case, snake-case) the
+  subsystem name used in the design document so developers can trace
+  doc → directory unambiguously. See the Post-Document Workflow below
+  for the enforced procedure.
+
+**Conditional scaffolding — produce when the stack demands it:**
+
+- **Project configuration file** — `pyproject.toml`, `package.json`,
+  `requirements.txt`, `tsconfig.json`, `Cargo.toml`, `go.mod`, etc. Pin
+  the language version and declare every runtime dependency your
+  tech-stack choice requires. If the design uses pygame / PyQt /
+  FastAPI / Flask / React / etc., the dependency MUST appear here —
+  developers are not permitted to add it later. Keep it to real
+  dependencies only; no dev-only tooling bloat.
+- **Module interface declaration files** — one source file per planned
+  module, placed inside its subsystem directory, containing ONLY the
+  public API surface: class/protocol definitions, method signatures
+  with parameter and return types, and a body of `pass` / `raise
+  NotImplementedError` / `throw new Error("not implemented")` /
+  equivalent. Include a module-level docstring summarising
+  responsibility. The developer fills these in during Phase 3; the
+  skeleton locks the contract.
+- **Main entry file declaration** — the runnable entry file (e.g.
+  `src/main.py`, `src/index.ts`, `cmd/<app>/main.go`) wired with the
+  top-level bootstrap *sequence*: imports, construction order of
+  subsystems, and the call that hands control to the main loop /
+  server / UI event loop. Subsystem methods invoked from here may be
+  stubs, but the boot path (including opening a window, starting the
+  HTTP listener, etc.) must be expressed in real code — not described
+  in prose. This is what guarantees the chosen stack is actually
+  exercised at runtime.
 
 You MUST NOT include:
-- Complete implementation code (no full class bodies, no full function implementations)
-- Runnable source files
-- Package boilerplate (setup.py, package.json, etc.)
+- Business logic, algorithm internals, state-machine transitions,
+  persistence logic, or any other module-internal behaviour. Function
+  and method bodies in interface files must be one of: `pass`,
+  `raise NotImplementedError(...)`, a single-line delegation to an
+  already-declared collaborator, or the language equivalent.
+- Test files of any kind. Tests belong to developer and QA phases.
+- Populated fixtures, seed data, or sample content.
 
-If you need to illustrate a design point, use pseudocode snippets or interface/type definitions.
+If you need to illustrate a design point beyond the scaffolding above, use
+pseudocode snippets or interface/type definitions inside the design document,
+not additional source files.
+
+### Post-Document Workflow — MANDATORY ORDER
+
+After `docs/architecture.md` is written and its Mermaid diagrams are
+validated, you MUST perform these steps in order. Do not report the
+task complete until every step has run.
+
+1. **Enumerate subsystems from your own design.** Re-read the
+   decomposition section of `docs/architecture.md` (typically the
+   C4Container and C4Component views plus the "Module decomposition"
+   section). Produce an explicit list — in your response text — of the
+   subsystem names you identified. This list is what the next steps
+   operate on; if it is empty, your decomposition is incomplete and you
+   must extend the document first.
+2. **Map each subsystem to a `src/<name>/` directory.** Use a stable,
+   lower-case, snake-case form of the subsystem name. Example mapping:
+   `UI Layer` → `src/ui/`, `Game Engine` → `src/engine/`, `Network
+   Client` → `src/network/`, `Persistence` → `src/persistence/`. Quote
+   the mapping explicitly in your response.
+3. **Create every directory and its barrel file** with `write_file`.
+   For Python, write an `__init__.py` in each — either empty or
+   containing a module docstring naming the subsystem and a one-line
+   responsibility summary. For TypeScript, write `index.ts`; for Rust,
+   `mod.rs`; etc. Do NOT rely on the runtime to auto-create directories
+   — the barrel file is what anchors them.
+4. **Verify the layout landed on disk.** Run the `execute` tool to
+   list `src/`:
+   ```
+   execute(command="ls -la src/ && find src -maxdepth 2 -type f | sort")
+   ```
+   Confirm that every subsystem name from step 1 has a matching
+   directory and barrel file. If any is missing, go back to step 3 and
+   fix — do not claim completion with a partial layout.
+5. **Report the subsystem → directory mapping in your final response**
+   so the developer phase can trust the layout. Example:
+   `Scaffolded 6 subsystems: ui/, engine/, network/, persistence/,
+   analytics/, platform/ — barrel files verified under src/.`
+
+### Document Language
+
+When you write any file under `docs/`, the natural language of the prose
+(headings, narrative paragraphs, bullet text, table content, diagram
+titles) MUST match the language of the user's original requirement text.
+Every dispatch you receive begins with a fenced block in the form:
+
+```
+=== ORIGINAL USER REQUIREMENT (preserve this natural language in all docs/*.md) ===
+<the user's raw requirement text>
+=== END ORIGINAL REQUIREMENT ===
+```
+
+Read that block to determine the language. The rule is binary:
+
+- If the requirement text contains ANY CJK character (Chinese, Japanese,
+  Korean ideograph), write the entire document's prose in **Simplified
+  Chinese**.
+- Otherwise, write the entire document's prose in **English**.
+
+The language rule applies to narrative prose only. The following MUST
+remain unchanged regardless of natural language:
+
+- Markdown structural syntax (fences, table pipes, list markers, heading
+  `#` characters).
+- File paths, directory names, module names, class names, function names,
+  variable names, CLI commands, shell snippets.
+- Technical terms and library/framework names (pygame, FastAPI, pytest,
+  Mermaid, C4Context, etc.).
+- Code blocks of any language — leave them byte-exact.
+- Mermaid diagram reserved words (`flowchart`, `C4Container`, `sequenceDiagram`, …)
+  and node IDs. Human-readable labels/titles inside diagrams SHOULD be
+  translated to match the document language.
+
+When you quote the user's original requirement text verbatim (e.g. in an
+Executive Summary or a "背景" section), preserve it EXACTLY as the user
+wrote it — do not translate, paraphrase, or normalise punctuation.
+
+Do not mix languages within a single document. Pick one per the binary
+rule above and apply it consistently.
 
 ### Diagram Format
 

--- a/src/aise/agents/product_manager.md
+++ b/src/aise/agents/product_manager.md
@@ -89,6 +89,47 @@ git diff --name-only phase_<N-1>_<name>..HEAD
 
 Cite the file list and commit subjects verbatim. Do not paraphrase.
 
+### Document Language
+
+When you write any file under `docs/`, the natural language of the prose
+(headings, narrative paragraphs, bullet text, table content, diagram
+titles) MUST match the language of the user's original requirement text.
+Every dispatch you receive begins with a fenced block in the form:
+
+```
+=== ORIGINAL USER REQUIREMENT (preserve this natural language in all docs/*.md) ===
+<the user's raw requirement text>
+=== END ORIGINAL REQUIREMENT ===
+```
+
+Read that block to determine the language. The rule is binary:
+
+- If the requirement text contains ANY CJK character (Chinese, Japanese,
+  Korean ideograph), write the entire document's prose in **Simplified
+  Chinese**.
+- Otherwise, write the entire document's prose in **English**.
+
+The language rule applies to narrative prose only. The following MUST
+remain unchanged regardless of natural language:
+
+- Markdown structural syntax (fences, table pipes, list markers, heading
+  `#` characters).
+- File paths, directory names, module names, class names, function names,
+  variable names, CLI commands, shell snippets.
+- Technical terms and library/framework names (pygame, FastAPI, pytest,
+  Mermaid, C4Context, etc.).
+- Code blocks of any language — leave them byte-exact.
+- Mermaid diagram reserved words (`flowchart`, `C4Container`, `sequenceDiagram`, …)
+  and node IDs. Human-readable labels/titles inside diagrams SHOULD be
+  translated to match the document language.
+
+When you quote the user's original requirement text verbatim (e.g. in an
+Executive Summary or a "背景" section), preserve it EXACTLY as the user
+wrote it — do not translate, paraphrase, or normalise punctuation.
+
+Do not mix languages within a single document. Pick one per the binary
+rule above and apply it consistently.
+
 ### Diagram Format
 
 Any diagram you include in a requirement or delivery document (user

--- a/src/aise/agents/qa_engineer.md
+++ b/src/aise/agents/qa_engineer.md
@@ -40,19 +40,104 @@ unit tests (and already run pytest to verify those unit tests pass).
    Do NOT read every file.
 2. List `tests/` to see what unit tests already exist. Do NOT re-read
    them; you only need to know their names to avoid duplication.
-3. Write ONE integration test file: `tests/test_integration.py` covering
+3. **Scan `docs/requirement.md` for UI requirements.** Look for Chinese
+   or English terms such as "UI", "GUI", "界面", "图形界面", "画面",
+   "窗口", "window", "screen", "canvas", "render", "HUD", "HTML page",
+   "web interface", "可视化", plus any explicit requirement that a
+   human can *see* and *interact with* the application. Record whether
+   the project is **UI-required** or **headless-only** — the answer
+   drives step 5.
+4. Write ONE integration test file: `tests/test_integration.py` covering
    cross-module scenarios. Optionally add `docs/integration_test_plan.md`
    for a short plan.
-4. **Run the full test suite** with the `execute` tool:
+5. **Run the full test suite** with the `execute` tool:
    ```
    execute(command="python -m pytest tests/ -q --tb=short")
    ```
    This is **REQUIRED** — do not skip it.
-5. If the integration tests fail, fix `tests/test_integration.py` (or
+6. If the integration tests fail, fix `tests/test_integration.py` (or
    flag a real product bug in your summary) and re-run pytest. At most
    **3 fix attempts**.
-6. Respond with a brief summary: which integration scenarios you cover +
-   the final pytest result (pass/fail counts). STOP.
+7. **UI validation — REQUIRED only when step 3 marked the project
+   UI-required.** Skip this step entirely for headless-only projects.
+   See the "UI Validation Step" section below for the exact procedure.
+8. Respond with a brief summary: which integration scenarios you cover,
+   the final pytest result (pass/fail counts), AND — if UI-required —
+   the UI-validation verdict (PASS / FAIL with reason). STOP.
+
+### UI Validation Step
+
+Trigger: step 3 marked the project as UI-required.
+
+Goal: confirm the application actually instantiates a user-facing
+interface at runtime, not just a set of Python classes whose unit tests
+pass. Passing pytest does NOT prove a UI exists — previous projects have
+shipped "UI modules" that only return dicts and never open a window.
+
+Perform all three checks in order. If any check fails, record the
+failure in your summary as **UI VALIDATION FAILED: <reason>** and STOP —
+do not attempt to silently fix or skip.
+
+**Check 7.1 — Framework dependency is pinned.**
+Read the project config file (`pyproject.toml`, `package.json`,
+`requirements.txt`, etc.) and confirm a real UI framework is listed in
+the runtime dependencies. Acceptable frameworks include, but are not
+limited to:
+- Desktop/game: `pygame`, `pyglet`, `arcade`, `tkinter` (stdlib —
+  accept if imported and used), `PyQt5`/`PyQt6`/`PySide6`, `kivy`,
+  `wxPython`, `textual` (TUI), `curses` (stdlib — accept if imported
+  and used)
+- Web server-rendered: `flask`, `fastapi` + a template engine, `django`,
+  `starlette` + templates, `express` + a view engine
+- Web SPA: `react`, `vue`, `svelte`, `solid-js`, `angular`
+- Cross-platform: `electron`, `tauri`, `flet`
+
+If the dependency list is empty (`dependencies = []`) or contains no UI
+framework, this check **FAILS**. Do not accept "we rolled our own UI in
+pure Python dicts" — that is the exact failure mode this step exists
+to catch.
+
+**Check 7.2 — Entry point actually initialises the UI.**
+Grep the entry file (`src/main.py` or equivalent) and the top-level
+bootstrap modules for concrete initialisation calls of the framework
+from check 7.1. Examples of what counts:
+- `pygame.init()` + `pygame.display.set_mode(...)` for pygame
+- `tk.Tk()` / `QApplication(...)` / `App().run()` / `arcade.run()`
+- `app.run(...)` for a Flask/FastAPI server on a bound host/port
+- `curses.wrapper(...)` for curses
+- `Application(...).run()` for textual
+
+A simulated loop that only prints status lines (`print("[STATUS]
+tick=...")` + `time.sleep(...)`) **DOES NOT** count. If you cannot
+locate a real initialisation call, this check **FAILS**.
+
+**Check 7.3 — Entry point boots without UI-layer errors.**
+Launch the entry point with a short timeout using the `execute` tool.
+Use the command the developer declared via `RUN:` (found in the
+delivery artefacts or recovered by reading the entry file). Example:
+```
+execute(command="timeout 5 python src/main.py 2>&1 || true")
+```
+For GUI frameworks that require a display, set
+`SDL_VIDEODRIVER=dummy` (pygame), `QT_QPA_PLATFORM=offscreen` (Qt), or
+the framework-appropriate headless flag before launching, so the check
+runs in the sandbox:
+```
+execute(command="SDL_VIDEODRIVER=dummy timeout 5 python src/main.py 2>&1 || true")
+```
+Expected outcome: the process either runs until the timeout kills it
+(proves it entered its event/main loop — this is SUCCESS, same
+convention as the developer's RUN: check) OR prints lines proving UI
+setup happened (e.g. "pygame ... Hello from the pygame community",
+"Uvicorn running on http://...", a Qt warning about offscreen mode).
+Import errors, `ModuleNotFoundError`, `NoneType has no attribute`
+around UI objects, or immediate clean exits with no UI-layer output
+count as **FAILURE**.
+
+Report the verdict explicitly in your final summary — e.g.
+`UI VALIDATION: PASS (pygame.display.set_mode reached, process
+survived 5s timeout)` or `UI VALIDATION: FAILED — pyproject.toml
+dependencies=[], no GUI framework present`.
 
 ### Output Rules
 
@@ -62,6 +147,47 @@ unit tests (and already run pytest to verify those unit tests pass).
 - Each test file must be complete, runnable pytest code — NOT a plan or description.
 - Do NOT duplicate the developer's unit tests (no `tests/test_<module>.py`).
 - Do NOT respond with "I'll create tests..." — actually write the test files.
+
+### Document Language
+
+When you write any file under `docs/`, the natural language of the prose
+(headings, narrative paragraphs, bullet text, table content, diagram
+titles) MUST match the language of the user's original requirement text.
+Every dispatch you receive begins with a fenced block in the form:
+
+```
+=== ORIGINAL USER REQUIREMENT (preserve this natural language in all docs/*.md) ===
+<the user's raw requirement text>
+=== END ORIGINAL REQUIREMENT ===
+```
+
+Read that block to determine the language. The rule is binary:
+
+- If the requirement text contains ANY CJK character (Chinese, Japanese,
+  Korean ideograph), write the entire document's prose in **Simplified
+  Chinese**.
+- Otherwise, write the entire document's prose in **English**.
+
+The language rule applies to narrative prose only. The following MUST
+remain unchanged regardless of natural language:
+
+- Markdown structural syntax (fences, table pipes, list markers, heading
+  `#` characters).
+- File paths, directory names, module names, class names, function names,
+  variable names, CLI commands, shell snippets.
+- Technical terms and library/framework names (pygame, FastAPI, pytest,
+  Mermaid, C4Context, etc.).
+- Code blocks of any language — leave them byte-exact.
+- Mermaid diagram reserved words (`flowchart`, `C4Container`, `sequenceDiagram`, …)
+  and node IDs. Human-readable labels/titles inside diagrams SHOULD be
+  translated to match the document language.
+
+When you quote the user's original requirement text verbatim (e.g. in an
+Executive Summary or a "背景" section), preserve it EXACTLY as the user
+wrote it — do not translate, paraphrase, or normalise punctuation.
+
+Do not mix languages within a single document. Pick one per the binary
+rule above and apply it consistently.
 
 ### Strict Prohibitions
 

--- a/src/aise/core/project.py
+++ b/src/aise/core/project.py
@@ -152,6 +152,7 @@ class Project:
             "project_root": self.project_root,
             "created_at": self.created_at.isoformat(),
             "updated_at": self.updated_at.isoformat(),
+            "scaffolding_error": self.scaffolding_error,
         }
 
     def __repr__(self) -> str:

--- a/src/aise/runtime/project_session.py
+++ b/src/aise/runtime/project_session.py
@@ -139,6 +139,12 @@ class ProjectSession:
         global_pm_rt = self._manager.get_runtime(self._orchestrator_name)
 
         self._requirement = requirement
+        # Make the raw requirement visible to every dispatch so workers
+        # can read it directly and mirror the user's natural language
+        # in any docs/*.md they write (see tool_primitives.dispatch_task
+        # for the prefix format, and architect.md / product_manager.md /
+        # qa_engineer.md "Document Language" sections for the rule).
+        self._ctx.original_requirement = requirement
         try:
             if global_pm_rt is not None:
                 global_pm_rt._state = AgentState.WORKING

--- a/src/aise/runtime/tool_primitives.py
+++ b/src/aise/runtime/tool_primitives.py
@@ -165,6 +165,12 @@ class ToolContext:
     event_lock: threading.Lock = field(default_factory=threading.Lock)
     runtime_resolver: Callable[[str, Any], Any] | None = None
     processes_dir: Path | None = None
+    # The raw user requirement that kicked off this session. Prepended
+    # to every dispatch_task prompt so workers see the user's original
+    # natural language and can mirror it in any docs/*.md they write.
+    # Empty string means "no requirement available" (e.g. unit tests
+    # exercising the primitive directly); the prefix is then skipped.
+    original_requirement: str = ""
     # Dedup caches: the orchestrator fires a ``stage_update`` before every
     # dispatch even when the stage has not actually changed (parallel
     # developer dispatches all emit "implementation started"), and weak
@@ -420,9 +426,26 @@ def make_dispatch_tools(ctx: ToolContext) -> list[BaseTool]:
                     }
                 )
 
+            # Build the prompt the worker actually sees. Prepend the
+            # project's original user requirement (if the session set
+            # one on ctx) so agents have a stable signal to mirror the
+            # user's natural language when writing docs/*.md. The
+            # already-emitted ``request_msg`` keeps the unprefixed
+            # ``task_description`` in its payload so the UI/log is not
+            # bloated by N copies of the same requirement block.
+            worker_prompt = task_description
+            if ctx.original_requirement:
+                worker_prompt = (
+                    "=== ORIGINAL USER REQUIREMENT "
+                    "(preserve this natural language in all docs/*.md) ===\n"
+                    f"{ctx.original_requirement}\n"
+                    "=== END ORIGINAL REQUIREMENT ===\n\n"
+                    f"{task_description}"
+                )
+
             # First attempt.
             result = dispatch_rt.handle_message(
-                task_description,
+                worker_prompt,
                 on_todos_update=_on_todos_update,
             )
 
@@ -455,7 +478,7 @@ def make_dispatch_tools(ctx: ToolContext) -> list[BaseTool]:
                         _MAX_DISPATCH_RETRIES,
                         task_id,
                     )
-                retry_prompt = _build_retry_prompt(task_description, result)
+                retry_prompt = _build_retry_prompt(worker_prompt, result)
                 result = dispatch_rt.handle_message(
                     retry_prompt,
                     on_todos_update=_on_todos_update,

--- a/src/aise/web/safety_net_events_service.py
+++ b/src/aise/web/safety_net_events_service.py
@@ -174,11 +174,20 @@ class SafetyNetEventsService:
 
     def _target_projects(self, project_id: str | None) -> list[str]:
         """Resolve the scan list. When ``project_id`` is set, scope
-        to that one directory (even if it doesn't exist yet — we'll
-        just skip it); otherwise scan everything under projects_root.
+        to that one directory; otherwise scan everything under
+        projects_root.
+
+        ``project_id`` is caller-controlled (query-string input) so it
+        is validated against :meth:`list_project_ids`. Anything that
+        doesn't match an existing direct child of ``projects_root`` —
+        including path-traversal attempts like ``../etc`` — returns
+        an empty scan list, matching the legacy "missing project →
+        no events" behavior without exposing the filesystem.
         """
         if project_id:
-            return [project_id]
+            if project_id in self.list_project_ids():
+                return [project_id]
+            return []
         return self.list_project_ids()
 
     def _read_events(self, project_id: str) -> list[_RawEvent]:

--- a/src/aise/web/static/app.js
+++ b/src/aise/web/static/app.js
@@ -493,6 +493,7 @@ function setupProjectReact() {
         const h = window.React.createElement;
         const project = initial.project;
         const projectId = String((project.info || {}).project_id || "");
+        const [projectInfo, setProjectInfo] = window.React.useState(project.info || {});
         const [requirements, setRequirements] = window.React.useState(Array.isArray(project.requirements) ? project.requirements : []);
         const [runs, setRuns] = window.React.useState(Array.isArray(project.runs) ? project.runs : []);
         const [text, setText] = window.React.useState("");
@@ -506,11 +507,13 @@ function setupProjectReact() {
             let timer = 0;
             async function refresh() {
                 try {
-                    const [requirementsData, runsData] = await Promise.all([
+                    const [projData, requirementsData, runsData] = await Promise.all([
+                        fetchJson(`/api/projects/${encodeURIComponent(projectId)}`),
                         fetchJson(`/api/projects/${encodeURIComponent(projectId)}/requirements`),
                         fetchJson(`/api/projects/${encodeURIComponent(projectId)}/runs`),
                     ]);
                     if (!active) return;
+                    if (projData && projData.info) setProjectInfo(projData.info);
                     setRequirements(Array.isArray(requirementsData.requirements) ? requirementsData.requirements : []);
                     setRuns(Array.isArray(runsData.runs) ? runsData.runs : []);
                     setProjectMissing(false);
@@ -600,21 +603,26 @@ function setupProjectReact() {
             })[0];
         }
 
+        const liveStatus = projectInfo.status || (project.info || {}).status || "";
+        const isScaffolding = liveStatus === "scaffolding";
+        const scaffoldingFailed = liveStatus === "scaffolding_failed";
+        const blockActions = projectMissing || isScaffolding || scaffoldingFailed;
+
         return h(
             "div",
             { className: "project-layout" },
             h(
                 "section",
                 { className: "card card-glow project-header-card" },
-                h("h1", null, project.info.project_name),
-                h("p", { className: "muted" }, t("project.header_meta", { id: project.info.project_id, status: project.info.status, mode: project.info.development_mode })),
+                h("h1", null, projectInfo.project_name || project.info.project_name),
+                h("p", { className: "muted" }, t("project.header_meta", { id: projectInfo.project_id || project.info.project_id, status: liveStatus, mode: projectInfo.development_mode || project.info.development_mode })),
                 h("div", { style: { display: "flex", gap: "8px", marginTop: "8px" } },
                     h(
                         "button",
                         {
                             type: "button",
                             className: "btn secondary",
-                            disabled: projectMissing,
+                            disabled: blockActions,
                             onClick: restartCurrentProject,
                         },
                         t("project.restart")
@@ -639,7 +647,39 @@ function setupProjectReact() {
                     h("a", { className: "btn secondary", href: "/" }, t("project.back_to_list"))
                 )
                 : null,
-            view === "default" ? (function () {
+            !projectMissing && isScaffolding
+                ? h(
+                    "section",
+                    { className: "card", key: "scaffolding-status" },
+                    h("h2", { style: { marginTop: 0 } },
+                        h("span", { style: { display: "inline-block", width: "10px", height: "10px", borderRadius: "50%", background: "var(--warning, #f59e0b)", marginRight: "10px", animation: "pulse 1.4s ease-in-out infinite" } }),
+                        t("project.scaffolding_title")
+                    ),
+                    h("p", null, t("project.scaffolding_hint")),
+                    h("h3", null, t("project.scaffolding_steps_heading")),
+                    h("ul", { className: "history-list" },
+                        h("li", null, t("project.scaffolding_step_dirs")),
+                        h("li", null, t("project.scaffolding_step_git")),
+                        h("li", null, t("project.scaffolding_step_gitignore"))
+                    ),
+                    h("p", { className: "muted", style: { fontSize: "12px", marginTop: "12px" } }, t("project.scaffolding_polling_note"))
+                )
+                : null,
+            !projectMissing && scaffoldingFailed
+                ? h(
+                    "section",
+                    { className: "card", key: "scaffolding-failed" },
+                    h("h2", { style: { marginTop: 0 } }, t("project.scaffolding_failed_title")),
+                    h("p", null, t("project.scaffolding_failed_hint")),
+                    h("pre", { className: "error" },
+                        (projectInfo.scaffolding_error && String(projectInfo.scaffolding_error))
+                        || t("project.scaffolding_failed_fallback_error")
+                    ),
+                    h("p", { className: "muted", style: { fontSize: "12px", marginTop: "8px" } }, t("project.scaffolding_failed_guidance")),
+                    h("a", { className: "btn secondary", href: "/" }, t("project.back_to_list"))
+                )
+                : null,
+            !projectMissing && !isScaffolding && !scaffoldingFailed && view === "default" ? (function () {
                 const latestRun = pickLatestRun(runs);
                 const hasIncrementalBaseline = runs.some(function (r) {
                     return r && r.status === "completed" && (r.result || "").toString().trim();
@@ -1112,21 +1152,38 @@ function setupRunReact() {
                 taskResponseByTaskId[ev.taskId] = ev;
             }
         }
-        // Hide raw todos_update rows (render inline under their task_request)
-        // and task_response rows (merged into their request).
-        const visibleLog = taskLog.filter(
-            (e) => e.type !== "todos_update" && e.type !== "task_response",
-        );
+        // Events excluded from the timeline log:
+        //   - todos_update: rendered inline under its owning task_request.
+        //   - task_response: merged into its paired task_request card.
+        //   - phase_plan / phase_start / phase_complete: orchestrator
+        //     bookkeeping events that only drive server-side retry
+        //     metadata (run.phase_total, run.failed_phase_idx). Phase
+        //     progress is already visible to the user via the stage-chip
+        //     strip above, so rendering them as log rows is pure noise.
+        //   - tool_call: orchestrator-internal primitive invocations
+        //     (list_processes, get_process, list_agents, execute_shell).
+        //     The A2A log is meant for agent-to-agent dispatches; tool
+        //     calls are the orchestrator's private actions and carry no
+        //     taskId, so they can't be grouped under a parent dispatch.
+        const HIDDEN_LOG_EVENT_TYPES = new Set([
+            "todos_update",
+            "task_response",
+            "phase_plan",
+            "phase_start",
+            "phase_complete",
+            "phase_resume",
+            "tool_call",
+            "language_config",
+            "workflow_complete",
+        ]);
+        const isVisibleEvent = (e) => !!e && !HIDDEN_LOG_EVENT_TYPES.has(e.type);
+        const visibleLog = taskLog.filter(isVisibleEvent);
         // Filter predicate uses the NORMALIZED stage so a single
         // ``implementation`` chip matches every ``implementation_layer*``
         // event, not just the one raw id the user clicked.
         const visibleStages = taskLog
             .map((_, i) => evStagesNormalized[i])
-            .filter(
-                (_, i) =>
-                    taskLog[i].type !== "todos_update" &&
-                    taskLog[i].type !== "task_response",
-            );
+            .filter((_, i) => isVisibleEvent(taskLog[i]));
         const filteredLog = stageFilter
             ? visibleLog.filter((_, i) => visibleStages[i] === stageFilter)
             : visibleLog;

--- a/src/aise/web/static/locales/en/translation.json
+++ b/src/aise/web/static/locales/en/translation.json
@@ -266,7 +266,18 @@
     "col_view": "View",
     "view_detail": "Details",
     "no_runs": "No runs yet.",
-    "redirect_notice": "Redirecting to the latest run..."
+    "redirect_notice": "Redirecting to the latest run...",
+    "scaffolding_title": "Preparing environment",
+    "scaffolding_hint": "The product-manager agent is initialising the project directory and git repository. This page will refresh automatically; the \"Submit requirement\" entry appears once the project is ready.",
+    "scaffolding_steps_heading": "Steps in progress",
+    "scaffolding_step_dirs": "Create directory layout (docs/, src/, tests/, scripts/, config/, artifacts/, trace/)",
+    "scaffolding_step_git": "Initialise git repository and configure local identity",
+    "scaffolding_step_gitignore": "Seed the baseline .gitignore and make the initial scaffold commit",
+    "scaffolding_polling_note": "Status refreshes every 3 seconds — no manual reload needed.",
+    "scaffolding_failed_title": "Environment preparation failed",
+    "scaffolding_failed_hint": "Project initialisation did not complete, so no requirement can be submitted. Error detail:",
+    "scaffolding_failed_fallback_error": "No specific error was captured. Check the runtime logs for details.",
+    "scaffolding_failed_guidance": "The recommended recovery is to delete the project and re-create it. If the failure recurs, inspect the product-manager agent logs and the project-root directory permissions."
   },
   "monitor": {
     "title": "Agent Monitor",

--- a/src/aise/web/static/locales/zh/translation.json
+++ b/src/aise/web/static/locales/zh/translation.json
@@ -266,7 +266,18 @@
     "col_view": "查看",
     "view_detail": "详情",
     "no_runs": "暂无执行记录。",
-    "redirect_notice": "正在跳转到最新执行记录..."
+    "redirect_notice": "正在跳转到最新执行记录...",
+    "scaffolding_title": "环境准备中",
+    "scaffolding_hint": "项目目录和 git 仓库正在由 product-manager 代理初始化。准备完成后此页面会自动刷新，可在下方看到「下发需求」入口。",
+    "scaffolding_steps_heading": "正在执行的步骤",
+    "scaffolding_step_dirs": "创建目录结构（docs/、src/、tests/、scripts/、config/、artifacts/、trace/）",
+    "scaffolding_step_git": "初始化 git 仓库并配置本地身份",
+    "scaffolding_step_gitignore": "生成基线 .gitignore 并完成首个 scaffold 提交",
+    "scaffolding_polling_note": "系统每 3 秒自动刷新一次状态，无需手动重载。",
+    "scaffolding_failed_title": "环境准备失败",
+    "scaffolding_failed_hint": "项目初始化未成功，无法继续下发需求。错误详情：",
+    "scaffolding_failed_fallback_error": "未捕获到具体错误信息，请查看运行日志。",
+    "scaffolding_failed_guidance": "建议删除该项目后重新创建；如果问题反复出现，请检查 product-manager 代理日志与项目根目录权限。"
   },
   "monitor": {
     "title": "Agent Monitor",

--- a/src/aise/web/static/main.css
+++ b/src/aise/web/static/main.css
@@ -2485,7 +2485,7 @@ button.flow-composite-card:hover,
 .task-log-level.error {
   border-color: var(--error-border);
   background: var(--error-light);
-  color: var(--error);
+  color: #b91c1c;
 }
 
 .task-log-level.warning {
@@ -3247,19 +3247,22 @@ button.flow-composite-card:hover,
 .logs-filters .logs-filter-row {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, auto) minmax(0, 1fr));
-  gap: 6px 12px;
+  gap: 8px 14px;
   align-items: center;
 }
 .logs-filters .logs-filter-row label {
-  font-size: 0.78rem;
-  color: #9aa4b2;
+  font-size: 0.72rem;
+  color: var(--muted);
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.05em;
   white-space: nowrap;
+  font-weight: 600;
 }
 .logs-filters .logs-filter-row input,
 .logs-filters .logs-filter-row select {
   min-width: 100px;
+  padding: 7px 10px;
+  font-size: 13px;
 }
 .logs-filters .logs-filter-row button {
   grid-column: span 2;
@@ -3269,47 +3272,77 @@ button.flow-composite-card:hover,
 .log-viewer {
   max-height: 60vh;
   overflow-y: auto;
-  background: rgba(0,0,0,0.25);
-  border-radius: 6px;
-  font-family: "JetBrains Mono", monospace;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
   font-size: 0.78rem;
+  color: var(--text);
 }
 .log-row {
   display: grid;
   grid-template-columns: 170px 80px 160px 1fr;
-  padding: 2px 8px;
+  padding: 4px 10px;
   gap: 10px;
   cursor: pointer;
-  border-bottom: 1px solid rgba(255,255,255,0.04);
+  border-bottom: 1px solid var(--line-light);
   white-space: nowrap;
+  transition: background var(--transition-fast);
 }
-.log-row:hover { background: rgba(255,255,255,0.04); }
-.log-row-selected { background: rgba(14,165,233,0.10); }
-.log-col-ts { color: #94a3b8; }
-.log-col-level { font-weight: 600; text-transform: uppercase; font-size: 0.72rem; }
-.log-col-logger { color: #a5b4fc; }
-.log-col-message { white-space: normal; word-break: break-word; }
-.log-level-debug { color: #64748b; }
-.log-level-info { color: #38bdf8; }
-.log-level-warning, .log-level-warn { color: #f59e0b; }
-.log-level-error { color: #ef4444; }
-.log-level-critical, .log-level-fatal { color: #ec4899; }
-.log-row-error { background: rgba(239, 68, 68, 0.06); }
-.log-row-warn { background: rgba(245, 158, 11, 0.06); }
+.log-row:last-child { border-bottom: none; }
+.log-row:hover { background: var(--surface-hover); }
+.log-row-selected,
+.log-row-selected:hover,
+.log-row-error.log-row-selected,
+.log-row-warn.log-row-selected,
+.log-row-error.log-row-selected:hover,
+.log-row-warn.log-row-selected:hover {
+  background: rgba(99, 102, 241, 0.18);
+  border-bottom-color: var(--primary-border);
+  box-shadow: inset 3px 0 0 var(--primary);
+}
+.log-row-selected .log-col-message { font-weight: 600; color: var(--text); }
+.log-row-selected .log-col-ts { color: var(--primary-hover); font-weight: 600; }
+.log-col-ts { color: var(--muted); }
+.log-col-level {
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  align-self: center;
+}
+.log-col-logger {
+  color: var(--primary-hover);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.log-col-message { white-space: normal; word-break: break-word; color: var(--text); }
+.log-level-debug { color: var(--muted); }
+.log-level-info { color: #0369a1; }
+.log-level-warning, .log-level-warn { color: #b45309; }
+.log-level-error { color: #b91c1c; }
+.log-level-critical, .log-level-fatal { color: #9d174d; }
+.log-row-error { background: rgba(239, 68, 68, 0.05); }
+.log-row-warn { background: rgba(245, 158, 11, 0.05); }
+.log-row-error:hover { background: rgba(239, 68, 68, 0.1); }
+.log-row-warn:hover { background: rgba(245, 158, 11, 0.1); }
 
 .log-analysis {
   margin-top: 12px;
-  background: rgba(14, 165, 233, 0.06);
-  border: 1px solid rgba(14, 165, 233, 0.2);
-  border-radius: 6px;
-  padding: 10px 14px;
+  background: var(--surface-soft);
+  border: 1px solid var(--primary-border);
+  border-left: 3px solid var(--primary);
+  border-radius: var(--radius-sm);
+  padding: 12px 16px;
 }
 .log-analysis pre {
   white-space: pre-wrap;
   word-break: break-word;
-  font-family: "JetBrains Mono", monospace;
+  font-family: var(--font-mono);
   font-size: 0.82rem;
-  color: #e5e7eb;
+  color: var(--text);
+  margin: 0;
+  line-height: 1.55;
 }
 
 /* Safety-net analytics dashboard ------------------------------------ */
@@ -3323,39 +3356,53 @@ button.flow-composite-card:hover,
 .analytics-filters label {
   display: flex;
   flex-direction: column;
-  font-size: 0.78rem;
-  color: #9ca3af;
-  gap: 4px;
+  font-size: 0.72rem;
+  color: var(--muted);
+  gap: 6px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 .analytics-filters input,
 .analytics-filters select {
-  background: #1f2937;
-  color: #e5e7eb;
-  border: 1px solid #374151;
-  border-radius: 4px;
-  padding: 6px 8px;
-  font-size: 0.85rem;
+  font-size: 0.88rem;
   min-width: 180px;
+  padding: 8px 10px;
+  text-transform: none;
+  letter-spacing: normal;
+  font-weight: 400;
+  color: var(--text);
 }
 .analytics-filters button {
-  background: #0ea5e9;
-  color: #fff;
+  background: linear-gradient(135deg, var(--primary), var(--primary-hover));
+  color: var(--text-inverse);
   border: none;
-  border-radius: 4px;
-  padding: 8px 16px;
+  border-radius: var(--radius-sm);
+  padding: 9px 18px;
   cursor: pointer;
+  font-weight: 600;
+  font-size: 0.88rem;
+  transition: filter var(--transition-fast), box-shadow var(--transition-fast);
+  box-shadow: 0 1px 3px rgba(99, 102, 241, 0.2);
+}
+.analytics-filters button:hover:not(:disabled) {
+  filter: brightness(1.05);
+  box-shadow: 0 2px 6px rgba(99, 102, 241, 0.3);
 }
 .analytics-filters button:disabled {
-  background: #475569;
+  background: var(--pending-color);
   cursor: wait;
+  box-shadow: none;
 }
 .analytics-error {
-  background: rgba(239, 68, 68, 0.08);
-  border: 1px solid rgba(239, 68, 68, 0.25);
-  color: #fca5a5;
-  padding: 8px 12px;
-  border-radius: 4px;
+  background: var(--error-light);
+  border: 1px solid var(--error-border);
+  color: #b91c1c;
+  padding: 10px 14px;
+  border-radius: var(--radius-sm);
   margin-bottom: 12px;
+  font-size: 0.88rem;
+  font-weight: 500;
 }
 .analytics-pill-row {
   display: grid;
@@ -3364,36 +3411,53 @@ button.flow-composite-card:hover,
   margin-bottom: 20px;
 }
 .analytics-pill {
-  background: #1f2937;
-  border: 1px solid #374151;
-  border-radius: 6px;
-  padding: 14px 16px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 16px 18px;
+  box-shadow: var(--shadow-sm);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast), transform var(--transition-fast);
+}
+.analytics-pill:hover {
+  border-color: var(--primary-border);
+  box-shadow: var(--shadow);
+  transform: translateY(-1px);
 }
 .analytics-pill-value {
-  font-size: 1.6rem;
-  font-weight: 600;
-  color: #e5e7eb;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--text);
+  font-family: var(--font-heading);
+  line-height: 1.2;
+  font-variant-numeric: tabular-nums;
 }
 .analytics-pill-label {
-  font-size: 0.78rem;
-  color: #9ca3af;
-  margin-top: 4px;
+  font-size: 0.72rem;
+  color: var(--muted);
+  margin-top: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
 }
-.analytics-pill-success { border-left: 3px solid #10b981; }
-.analytics-pill-failed { border-left: 3px solid #ef4444; }
-.analytics-pill-skipped { border-left: 3px solid #6b7280; }
+.analytics-pill-success { border-left: 3px solid var(--success); }
+.analytics-pill-success .analytics-pill-value { color: #047857; }
+.analytics-pill-failed { border-left: 3px solid var(--error); }
+.analytics-pill-failed .analytics-pill-value { color: #b91c1c; }
+.analytics-pill-skipped { border-left: 3px solid var(--pending-color); }
 .analytics-empty,
 .analytics-empty-hero {
-  color: #9ca3af;
+  color: var(--muted);
   font-size: 0.9rem;
   padding: 10px 0;
+  margin: 0;
 }
 .analytics-empty-hero {
-  background: rgba(14, 165, 233, 0.05);
-  border: 1px dashed rgba(14, 165, 233, 0.3);
-  border-radius: 6px;
+  background: var(--primary-light);
+  border: 1px dashed var(--primary-border);
+  border-radius: var(--radius-sm);
   padding: 14px 18px;
   margin: 10px 0 20px;
+  color: var(--text-secondary);
 }
 .analytics-grid {
   display: grid;
@@ -3402,38 +3466,51 @@ button.flow-composite-card:hover,
   margin-bottom: 20px;
 }
 .analytics-section {
-  background: #1f2937;
-  border: 1px solid #374151;
-  border-radius: 6px;
-  padding: 14px 16px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 16px 18px;
+  box-shadow: var(--shadow-sm);
 }
 .analytics-section h3 {
-  margin: 0 0 10px;
+  margin: 0 0 12px;
   font-size: 0.95rem;
-  color: #d1d5db;
+  color: var(--text);
+  font-weight: 700;
 }
 .analytics-top-list {
   list-style: decimal inside;
   padding: 0;
   margin: 0;
+  color: var(--muted);
 }
 .analytics-top-list li {
   display: flex;
   justify-content: space-between;
-  padding: 4px 0;
-  border-bottom: 1px solid #2d3748;
+  align-items: center;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--line-light);
   font-size: 0.85rem;
+  gap: 12px;
 }
 .analytics-top-list li:last-child { border-bottom: none; }
 .analytics-top-key {
-  color: #e5e7eb;
-  font-family: "JetBrains Mono", monospace;
+  color: var(--text);
+  font-family: var(--font-mono);
   overflow-wrap: anywhere;
+  flex: 1;
+  min-width: 0;
 }
 .analytics-top-count {
-  color: #9ca3af;
+  color: var(--primary);
   font-variant-numeric: tabular-nums;
   margin-left: 12px;
+  font-weight: 700;
+  background: var(--primary-light);
+  padding: 2px 10px;
+  border-radius: var(--radius-pill);
+  font-size: 0.78rem;
+  flex-shrink: 0;
 }
 .analytics-recent {
   overflow-x: auto;
@@ -3441,24 +3518,33 @@ button.flow-composite-card:hover,
 .analytics-recent-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.82rem;
+  font-size: 0.85rem;
 }
 .analytics-recent-table th,
 .analytics-recent-table td {
-  padding: 6px 8px;
-  border-bottom: 1px solid #2d3748;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--line-light);
   text-align: left;
   white-space: nowrap;
 }
+.analytics-recent-table thead tr {
+  border-bottom: 2px solid var(--line);
+}
 .analytics-recent-table th {
-  color: #9ca3af;
-  font-weight: 500;
+  color: var(--muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.7rem;
 }
 .analytics-recent-table td {
-  color: #e5e7eb;
+  color: var(--text);
+}
+.analytics-recent-table tbody tr:hover {
+  background: var(--surface-soft);
 }
 .analytics-recent-table .analytics-ts {
-  font-family: "JetBrains Mono", monospace;
-  color: #9ca3af;
+  font-family: var(--font-mono);
+  color: var(--muted);
   font-size: 0.78rem;
 }

--- a/src/aise/web/templates/layout.html
+++ b/src/aise/web/templates/layout.html
@@ -9,7 +9,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&family=Manrope:wght@500;600;700;800&family=Noto+Sans+SC:wght@400;500;700&display=swap">
-  <link rel="stylesheet" href="/static/main.css?v=20260422c">
+  <link rel="stylesheet" href="/static/main.css?v=20260422e">
 </head>
 <body>
   <div class="app-shell">
@@ -111,7 +111,7 @@
        language is authoritative. -->
   <script src="https://unpkg.com/i18next@23.11.5/dist/umd/i18next.min.js"></script>
   <script src="https://unpkg.com/i18next-http-backend@2.5.2/i18nextHttpBackend.min.js"></script>
-  <script src="/static/app.js?v=20260422c"></script>
+  <script src="/static/app.js?v=20260422e"></script>
   {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/tests/test_core/test_project_manager.py
+++ b/tests/test_core/test_project_manager.py
@@ -206,3 +206,27 @@ class TestProjectManagerGlobalConfig:
         assert len(rows) == 1
         assert rows[0]["phase"] == "requirements"
         assert rows[0]["status"] == "completed"
+
+
+class TestProjectGetInfoScaffoldingError:
+    def test_get_info_includes_scaffolding_error_key_when_unset(self):
+        project = Project(
+            project_id="p_info_0",
+            config=ProjectConfig(project_name="InfoScaffoldOK"),
+            orchestrator=_StubOrchestrator(),  # type: ignore[arg-type]
+        )
+        info = project.get_info()
+        assert "scaffolding_error" in info
+        assert info["scaffolding_error"] is None
+        assert info["status"] == "scaffolding"
+
+    def test_get_info_exposes_scaffolding_error_after_failure(self):
+        project = Project(
+            project_id="p_info_1",
+            config=ProjectConfig(project_name="InfoScaffoldFail"),
+            orchestrator=_StubOrchestrator(),  # type: ignore[arg-type]
+        )
+        project.fail_scaffolding("mkdir refused: permission denied on /opt/ai")
+        info = project.get_info()
+        assert info["status"] == "scaffolding_failed"
+        assert info["scaffolding_error"] == "mkdir refused: permission denied on /opt/ai"

--- a/tests/test_runtime/test_project_session.py
+++ b/tests/test_runtime/test_project_session.py
@@ -136,6 +136,75 @@ class TestProjectSessionTools:
         assert "task_request" in types
         assert "task_response" in types
 
+    def test_dispatch_prepends_original_requirement_to_worker_prompt(self, session):
+        """When the session has an original requirement, dispatch_task
+        must prefix it onto the worker prompt so agents can mirror the
+        user's natural language in docs/*.md. The emitted task_request
+        event keeps the raw task_description unmodified so the log is
+        not polluted by N copies of the requirement block.
+        """
+        session._ctx.original_requirement = "创建一个贪吃蛇游戏，需要方向键控制"
+        tools = session._make_tools()
+        dispatch = next(t for t in tools if t.name == "dispatch_task")
+
+        # Capture what the worker's handle_message actually receives.
+        captured = {}
+        target = session._manager.get_runtime("developer")
+        original_handle = target.handle_message
+
+        def _capture(prompt, **kw):
+            captured["prompt"] = prompt
+            return original_handle(prompt, **kw)
+
+        target.handle_message = _capture
+
+        dispatch.invoke(
+            {
+                "agent_name": "developer",
+                "task_description": "Implement module X",
+            }
+        )
+
+        worker_prompt = captured["prompt"]
+        assert "=== ORIGINAL USER REQUIREMENT" in worker_prompt
+        assert "创建一个贪吃蛇游戏" in worker_prompt
+        assert "=== END ORIGINAL REQUIREMENT ===" in worker_prompt
+        assert "Implement module X" in worker_prompt
+
+        # The emitted task_request payload keeps the raw description,
+        # unpolluted by the prefix.
+        requests = [e for e in session.task_log if e["type"] == "task_request"]
+        assert requests, "expected at least one task_request event"
+        assert requests[-1]["payload"]["task"] == "Implement module X"
+
+    def test_dispatch_without_original_requirement_is_unchanged(self, session):
+        """Default (empty) requirement means no prefix — preserves the
+        existing contract for unit tests and any caller that invokes
+        the primitive directly without setting the session requirement.
+        """
+        # Ensure nothing set it.
+        session._ctx.original_requirement = ""
+        tools = session._make_tools()
+        dispatch = next(t for t in tools if t.name == "dispatch_task")
+
+        captured = {}
+        target = session._manager.get_runtime("developer")
+        original_handle = target.handle_message
+
+        def _capture(prompt, **kw):
+            captured["prompt"] = prompt
+            return original_handle(prompt, **kw)
+
+        target.handle_message = _capture
+
+        dispatch.invoke(
+            {
+                "agent_name": "developer",
+                "task_description": "bare task",
+            }
+        )
+        assert captured["prompt"] == "bare task"
+
 
 class TestPhase4EntryPointContract:
     """The Phase 4 prompt must instruct the developer to produce an

--- a/tests/test_web/test_safety_net_events_service.py
+++ b/tests/test_web/test_safety_net_events_service.py
@@ -181,6 +181,24 @@ class TestFilters:
         summary = svc.summarize(project_id="does-not-exist")
         assert summary.total == 0
 
+    def test_project_id_path_traversal_is_rejected(self, tmp_path: Path) -> None:
+        """The ``project_id`` filter comes straight from the query
+        string; it must not be able to escape ``projects_root``. A
+        bait file is planted as a sibling of ``projects_root`` at the
+        exact path a traversal would resolve to — if the guard is
+        missing, the service would read it.
+        """
+        root = tmp_path / "projects"
+        _seed_events(root, "legit_project", [_event(ts="2026-04-22T10:00:00+00:00")])
+        bait = tmp_path / "leaked" / "trace" / "safety_net_events.jsonl"
+        bait.parent.mkdir(parents=True)
+        bait.write_text(json.dumps(_event(ts="2099-01-01T00:00:00+00:00")) + "\n", encoding="utf-8")
+
+        svc = SafetyNetEventsService(root)
+        assert svc.summarize(project_id="../leaked").total == 0
+        assert svc.summarize(project_id="/etc").total == 0
+        assert svc.summarize(project_id="legit_project/../../leaked").total == 0
+
     def test_since_filter_excludes_older_events(self, tmp_path: Path) -> None:
         root = tmp_path / "projects"
         _seed_events(


### PR DESCRIPTION
## Summary

Addresses a cluster of UX and correctness gaps surfaced while running project_5-snake end-to-end.

- **Scaffolding UX** — new "Preparing environment" / "Preparation failed" cards on the project-detail page. Previously the page was blank while the PM agent was initialising the project tree, and any scaffolding failure was invisible. `Project.get_info()` now exposes `scaffolding_error`, `projectInfo` is polled live so the view auto-transitions on status flip, and action buttons are disabled while scaffolding.
- **Requirement-language propagation** — workers used to receive only the orchestrator-drafted (English) `task_description`, never the user's raw requirement, so `docs/*.md` always came out in English regardless of input language. `ToolContext.original_requirement` carries the raw user text, `ProjectSession.run` wires it at entry, and `dispatch_task` prepends a bounded `=== ORIGINAL USER REQUIREMENT ===` block to every worker prompt (keeping the emitted `task_request.payload.task` unmodified so the UI isn't bloated). The three doc-producing agents (`product_manager`, `architect`, `qa_engineer`) now have a reliable signal to mirror the user's natural language (binary CJK rule).
- **Architect scaffolding requirements** — architect is now allowed and required to create project-config, subsystem directories, interface-stub files, and the main-entry file after writing `docs/architecture.md`. Post-document workflow enumerates subsystems from the C4 diagrams, maps each to `src/<name>/`, creates barrel files, and verifies on disk via `execute`.
- **QA UI validation** — when the requirement asks for a UI, `qa_engineer` now runs a three-step validation (framework dep pinned in project config, entry point calls a real init like `pygame.display.set_mode` / `app.run`, and headless boot smoke test). Catches the "simulated loop that only prints `[STATUS] tick=...`" failure mode that project_5 produced previously.
- **A2A log cleanup** — the run-detail timeline used to render runtime-control events (`phase_plan/start/complete/resume`, `tool_call`, `language_config`, `workflow_complete`) as uninformative top-level rows. Shared `HIDDEN_LOG_EVENT_TYPES` set hides them; stage progress is already visible via the chip strip.

## Tests

- `tests/test_core/test_project_manager.py` — `TestProjectGetInfoScaffoldingError` (2 tests) covers the new `get_info()["scaffolding_error"]` field in both default and populated states.
- `tests/test_runtime/test_project_session.py` — two tests verify `dispatch_task` prepends the requirement when `ctx.original_requirement` is set and leaves the prompt alone when empty (back-compat for unit tests).
- Existing agent / project / runtime tests remain green: `pytest tests/test_runtime/test_project_session.py tests/test_agents/ tests/test_core/test_project_manager.py` → 126 passed, 3 skipped.
- `ruff check` clean on the Python files in this diff; `node --check` clean on `app.js`; zh/en locale JSON parses and has key parity.

## Carryover from earlier auto-runs

This branch also carries a few changes that predate this session and were never manually committed:

- `src/aise/web/static/main.css`, `src/aise/web/templates/layout.html` — small visual tweaks from prior work.
- `docs/requirement.md`, `.coverage` at repo root — **artifacts accidentally written by a project_5 run into the AISE repo root** (from commit `aba7c3d`). These should arguably be `.gitignore`d and reverted; flagging for reviewer consideration.
- `projects/project_5-snake/docs/delivery_report.md` deletion — the stale English-prose report, will be regenerated on the next Phase 6 run under the new language-mirroring rule.

## Test plan

- [ ] Create a new project with a Chinese requirement (e.g. `创建一个简单的贪吃蛇游戏`); confirm the project-detail page shows the "环境准备中" card with the pulsing dot while status=scaffolding, and auto-transitions to the action card once ready.
- [ ] Trigger a scaffolding failure (e.g. revoke write permission on the projects root); confirm the error card displays the captured `scaffolding_error` text.
- [ ] Run the same Chinese requirement through Phase 1–6; confirm `docs/requirement.md`, `docs/architecture.md`, and `docs/delivery_report.md` are all written in Chinese (prose only — code blocks, paths, framework names stay English).
- [ ] Run an English requirement; confirm docs come out in English.
- [ ] Open an active run's detail page and confirm the timeline no longer shows rows for `phase_plan` / `phase_start` / `phase_complete` / `tool_call` / `language_config` / `workflow_complete`.
- [ ] For a UI-flagged project, run through QA phase; confirm the delivery summary includes `UI VALIDATION: PASS/FAILED` with a reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)