### PR TITLE
feat(runtime+web): per-run LLM token stats, dispatch budget auto-scale, two-stage subsystem fan-out

### DIFF
--- a/src/aise/agents/_runtime_skills/code_inspection/SKILL.md
+++ b/src/aise/agents/_runtime_skills/code_inspection/SKILL.md
@@ -36,13 +36,18 @@ Pick the toolset whose file-extension matches the file you wrote.
 Run each tool in the listed order; stop fixing only when both pass
 with zero findings. The tools below are all on the shell allowlist.
 
-| Language   | Files                 | Commands                                    |
-|------------|-----------------------|---------------------------------------------|
-| Python     | `*.py`                | `ruff check <file>` + `mypy <file>`         |
-| JavaScript | `*.js` / `*.mjs`      | `eslint <file>`                             |
-| TypeScript | `*.ts` / `*.tsx`      | `eslint <file>` + `tsc --noEmit <file>`     |
-| Go         | `*.go`                | `go vet ./...` + `gofmt -l <file>`          |
-| Rust       | `*.rs`                | `cargo clippy -- -D warnings` + `cargo check` |
+| Language     | Files                  | Commands                                          |
+|--------------|------------------------|---------------------------------------------------|
+| Python       | `*.py`                 | `ruff check <file>` + `mypy <file>`               |
+| JavaScript   | `*.js` / `*.mjs`       | `eslint <file>`                                   |
+| TypeScript   | `*.ts` / `*.tsx`       | `eslint <file>` + `tsc --noEmit`                  |
+| Go           | `*.go`                 | `go vet ./...` + `gofmt -l <file>`                |
+| Rust         | `*.rs`                 | `cargo clippy -- -D warnings` + `cargo check`     |
+| Java         | `*.java`               | `mvn -q compile` + `mvn -q checkstyle:check` (or `gradle check`) |
+| Kotlin       | `*.kt` / `*.kts`       | `gradle compileKotlin` + `ktlint <file>`          |
+| C# / .NET    | `*.cs`                 | `dotnet build --nologo -warnaserror` + `dotnet format --verify-no-changes` |
+| Ruby         | `*.rb`                 | `rubocop <file>`                                  |
+| PHP          | `*.php`                | `php -l <file>` + `phpstan analyse <file>`        |
 
 If the language of the file is not in this table, skip the inspection
 step for that file but note the skip in your response summary. Do NOT
@@ -56,28 +61,49 @@ in your summary — do NOT retry or bikeshed.
 ## Typical command shapes
 
 Run these from the project root — `execute_shell` sets the cwd
-automatically, so do not prepend `cd`.
+automatically, so do not prepend `cd`. Pick the row matching the
+language of the file you just wrote.
 
 ```
+# Python
 execute_shell(command="ruff check src/game_engine.py")
 execute_shell(command="mypy src/game_engine.py")
+# TypeScript / JavaScript
 execute_shell(command="eslint src/client/app.ts")
-execute_shell(command="tsc --noEmit src/client/app.ts")
+execute_shell(command="npx tsc --noEmit")
+# Go
 execute_shell(command="go vet ./internal/game")
 execute_shell(command="gofmt -l internal/game/engine.go")
+# Rust
 execute_shell(command="cargo clippy -- -D warnings")
+execute_shell(command="cargo check")
+# Java
+execute_shell(command="mvn -q compile")
+# C# / .NET
+execute_shell(command="dotnet build --nologo -warnaserror")
 ```
 
 ## Reporting
 
 In the summary you return to the orchestrator, include one line per
-file showing the final inspection result:
+file showing the final inspection result. Use whichever tool names
+match the language you actually ran — the format is the same.
 
 ```
+# Python project example
 Inspection:
 - src/game_engine.py: ruff OK, mypy OK
 - src/collision.py:   ruff OK, mypy OK
 - src/scoring.py:     ruff OK, mypy skipped (not installed)
+
+# TypeScript project example
+Inspection:
+- src/game_engine.ts: eslint OK, tsc OK
+- src/collision.ts:   eslint OK, tsc OK
+
+# Go project example
+Inspection:
+- internal/game/engine.go: go vet OK, gofmt OK
 ```
 
 This lets the orchestrator see at a glance that the module is both

--- a/src/aise/agents/_runtime_skills/tdd/SKILL.md
+++ b/src/aise/agents/_runtime_skills/tdd/SKILL.md
@@ -11,52 +11,87 @@ Use this skill whenever you are asked to implement source code. Every implementa
 
 ## Core Rule: 1:1 File Mapping
 
-Every source file under `src/` MUST have a corresponding test file under `tests/`:
+Every source file MUST have a corresponding test file at the location
+the language's test runner expects. Naming and directory layout depend
+on the project's language — pick the row that matches your stack and
+follow the example. Do **not** default to Python conventions when the
+project is in another language.
 
-| Source File | Test File |
-|---|---|
-| `src/entities.py` | `tests/test_entities.py` |
-| `src/game_engine.py` | `tests/test_game_engine.py` |
-| `src/collision.py` | `tests/test_collision.py` |
-| `src/scoring.py` | `tests/test_scoring.py` |
-| `src/core/snake.py` | `tests/test_core_snake.py` |
+| Language | Source File | Test File |
+| -------- | ----------- | --------- |
+| Python (pytest) | `src/entities.py` | `tests/test_entities.py` |
+| Python (pytest, nested package) | `src/core/snake.py` | `tests/test_core_snake.py` |
+| TypeScript (vitest) | `src/entities.ts` | `tests/entities.test.ts` |
+| TypeScript (jest, co-located) | `src/entities.ts` | `src/entities.test.ts` |
+| JavaScript (vitest / jest) | `src/entities.js` | `tests/entities.test.js` |
+| Go | `internal/entities/entities.go` | `internal/entities/entities_test.go` |
+| Rust (separate test) | `src/entities.rs` | `tests/entities.rs` |
+| Rust (in-file test module) | `src/entities.rs` | `#[cfg(test)] mod tests { ... }` block in the same file |
+| Java (Maven / Gradle) | `src/main/java/com/x/Entities.java` | `src/test/java/com/x/EntitiesTest.java` |
+| Kotlin | `src/main/kotlin/com/x/Entities.kt` | `src/test/kotlin/com/x/EntitiesTest.kt` |
+| C# / .NET | `src/Entities.cs` | `tests/EntitiesTests.cs` |
 
-**NEVER put all tests into a single file.** Each test file tests exactly one source module.
+**NEVER put all tests into a single file.** Each test file tests
+exactly one source module.
 
 ## Workflow: Module-by-Module TDD
 
-For each module you need to implement, execute this cycle **one module at a time**:
+For each module you need to implement, execute this cycle **one
+module at a time**.
 
 ### Step 1 — RED: Write the test file FIRST
 
+Use the test path matching your language and runner (see the table above).
+
 ```
+# Python
 write_file("tests/test_<module>.py", <test code>)
+# TypeScript (vitest)
+write_file("tests/<module>.test.ts", <test code>)
+# Go
+write_file("internal/<pkg>/<module>_test.go", <test code>)
+# Rust
+write_file("tests/<module>.rs", <test code>)
+# Java
+write_file("src/test/java/.../<Module>Test.java", <test code>)
 ```
 
 The test file must:
-- Import from the corresponding `src/<module>.py`
+- Import from / reference the corresponding source file
 - Cover the public API: constructors, methods, properties
 - Include edge cases and error conditions
-- Be runnable with `pytest`
+- Be runnable with the project's test runner (pytest / vitest /
+  jest / `go test` / `cargo test` / `mvn test` / `dotnet test` …)
 
 ### Step 2 — GREEN: Write the source file
 
+Use the source path matching your language (see the table above).
+
 ```
+# Python
 write_file("src/<module>.py", <implementation>)
+# TypeScript
+write_file("src/<module>.ts", <implementation>)
+# Go
+write_file("internal/<pkg>/<module>.go", <implementation>)
+# Rust
+write_file("src/<module>.rs", <implementation>)
+# Java
+write_file("src/main/java/.../<Module>.java", <implementation>)
 ```
 
 The source file must:
 - Implement exactly what the tests expect
-- Be complete, runnable Python — not stubs or TODOs
+- Be complete, runnable code — not stubs or TODOs
 
 ### Step 3 — Move to the next module
 
 **Do NOT go back and rewrite previous files.** Move forward:
 
 ```
-Module 1: tests/test_entities.py → src/entities.py    ✓ done, move on
-Module 2: tests/test_collision.py → src/collision.py   ✓ done, move on
-Module 3: tests/test_scoring.py → src/scoring.py       ✓ done, move on
+Module 1: tests/<entities-test> → src/<entities-source>    ✓ done, move on
+Module 2: tests/<collision-test> → src/<collision-source>  ✓ done, move on
+Module 3: tests/<scoring-test> → src/<scoring-source>      ✓ done, move on
 ...
 ```
 
@@ -64,23 +99,34 @@ Module 3: tests/test_scoring.py → src/scoring.py       ✓ done, move on
 
 When given multiple modules to implement, follow this order:
 
-1. **Data models / entities first** (classes with no dependencies on other src modules)
+1. **Data models / entities first** (classes with no dependencies on other source modules)
 2. **Utility modules next** (collision detection, scoring, input handling)
 3. **Integration / engine last** (the module that wires everything together)
 
-For each module, always write `tests/test_<name>.py` BEFORE `src/<name>.py`.
+For each module, always write the test file BEFORE the source file.
 
 ## Anti-Patterns to Avoid
 
-- **Single test file**: NEVER write all tests into one `tests/test_game.py`. Split by module.
-- **Rewriting completed files**: Once a module pair (test + src) is written, do NOT rewrite it. Move on.
-- **Skipping tests**: NEVER write `src/` code without its `tests/` counterpart first.
-- **Runner scripts**: NEVER create `run_pytest.py`, `test_runner.py`, etc. The orchestrator runs tests.
-- **Stubs/TODOs**: Every file must be complete, working code. No `pass` or `# TODO` placeholders.
+- **Single test file**: NEVER collapse all tests into one file (e.g.
+  `tests/test_game.py`, `tests/all.test.ts`, `internal/all_test.go`).
+  Split by module.
+- **Rewriting completed files**: Once a module pair (test + source) is
+  written, do NOT rewrite it. Move on.
+- **Skipping tests**: NEVER write source code without its test
+  counterpart first.
+- **Runner scripts**: NEVER create wrapper scripts (e.g.
+  `run_pytest.py`, `run_tests.sh`, `test_runner.js`, `runtests.go`,
+  `RunAllTests.java`). The orchestrator runs the tests directly.
+- **Stubs / TODOs**: Every file must be complete, working code. No
+  `pass` / `# TODO` (Python), `// TODO` (TS / Go / Java),
+  `panic!("todo")` (Rust), `throw new Error("not implemented")`
+  (TS / Java) placeholders.
 
 ## Example Session
 
-Task: "Implement entities.py, collision.py, and game_engine.py"
+Task: "Implement entities, collision, and game_engine modules"
+(language inferred from project config — example below shows Python;
+the same shape applies to other languages with paths swapped).
 
 ```
 Step 1: write_file("tests/test_entities.py", ...)     # RED
@@ -93,3 +139,6 @@ Step 7: Respond with a summary of what was created.    # DONE
 ```
 
 Total: 6 files written (3 test + 3 source), then STOP.
+
+For TypeScript / Go / Rust / Java, the structure is identical — only
+the file paths and extensions change (see the table at the top).

--- a/src/aise/agents/architect.md
+++ b/src/aise/agents/architect.md
@@ -57,26 +57,114 @@ own — if you don't lay down the skeleton, nobody will.
 
 **REQUIRED scaffolding — always produce, regardless of stack:**
 
-- **Subsystem directories — MANDATORY.** For every subsystem / container
-  / component group identified in the architecture decomposition
-  (typically visible as the groupings in your C4Container and
-  C4Component diagrams), create a corresponding directory under `src/`
-  with the minimum barrel file the language needs (`__init__.py` for
-  Python, `index.ts` for TypeScript, `mod.rs` for Rust). Barrel files
-  should re-export the subsystem's public interface or be empty — no
-  logic. The directory name must match (lower-case, snake-case) the
-  subsystem name used in the design document so developers can trace
-  doc → directory unambiguously. See the Post-Document Workflow below
-  for the enforced procedure.
+- **`docs/stack_contract.json` — MANDATORY.** A structured JSON file
+  that records the technology choices you made in
+  `docs/architecture.md`. Downstream phases (developer, qa_engineer,
+  delivery PM) read this file to determine the language, test
+  runner, framework, and run command — no LLM is allowed to
+  re-derive these choices from prose. Schema (every field
+  required):
+
+  ```json
+  {
+    "language": "python|typescript|javascript|go|rust|java|kotlin|csharp|...",
+    "runtime": "cpython|node|deno|jvm|dotnet|native|...",
+    "framework_backend": "<pinned framework name, or empty string if N/A>",
+    "framework_frontend": "<pinned framework name, or empty string if N/A>",
+    "package_manager": "pip|npm|yarn|pnpm|cargo|go|maven|gradle|nuget|...",
+    "project_config_file": "pyproject.toml|package.json|Cargo.toml|go.mod|pom.xml|...",
+    "test_runner": "pytest|vitest|jest|go test|cargo test|mvn test|...",
+    "static_analyzer": ["<one or more analyzer commands>"],
+    "entry_point": "<source file path of the runnable entry, e.g. src/main.py>",
+    "run_command": "<single shell command that boots the app, e.g. 'python src/main.py'>",
+    "ui_required": <true|false>,
+    "ui_kind": "<empty string if !ui_required, else one of: pygame|qt|tk|arcade|textual|curses|flask|fastapi|django|express|react|vue|svelte|angular|phaser|pixi|three|babylon|electron|tauri|fyne|gioui|egui|iced|bevy|javafx|spring-boot|wpf|maui|monogame|unity|godot|cocos>",
+    "subsystems": [
+      {
+        "name": "<subsystem id, snake_case — matches the C4 Container_Boundary or top-level Container in architecture.md>",
+        "src_dir": "<src/<name>/ or other idiomatic location>",
+        "responsibilities": "<one-sentence summary of what this subsystem owns>",
+        "components": [
+          {"name": "<component id, snake_case>",
+           "file": "<file path under src_dir, e.g. src/<subsystem>/<component>.py>",
+           "responsibility": "<one-sentence summary of this component>"}
+        ]
+      }
+    ]
+  }
+  ```
+
+  - `language` MUST match the language declared in
+    `docs/architecture.md` §"技术栈选型" / "Technology Stack" — do
+    not pick a language the architecture doesn't endorse.
+  - `framework_backend` / `framework_frontend` MUST appear as a
+    pinned dependency in the `project_config_file` you also produce
+    (see below). If the project is single-tier (only backend, only
+    frontend, or a CLI), set the unused side to `""`.
+  - `ui_required` is determined by you (architect), not by QA. Scan
+    `docs/requirement.md` for visible-UI keywords (UI / GUI / 界面
+    / HUD / canvas / window / 画面 / etc.) and any explicit "user
+    can see / interact with" requirement. If you find any, set
+    `true` and pick the matching `ui_kind`; otherwise `false`.
+  - **`subsystems[]` is a TWO-LEVEL structure** — subsystems are
+    parents (one per `src/<name>/` directory), components are
+    children (one per source file inside the directory). See
+    Post-Document Workflow Step 1 for how to identify subsystems
+    vs components from the C4 diagrams. **You MUST NOT flatten
+    components into the top level.**
+  - Each `subsystems[].components[].file` MUST be prefixed by its
+    parent's `src_dir`. The runtime validates this — a flat layout
+    where components point at sibling top-level paths fails the
+    check and triggers an architect re-dispatch.
+  - Soft cap: aim for ≤ 10 subsystems for typical projects. If you
+    exceed it, you are likely flat-listing components again.
+
+  This file is read by `dispatch_task` to prepend a `STACK
+  CONTRACT` block to every worker prompt; by qa_engineer to drive
+  UI Validation; by Phase 6 to interpret QA's metrics. **If you
+  skip this file or produce a flat-list schema, the entire
+  downstream pipeline falls back to language-detection-by-LLM,
+  which is what produced project_7-tower's three-stacks-coexist
+  AND 24-flat-directories failure modes.**
+
+- **Subsystem directories — MANDATORY (one directory per *subsystem*,
+  NOT one directory per component).** A "subsystem" is the unit of
+  decomposition the architecture document draws an outline around —
+  in C4 terms it is a `Container` node OR a `Container_Boundary`
+  group, **never** an individual `Component`. Components live as
+  source files INSIDE the subsystem's directory (or as Python
+  sub-packages when a single component is itself made of several
+  files).
+
+  Concrete rule: count the `Container(...)` and
+  `Container_Boundary(...)` nodes in your C4Container view. That
+  number == the number of `src/` top-level directories you are
+  about to create. If the architecture shows 4
+  `Container_Boundary` groups (e.g. `ui_boundary`,
+  `gameplay_boundary`, `system_boundary`, `render_boundary`)
+  containing 24 `Component(...)` nodes, you create **4**
+  directories — `src/ui/`, `src/gameplay/`, `src/system/`,
+  `src/render/` — each with ~6 component files inside. You do
+  **NOT** create 24 sibling directories named after each
+  component.
+
+  Directory naming: lower-case snake_case form of the subsystem
+  name; equal to the corresponding `subsystems[].name` in
+  `docs/stack_contract.json`. Each directory carries the minimum
+  barrel file the language needs (`__init__.py` for Python,
+  `index.ts` for TypeScript, `mod.rs` for Rust, `doc.go` for Go,
+  `package-info.java` for Java). Barrel files should re-export the
+  subsystem's public interface or be empty — no logic.
 
 **Conditional scaffolding — produce when the stack demands it:**
 
 - **Project configuration file** — `pyproject.toml`, `package.json`,
-  `requirements.txt`, `tsconfig.json`, `Cargo.toml`, `go.mod`, etc. Pin
-  the language version and declare every runtime dependency your
-  tech-stack choice requires. If the design uses pygame / PyQt /
-  FastAPI / Flask / React / etc., the dependency MUST appear here —
-  developers are not permitted to add it later. Keep it to real
+  `requirements.txt`, `tsconfig.json`, `Cargo.toml`, `go.mod`,
+  `pom.xml`, `build.gradle.kts`, etc. Pin the language version and
+  declare every runtime dependency your tech-stack choice requires.
+  Whatever framework you put in
+  `stack_contract.framework_backend` / `framework_frontend` MUST
+  appear as a pinned dependency in this file. Keep it to real
   dependencies only; no dev-only tooling bloat.
 - **Module interface declaration files** — one source file per planned
   module, placed inside its subsystem directory, containing ONLY the
@@ -115,36 +203,181 @@ After `docs/architecture.md` is written and its Mermaid diagrams are
 validated, you MUST perform these steps in order. Do not report the
 task complete until every step has run.
 
-1. **Enumerate subsystems from your own design.** Re-read the
-   decomposition section of `docs/architecture.md` (typically the
-   C4Container and C4Component views plus the "Module decomposition"
-   section). Produce an explicit list — in your response text — of the
-   subsystem names you identified. This list is what the next steps
-   operate on; if it is empty, your decomposition is incomplete and you
-   must extend the document first.
-2. **Map each subsystem to a `src/<name>/` directory.** Use a stable,
-   lower-case, snake-case form of the subsystem name. Example mapping:
-   `UI Layer` → `src/ui/`, `Game Engine` → `src/engine/`, `Network
-   Client` → `src/network/`, `Persistence` → `src/persistence/`. Quote
-   the mapping explicitly in your response.
-3. **Create every directory and its barrel file** with `write_file`.
-   For Python, write an `__init__.py` in each — either empty or
-   containing a module docstring naming the subsystem and a one-line
-   responsibility summary. For TypeScript, write `index.ts`; for Rust,
-   `mod.rs`; etc. Do NOT rely on the runtime to auto-create directories
-   — the barrel file is what anchors them.
-4. **Verify the layout landed on disk.** Run the `execute` tool to
-   list `src/`:
+1. **Enumerate SUBSYSTEMS (not components) from your own design.**
+   A subsystem is the unit of decomposition the architecture
+   document draws an outline around. In C4 terms:
+
+   - ✅ Sources of subsystem identifiers: `Container(...)` nodes
+     (top-level deployable units) AND `Container_Boundary(...)`
+     groups (named groupings inside a container).
+   - ❌ NOT sources: `Component(...)` nodes. Components are
+     INSIDE subsystems and become source files, not directories.
+
+   Concrete procedure:
+   a. Open `docs/architecture.md` and look at the C4Container view.
+   b. Count the `Container(...)` and `Container_Boundary(...)`
+      nodes. That count IS the number of subsystems you have.
+      For a typical project this is 3-7; for a complex one
+      possibly up to 10. **If you find more than 10, you are
+      almost certainly mis-counting Component nodes — go back and
+      re-read.**
+   c. List the subsystem names in your response text, one per
+      line, in this exact form:
+
+      ```
+      Subsystem 1: <name> ← from Container_Boundary(<id>, "<title>")
+      Subsystem 2: <name> ← from Container_Boundary(<id>, "<title>")
+      ...
+      ```
+
+   d. Self-check: `count(subsystems) <= count(Container) +
+      count(Container_Boundary)`. If this inequality fails, you
+      promoted Components into subsystems — fix it before
+      continuing.
+
+2. **Map each subsystem to ONE `src/<name>/` directory; map each
+   component to ONE FILE inside that directory.** Two-level
+   structure, never flat. Use stable lower-case snake_case.
+
+   **Worked example (do this even if your project is simpler):**
+   The architecture has 4 `Container_Boundary` groups inside one
+   `Container(game_client, ...)`:
+
+   - `ui_boundary` containing 4 components (menu_ui, hud_ui,
+     inventory_ui, dialog_ui)
+   - `gameplay_boundary` containing 9 components (player_mgr,
+     combat_engine, item_mgr, level_mgr, npc_mgr, quest_mgr,
+     shop_mgr, trap_mgr, tutorial_mgr)
+   - `system_boundary` containing 8 components (achievement_mgr,
+     score_mgr, save_load_mgr, settings_mgr, input_mgr,
+     audio_mgr, ad_manager, purchase_mgr)
+   - `render_boundary` containing 2 components (map_renderer,
+     anim_renderer)
+
+   ✅ Correct mapping (4 directories, 23 files total):
+
    ```
-   execute(command="ls -la src/ && find src -maxdepth 2 -type f | sort")
+   src/
+   ├── ui/                ← subsystem 1
+   │   ├── __init__.py    ← barrel
+   │   ├── menu_ui.py
+   │   ├── hud_ui.py
+   │   ├── inventory_ui.py
+   │   └── dialog_ui.py
+   ├── gameplay/          ← subsystem 2
+   │   ├── __init__.py
+   │   ├── player.py
+   │   ├── combat.py
+   │   ├── item.py
+   │   ├── level.py
+   │   ├── npc.py
+   │   ├── quest.py
+   │   ├── shop.py
+   │   ├── trap.py
+   │   └── tutorial.py
+   ├── system/            ← subsystem 3
+   │   ├── __init__.py
+   │   ├── achievement.py
+   │   ├── score.py
+   │   ├── save_load.py
+   │   ├── settings.py
+   │   ├── input.py
+   │   ├── audio.py
+   │   ├── ad.py
+   │   └── purchase.py
+   └── render/            ← subsystem 4
+       ├── __init__.py
+       ├── map_renderer.py
+       └── anim_renderer.py
+   ```
+
+   ❌ **FORBIDDEN flat mapping** — do not produce this layout:
+
+   ```
+   src/
+   ├── achievement_system/__init__.py   ← single component as a top-level dir
+   ├── ad_manager/__init__.py
+   ├── audio_manager/__init__.py
+   ├── combat_system/__init__.py
+   ├── ... (and so on, 24 sibling top-level dirs)
+   ```
+
+   Multi-language paths follow the same shape — only the file
+   extensions / barrel names change:
+
+   - TypeScript: `src/<subsystem>/<component>.ts` +
+     `src/<subsystem>/index.ts` barrel
+   - Go: `internal/<subsystem>/<component>.go` +
+     `internal/<subsystem>/doc.go` barrel
+   - Rust: `src/<subsystem>/<component>.rs` +
+     `src/<subsystem>/mod.rs` barrel
+   - Java: `src/main/java/<group>/<subsystem>/<Component>.java`
+     + `src/main/java/<group>/<subsystem>/package-info.java`
+   - C# / .NET: `src/<Subsystem>/<Component>.cs` with
+     `namespace <App>.<Subsystem>;`
+
+   In your response text, quote the subsystem → directory mapping
+   AND the component → file mapping explicitly so the developer
+   phase can verify it.
+
+3. **Create every directory + barrel file + per-component source
+   stub** with `write_file`. Barrel-file conventions per language:
+
+   | Language | Barrel file | Typical content |
+   | -------- | ----------- | --------------- |
+   | Python | `__init__.py` | Empty, or a module docstring naming the subsystem |
+   | TypeScript / JavaScript | `index.ts` / `index.js` | `export *` re-exports of the subsystem's public API |
+   | Rust | `mod.rs` | `pub mod ...;` declarations for each child component |
+   | Go | `doc.go` | `// Package <subsystem> ...` doc comment |
+   | Java / Kotlin | `package-info.java` | `/** Subsystem responsibility ... */` package doc |
+   | C# / .NET | `<Subsystem>.cs` placeholder with `namespace ...` declaration | Empty namespace skeleton |
+
+   Per-component source stubs go inside the subsystem directory
+   following the `subsystems[].components[].file` paths from
+   stack_contract.json. Each stub contains only the public class /
+   protocol with method signatures + `pass` /
+   `raise NotImplementedError(...)` / `throw new Error("not
+   implemented")` bodies — no logic. Do NOT rely on the runtime to
+   auto-create directories — the barrel file is what anchors them
+   on disk.
+4. **Write `docs/stack_contract.json`** with the two-level schema
+   documented in the "REQUIRED scaffolding" section above. The
+   `subsystems[]` array MUST mirror the subsystem list from step 1
+   AND the directory layout from step 3 exactly: same names, same
+   `src_dir` values, every component's `file` path prefixed by its
+   parent's `src_dir`. The runtime validates these invariants — a
+   flat or malformed contract triggers an architect re-dispatch.
+5. **If the stack requires a project config file** (Python's
+   pyproject.toml, Node's package.json, Cargo.toml, go.mod, pom.xml,
+   etc.), write it now with the framework dependencies pinned to
+   match `stack_contract.framework_backend` /
+   `framework_frontend`. Skip only if the chosen language has no
+   such file (rare).
+6. **If the stack requires a runnable entry stub**, write the
+   entry-point file at `stack_contract.entry_point` with the
+   real bootstrap call (e.g. `app.listen(...)`,
+   `pygame.display.set_mode(...)`, `actix_web::HttpServer::new(...)`)
+   — subsystem method calls inside may delegate to stubs, but the
+   boot path itself must be real code. Developers fill in the rest
+   in Phase 3.
+7. **Verify the layout landed on disk.** Run the `execute` tool:
+   ```
+   execute(command="ls -la src/ docs/ && find src -maxdepth 2 -type f | sort && cat docs/stack_contract.json")
    ```
    Confirm that every subsystem name from step 1 has a matching
-   directory and barrel file. If any is missing, go back to step 3 and
-   fix — do not claim completion with a partial layout.
-5. **Report the subsystem → directory mapping in your final response**
-   so the developer phase can trust the layout. Example:
+   directory + barrel file, that `docs/stack_contract.json` is
+   present and the printed JSON is valid, and that the project
+   config file (if applicable) is present. If any is missing, go
+   back to the relevant step and fix — do not claim completion with
+   a partial layout.
+8. **Report in your final response** the subsystem → directory
+   mapping AND the chosen stack contract summary so the developer
+   phase can trust the layout. Example:
    `Scaffolded 6 subsystems: ui/, engine/, network/, persistence/,
-   analytics/, platform/ — barrel files verified under src/.`
+   analytics/, platform/ — barrel files verified under src/.
+   stack_contract.json: language=typescript, runtime=node,
+   framework_backend=fastify, framework_frontend=phaser,
+   ui_required=true, ui_kind=phaser.`
 
 ### Document Language
 

--- a/src/aise/agents/developer.md
+++ b/src/aise/agents/developer.md
@@ -26,28 +26,56 @@ You are an expert Software Developer agent. Your workflow is **strictly TDD**
 ### Per-Task Workflow — MANDATORY TDD ORDER
 
 For each module the task describes, follow this exact sequence. Do not
-reorder or skip steps.
+reorder or skip steps. Use file-naming and test-runner conventions
+appropriate to the project's language — read the language from the
+task description / architecture doc / project config file before
+choosing names. Do **not** default to Python conventions when the
+project is in another language.
 
-1. **RED — write the unit test file first** under `tests/test_<module>.py`.
-   Cover the public API the task specifies (constructors, methods, edge
-   cases). The test file must be complete, runnable pytest code.
-2. **GREEN — write the source file** under `src/<module>.py` that makes
-   the tests pass. Real code, no stubs or TODOs.
-3. **VERIFY — run ONLY the test file you just wrote** with the `execute` tool:
+1. **RED — write the unit test file first** alongside or under
+   `tests/`, using the test-file naming convention for your language
+   (e.g. `tests/test_<module>.py` for Python+pytest,
+   `tests/<module>.test.ts` for TypeScript+vitest/jest,
+   `internal/<pkg>/<module>_test.go` for Go,
+   `tests/<module>.rs` or `#[cfg(test)]` block in `src/<module>.rs`
+   for Rust, `src/test/java/.../<Module>Test.java` for Java).
+   Cover the public API the task specifies (constructors, methods,
+   edge cases). The test file must be complete, runnable code for
+   the chosen test runner.
+2. **GREEN — write the source file** at the canonical path for the
+   language (`src/<module>.py`, `src/<module>.ts`,
+   `internal/<pkg>/<module>.go`, `src/<module>.rs`,
+   `src/main/java/.../<Module>.java`) that makes the tests pass.
+   Real code, no stubs or TODOs.
+3. **VERIFY — run ONLY the test file you just wrote** with the
+   `execute` tool. The exact command depends on the project's test
+   runner (read it from the project config or task description).
+   Common per-file invocations:
    ```
+   # Python (pytest)
    execute(command="python -m pytest tests/test_<module>.py -q --tb=short")
+   # TypeScript (vitest)
+   execute(command="npx vitest run tests/<module>.test.ts")
+   # TypeScript (jest)
+   execute(command="npx jest tests/<module>.test.ts")
+   # Go
+   execute(command="go test ./internal/<pkg>/...")
+   # Rust
+   execute(command="cargo test --test <module>")
+   # Java (Maven)
+   execute(command="mvn test -Dtest=<Module>Test")
    ```
-   Substitute the actual module path for `<module>`. This step is
-   **REQUIRED**, not optional. Report whether tests pass.
+   This step is **REQUIRED**, not optional. Report whether tests pass.
 
-   **CRITICAL — do NOT run the full suite** (`pytest tests/`). Multiple
-   developers run in parallel in Phase 3; if two developers both run
-   the full suite at once they race on shared files and one can clobber
-   the other's output. Only the QA engineer runs the full suite, and
-   only after all developer dispatches return.
+   **CRITICAL — do NOT run the full suite** (`pytest tests/`,
+   `npx vitest`, `go test ./...`, `cargo test`, `mvn test`, etc.).
+   Multiple developers run in parallel in Phase 3; if two developers
+   both run the full suite at once they race on shared files and one
+   can clobber the other's output. Only the QA engineer runs the
+   full suite, and only after all developer dispatches return.
 4. If your module's tests fail, read the failure, fix the source (or
    the test, if the test was wrong), and re-run the same per-module
-   pytest command. At most **3 fix attempts** — then respond with a
+   test command. At most **3 fix attempts** — then respond with a
    summary and STOP.
 5. **INSPECT — run the static analyzer for the source file's language**
    (see the ``code_inspection`` skill for the language → toolset map).
@@ -56,15 +84,18 @@ reorder or skip steps.
    skip it and do not silence findings.
 6. When your module's tests pass AND its static inspection is clean
    (or the 3 test-fix attempts are exhausted), respond with a brief
-   text summary of what you created + the pytest result + the
+   text summary of what you created + the test result + the
    inspection result, and STOP.
 
 ### Scope
 
 - Implement ONLY the modules the task asks for. No unrelated files.
-- 1:1 mapping: every `src/<module>.py` has one `tests/test_<module>.py`.
-- When all required files exist and pytest has been run, STOP. Do NOT keep
-  writing or re-reading the same files to "double-check".
+- 1:1 mapping: every source file has one corresponding test file
+  under `tests/` (or the language's idiomatic test location). Naming
+  conventions are language-specific — see step 1 above.
+- When all required files exist and the per-file test command has
+  been run, STOP. Do NOT keep writing or re-reading the same files
+  to "double-check".
 
 ### Entry Point Files (language-agnostic)
 
@@ -74,15 +105,17 @@ application — TDD's "implement only what tests drive" rule is NOT
 enough. Unit tests cover importable APIs; an entry point is a
 **runnable script contract**. Both must be satisfied.
 
-Conventions by language (use whatever matches your project):
+Conventions by language (rows ordered alphabetically — pick the row
+that matches the project's stack, do **not** default to Python):
 
 | Language | Typical entry file | Launch command | Runnable hook |
 | -------- | ------------------ | -------------- | ------------- |
-| Python | `src/main.py` or `main.py` | `python src/main.py` | `if __name__ == "__main__":` block |
-| Node.js / TS | `src/index.js` | `node src/index.js` | Top-level call to bootstrap fn |
 | Go | `cmd/<app>/main.go` | `go run ./cmd/<app>` | `package main` + `func main()` |
-| Rust | `src/main.rs` | `cargo run` | `fn main()` |
 | Java | `src/main/java/.../App.java` | `java -jar app.jar` | `public static void main(String[])` |
+| Node.js / TypeScript | `src/index.js` or `src/index.ts` | `node src/index.js` / `npx tsx src/index.ts` | Top-level call to bootstrap fn |
+| Python | `src/main.py` or `main.py` | `python src/main.py` | `if __name__ == "__main__":` block |
+| Rust | `src/main.rs` | `cargo run` | `fn main()` |
+| C# / .NET | `src/Program.cs` | `dotnet run --project src/` | `Program.Main(string[] args)` |
 
 When your task involves an entry-point file, the source file MUST
 contain whatever your language needs to be launchable as a script. It
@@ -97,14 +130,17 @@ End your response with a line in this EXACT format, on its own line:
 RUN: <command to launch the app from project root>
 ```
 
-Examples:
+Examples (alphabetical — pick the row matching your project's stack):
 
 ```
-RUN: python src/main.py
-RUN: node src/index.js
-RUN: go run ./cmd/server
 RUN: cargo run --release
+RUN: dotnet run --project src/
+RUN: go run ./cmd/server
 RUN: java -jar target/app.jar
+RUN: node src/index.js
+RUN: npm run dev
+RUN: npx tsx src/index.ts
+RUN: python src/main.py
 ```
 
 The orchestrator will execute this command with a short timeout to
@@ -119,23 +155,44 @@ RUN: line — it's only for entry files.
 
 ### Running Commands
 
-Use the `execute` tool for shell commands. pytest is the ONLY command you
-routinely need, and **only on the specific test file you just wrote**:
+Use the `execute` tool for shell commands. The project's per-file
+test command is the ONLY command you routinely need, and **only on
+the specific test file you just wrote**. Pick the row matching your
+project's test runner:
+
 ```
+# Python (pytest)
 execute(command="python -m pytest tests/test_<module>.py -q --tb=short")
+# TypeScript (vitest)
+execute(command="npx vitest run tests/<module>.test.ts")
+# TypeScript (jest)
+execute(command="npx jest tests/<module>.test.ts")
+# Go
+execute(command="go test ./internal/<pkg>/...")
+# Rust
+execute(command="cargo test --test <module>")
+# Java (Maven)
+execute(command="mvn test -Dtest=<Module>Test")
 ```
-Never run `pytest tests/` (the full suite) — that is the QA engineer's
-responsibility in Phase 5.
+
+Never run the full test suite (`pytest tests/`, `npx vitest`,
+`go test ./...`, `cargo test`, `mvn test`, etc.) — that is the QA
+engineer's responsibility in Phase 5.
 
 ### Strict Prohibitions
 
 - Do NOT use the `task` tool (subagent). Write files directly yourself.
-- Do NOT create runner scripts (`run_tests.py`, `run_pytest.py`, etc.). Use `execute` directly.
+- Do NOT create runner scripts (e.g. `run_tests.py`, `run_pytest.py`,
+  `run_tests.sh`, `test_runner.js`, `runtests.go`, `RunAllTests.java`).
+  Use `execute` directly.
 - Do NOT rewrite files that already exist with identical content. If the
   tool returns ``LOOP_DETECTED``, stop immediately.
 - Do NOT create variant filenames (_new, _fixed, _final, _v2). Each file should be written ONCE.
-- Do NOT write integration tests (``tests/test_integration.py``). That is
-  the QA engineer's job, not yours.
+- Do NOT write integration tests — that is the QA engineer's job in
+  Phase 5. The integration test file path follows the project's test
+  runner convention (e.g. `tests/test_integration.py` for pytest,
+  `tests/integration.test.ts` for vitest, `internal/integration_test.go`
+  for Go, `tests/integration.rs` for Rust).
 
 ## Skills
 

--- a/src/aise/agents/product_manager.md
+++ b/src/aise/agents/product_manager.md
@@ -184,12 +184,26 @@ responding to the orchestrator.
 
 When the orchestrator dispatches a task asking you to write
 `docs/delivery_report.md`, the task description will include RAW TOOL
-OUTPUTS (``find``, ``wc -l``, ``pytest``, optionally ``pytest-cov``).
+OUTPUTS (file count, lines of code, test runner output, optional
+coverage). The tool names depend on the project's language — typical
+combinations:
+
+| Language | File-count + LOC | Test runner | Coverage |
+| -------- | ---------------- | ----------- | -------- |
+| Python | `find src -name "*.py"`, `wc -l` | `pytest` | `pytest --cov` |
+| TypeScript / JavaScript | `find src -name "*.ts"`, `wc -l` | `vitest` / `jest` | `vitest --coverage` / `jest --coverage` |
+| Go | `find . -name "*.go" -not -path "./vendor/*"`, `wc -l` | `go test ./...` | `go test -cover ./...` |
+| Rust | `find src -name "*.rs"`, `wc -l` | `cargo test` | `cargo tarpaulin` / `cargo llvm-cov` |
+| Java | `find src -name "*.java"`, `wc -l` | `mvn test` / `gradle test` | `jacoco` |
+| C# / .NET | `find . -name "*.cs"`, `wc -l` | `dotnet test` | `coverlet` |
+
 **Use those numbers verbatim.** Do not invent figures or round
 aggressively — cite what the tools reported. If a metric was not
-provided (e.g. coverage not measured because pytest-cov isn't
+provided (e.g. coverage not measured because the coverage tool isn't
 installed), explicitly say so in the report rather than fabricating a
-value.
+value. Do NOT default to assuming Python — read the project's
+language from the architecture doc / project config file before
+interpreting the raw outputs.
 
 ## Skills
 

--- a/src/aise/agents/qa_engineer.md
+++ b/src/aise/agents/qa_engineer.md
@@ -23,129 +23,280 @@ You are an expert QA Engineer agent specializing in SYSTEM INTEGRATION TESTING.
 
 ### Your Role
 
-You run AFTER the developer has written per-module source files and their
-unit tests (and already run pytest to verify those unit tests pass).
+You run AFTER the developer has written per-module source files and
+their unit tests (and already run the project's per-file test command
+to verify those unit tests pass).
 
-- Developer wrote `src/<module>.py` + `tests/test_<module>.py` for every module.
+- Developer wrote one source file + one test file per module, using
+  the language's idiomatic naming (e.g. `src/<module>.py` +
+  `tests/test_<module>.py` for Python, `src/<module>.ts` +
+  `tests/<module>.test.ts` for TypeScript, `internal/<pkg>/<module>.go`
+  + `internal/<pkg>/<module>_test.go` for Go, etc.).
 - Your job: write **integration tests only** — cross-module interactions,
   end-to-end flows, system boundaries — and then **run the full test
   suite** to verify everything still passes.
 - You do NOT write additional unit tests for individual modules. That is
   the developer's responsibility and was done in the previous phase.
 
+Determine the project's language and test runner BEFORE writing any
+test file: read the architecture doc and the project config file
+(`pyproject.toml` / `package.json` / `Cargo.toml` / `go.mod` /
+`pom.xml` / `build.gradle.kts` / `requirements.txt`), or read
+`docs/stack_contract.json` if present. Do **not** default to Python.
+
 ### QA Workflow — MANDATORY ORDER
 
 1. Read 2–3 key source files in `src/` (enough to identify the main
    integration seams — typically the entry point plus 1–2 core modules).
    Do NOT read every file.
-2. List `tests/` to see what unit tests already exist. Do NOT re-read
-   them; you only need to know their names to avoid duplication.
+2. List `tests/` (or the language's idiomatic test directory) to see
+   what unit tests already exist. Do NOT re-read them; you only need
+   to know their names to avoid duplication.
 3. **Scan `docs/requirement.md` for UI requirements.** Look for Chinese
    or English terms such as "UI", "GUI", "界面", "图形界面", "画面",
    "窗口", "window", "screen", "canvas", "render", "HUD", "HTML page",
    "web interface", "可视化", plus any explicit requirement that a
    human can *see* and *interact with* the application. Record whether
    the project is **UI-required** or **headless-only** — the answer
-   drives step 5.
-4. Write ONE integration test file: `tests/test_integration.py` covering
-   cross-module scenarios. Optionally add `docs/integration_test_plan.md`
-   for a short plan.
-5. **Run the full test suite** with the `execute` tool:
+   drives step 7.
+4. Write ONE integration test file at the path your test runner
+   conventionally uses for integration tests (e.g.
+   `tests/test_integration.py` for pytest,
+   `tests/integration.test.ts` for vitest/jest,
+   `internal/integration_test.go` for Go,
+   `tests/integration.rs` for Rust,
+   `src/test/java/.../IntegrationTest.java` for Java).
+   Optionally add `docs/integration_test_plan.md` for a short plan.
+5. **Run the full test suite** with the `execute` tool. The exact
+   command depends on the project's test runner:
    ```
+   # Python (pytest)
    execute(command="python -m pytest tests/ -q --tb=short")
+   # TypeScript (vitest)
+   execute(command="npx vitest run")
+   # TypeScript (jest)
+   execute(command="npx jest")
+   # Go
+   execute(command="go test ./...")
+   # Rust
+   execute(command="cargo test")
+   # Java (Maven)
+   execute(command="mvn test")
    ```
    This is **REQUIRED** — do not skip it.
-6. If the integration tests fail, fix `tests/test_integration.py` (or
-   flag a real product bug in your summary) and re-run pytest. At most
-   **3 fix attempts**.
+6. If the integration tests fail, fix the integration test file (or
+   flag a real product bug in your summary) and re-run the full
+   suite. At most **3 fix attempts**.
 7. **UI validation — REQUIRED only when step 3 marked the project
    UI-required.** Skip this step entirely for headless-only projects.
    See the "UI Validation Step" section below for the exact procedure.
-8. Respond with a brief summary: which integration scenarios you cover,
-   the final pytest result (pass/fail counts), AND — if UI-required —
-   the UI-validation verdict (PASS / FAIL with reason). STOP.
+8. **Write `docs/qa_report.json` (REQUIRED).** Phase 6 reads this
+   file verbatim to build the delivery report; if it's missing or
+   malformed Phase 6 will dispatch you again. See the
+   "Required Output Artifact" section below for the exact schema.
+9. Respond with a brief summary: which integration scenarios you
+   cover, the final test result (pass/fail counts), AND — if
+   UI-required — the UI-validation verdict (PASS / FAIL with reason).
+   End the response with one line:
+   `QA REPORT: docs/qa_report.json (verdict=<UI verdict or N/A>)`.
+   STOP.
 
 ### UI Validation Step
 
 Trigger: step 3 marked the project as UI-required.
 
 Goal: confirm the application actually instantiates a user-facing
-interface at runtime, not just a set of Python classes whose unit tests
-pass. Passing pytest does NOT prove a UI exists — previous projects have
-shipped "UI modules" that only return dicts and never open a window.
+interface at runtime, not just a set of source modules whose unit
+tests pass. A green test suite does **NOT** prove a UI exists —
+previous projects have shipped "UI modules" that only return data
+structures and never open a window.
 
 Perform all three checks in order. If any check fails, record the
 failure in your summary as **UI VALIDATION FAILED: <reason>** and STOP —
 do not attempt to silently fix or skip.
 
 **Check 7.1 — Framework dependency is pinned.**
-Read the project config file (`pyproject.toml`, `package.json`,
-`requirements.txt`, etc.) and confirm a real UI framework is listed in
-the runtime dependencies. Acceptable frameworks include, but are not
-limited to:
-- Desktop/game: `pygame`, `pyglet`, `arcade`, `tkinter` (stdlib —
-  accept if imported and used), `PyQt5`/`PyQt6`/`PySide6`, `kivy`,
-  `wxPython`, `textual` (TUI), `curses` (stdlib — accept if imported
-  and used)
-- Web server-rendered: `flask`, `fastapi` + a template engine, `django`,
-  `starlette` + templates, `express` + a view engine
-- Web SPA: `react`, `vue`, `svelte`, `solid-js`, `angular`
-- Cross-platform: `electron`, `tauri`, `flet`
+Read the project config file appropriate to the project's language
+(`pyproject.toml`, `requirements.txt`, `package.json`, `Cargo.toml`,
+`go.mod`, `pom.xml`, `build.gradle.kts`, `Gemfile`, etc.) and confirm
+a real UI framework is listed in the runtime dependencies.
+Acceptable frameworks include, but are not limited to:
 
-If the dependency list is empty (`dependencies = []`) or contains no UI
-framework, this check **FAILS**. Do not accept "we rolled our own UI in
-pure Python dicts" — that is the exact failure mode this step exists
+| UI kind | Examples |
+| ------- | -------- |
+| Python desktop / game | `pygame`, `pyglet`, `arcade`, `tkinter` (stdlib — accept if imported and used), `PyQt5`/`PyQt6`/`PySide6`, `kivy`, `wxPython`, `textual` (TUI), `curses` (stdlib — accept if imported and used) |
+| Python web (server-rendered) | `flask`, `fastapi` + a template engine, `django`, `starlette` + templates |
+| Node.js / TypeScript desktop / game | `phaser`, `babylonjs`, `three`, `pixi.js`, `electron`, `tauri` |
+| Node.js / TypeScript web | `react`, `vue`, `svelte`, `solid-js`, `angular`, `next`, `nuxt`, `express` + a view engine |
+| Go | `fyne`, `gioui`, `wails`, `webview`, `gin` / `echo` + templates |
+| Rust | `egui`, `iced`, `bevy`, `tauri`, `dioxus`, `yew`, `actix-web` + templates |
+| Java / Kotlin | `javafx`, `swing`, `libgdx`, `spring-boot` + thymeleaf |
+| C# / .NET | `WPF`, `WinForms`, `MAUI`, `Avalonia`, `MonoGame`, `ASP.NET MVC` |
+| Game engines | Unity (Unity project files), Godot (`*.godot`), Cocos2d / Cocos Creator |
+
+If the dependency list is empty or contains no UI framework, this
+check **FAILS**. Do not accept "we rolled our own UI in plain
+data structures" — that is the exact failure mode this step exists
 to catch.
 
 **Check 7.2 — Entry point actually initialises the UI.**
-Grep the entry file (`src/main.py` or equivalent) and the top-level
-bootstrap modules for concrete initialisation calls of the framework
-from check 7.1. Examples of what counts:
-- `pygame.init()` + `pygame.display.set_mode(...)` for pygame
-- `tk.Tk()` / `QApplication(...)` / `App().run()` / `arcade.run()`
-- `app.run(...)` for a Flask/FastAPI server on a bound host/port
-- `curses.wrapper(...)` for curses
-- `Application(...).run()` for textual
+Grep the entry file (`src/main.py`, `src/index.ts`,
+`cmd/<app>/main.go`, `src/main.rs`, `src/main/java/.../App.java`,
+or whatever your project's entry is) and the top-level bootstrap
+modules for concrete initialisation calls of the framework from
+check 7.1. Examples of what counts (pick the row matching your
+stack):
 
-A simulated loop that only prints status lines (`print("[STATUS]
-tick=...")` + `time.sleep(...)`) **DOES NOT** count. If you cannot
-locate a real initialisation call, this check **FAILS**.
+| Framework family | Initialisation call you must find |
+| ---------------- | --------------------------------- |
+| pygame / SDL | `pygame.init()` + `pygame.display.set_mode(...)` |
+| Qt (PyQt / PySide / QtWidgets) | `QApplication(...).exec()` |
+| Tk | `tk.Tk()` / `tkinter.Tk()` |
+| arcade | `arcade.run()` |
+| textual | `App().run()` / `Application(...).run()` |
+| curses | `curses.wrapper(...)` |
+| Flask / FastAPI / Django / express | `app.run(...)` / `uvicorn.run(...)` / `django.core.management.execute_from_command_line` / `app.listen(...)` |
+| React / Vue / Svelte / Angular | `ReactDOM.createRoot(...).render(...)` / `createApp(...).mount(...)` / `new App({ target: ... })` / `platformBrowserDynamic().bootstrapModule(...)` |
+| Phaser / pixi.js / three / babylonjs | `new Phaser.Game({...})` / `new PIXI.Application({...})` / `new THREE.WebGLRenderer({...})` / `new BABYLON.Engine(...)` |
+| Electron / Tauri | `app.whenReady().then(createWindow)` / `tauri::Builder::default().run(...)` |
+| Go (Fyne / Gio / Gin) | `app.New().NewWindow(...).ShowAndRun()` / `app.NewWindow(...).Run()` / `r.Run(":8080")` |
+| Rust (egui / iced / bevy / actix) | `eframe::run_native(...)` / `iced::Application::run(...)` / `App::new().add_plugins(...).run()` / `HttpServer::new(...).bind(...)?.run().await` |
+| Java (JavaFX / Spring) | `Application.launch(App.class, args)` / `SpringApplication.run(App.class, args)` |
+| .NET (WPF / ASP.NET) | `new App().Run(new MainWindow())` / `WebApplication.CreateBuilder(args).Build().Run()` |
+| Unity / Godot | A `Scene` / `MonoBehaviour.Start()` is acceptable; a script with no scene reference is not |
+
+A simulated loop that only prints status lines (e.g. `print("[STATUS]
+tick=...")` + `time.sleep(...)` in Python, `console.log(...)` +
+`setInterval(...)` in JS, `fmt.Println(...)` + `time.Sleep(...)` in
+Go) **DOES NOT** count. If you cannot locate a real initialisation
+call, this check **FAILS**.
 
 **Check 7.3 — Entry point boots without UI-layer errors.**
-Launch the entry point with a short timeout using the `execute` tool.
-Use the command the developer declared via `RUN:` (found in the
-delivery artefacts or recovered by reading the entry file). Example:
-```
-execute(command="timeout 5 python src/main.py 2>&1 || true")
-```
-For GUI frameworks that require a display, set
-`SDL_VIDEODRIVER=dummy` (pygame), `QT_QPA_PLATFORM=offscreen` (Qt), or
-the framework-appropriate headless flag before launching, so the check
-runs in the sandbox:
-```
-execute(command="SDL_VIDEODRIVER=dummy timeout 5 python src/main.py 2>&1 || true")
-```
+Launch the entry point with a short timeout using the `execute`
+tool. Use the command the developer declared via `RUN:` (found in
+the delivery artefacts or recovered by reading the entry file).
+Example launches by stack (pick the row matching your project):
+
+| Stack / UI kind | Headless flag (if any) | Example launch (5s timeout) |
+| --------------- | ---------------------- | --------------------------- |
+| pygame / SDL | `SDL_VIDEODRIVER=dummy` | `SDL_VIDEODRIVER=dummy timeout 5 python src/main.py 2>&1 \|\| true` |
+| Qt (PyQt / PySide) | `QT_QPA_PLATFORM=offscreen` | `QT_QPA_PLATFORM=offscreen timeout 5 python src/main.py 2>&1 \|\| true` |
+| arcade / pyglet | `SDL_VIDEODRIVER=dummy` (often) | `timeout 5 python src/main.py 2>&1 \|\| true` |
+| Flask / FastAPI / Django | (none — a bound port is success) | `timeout 5 python src/main.py 2>&1 \|\| true` |
+| Node web (Express / Next / Nuxt) | (none) | `timeout 5 npm run dev 2>&1 \|\| true` |
+| Node game (Phaser via Vite/Webpack) | (none — boot dev server, then curl) | `(npm run dev &) ; sleep 3 ; curl -I http://localhost:5173 ; kill %1 2>/dev/null` |
+| Electron | `xvfb-run` | `xvfb-run -a timeout 5 npm run start 2>&1 \|\| true` |
+| Go (Fyne / Gio) | `xvfb-run` for desktop | `xvfb-run -a timeout 5 go run ./cmd/<app> 2>&1 \|\| true` |
+| Go (Gin / Echo) | (none — bound port is success) | `timeout 5 go run ./cmd/<app> 2>&1 \|\| true` |
+| Rust (egui / iced) | `xvfb-run` | `xvfb-run -a timeout 5 cargo run 2>&1 \|\| true` |
+| Rust (actix-web) | (none) | `timeout 5 cargo run 2>&1 \|\| true` |
+| Java / Spring Boot | (none — bound port is success) | `timeout 5 java -jar target/app.jar 2>&1 \|\| true` |
+| Unity headless build | `-batchmode -nographics` | `timeout 10 ./Build/MyGame.x86_64 -batchmode -nographics 2>&1 \|\| true` |
+| Godot | `--headless` | `timeout 5 godot --headless --quit 2>&1 \|\| true` |
+
+If your stack is not in this table, fall back to: launch the
+developer's `RUN:` command with a 5s timeout; treat "process still
+alive when killed" as PASS, "exit ≠ 0 with import / setup error in
+first 200 lines of stderr" as FAIL.
+
 Expected outcome: the process either runs until the timeout kills it
 (proves it entered its event/main loop — this is SUCCESS, same
 convention as the developer's RUN: check) OR prints lines proving UI
 setup happened (e.g. "pygame ... Hello from the pygame community",
-"Uvicorn running on http://...", a Qt warning about offscreen mode).
-Import errors, `ModuleNotFoundError`, `NoneType has no attribute`
+"Uvicorn running on http://...", "Local: http://localhost:5173/",
+a Qt warning about offscreen mode). Import errors,
+`ModuleNotFoundError`, `Cannot find module`, `NullPointerException`
 around UI objects, or immediate clean exits with no UI-layer output
 count as **FAILURE**.
 
 Report the verdict explicitly in your final summary — e.g.
 `UI VALIDATION: PASS (pygame.display.set_mode reached, process
-survived 5s timeout)` or `UI VALIDATION: FAILED — pyproject.toml
-dependencies=[], no GUI framework present`.
+survived 5s timeout)` or `UI VALIDATION: FAILED — package.json
+dependencies has no UI framework`.
+
+### Required Output Artifact: `docs/qa_report.json`
+
+In addition to the integration test file and (optional) test plan
+markdown, you MUST write a single JSON file at
+`docs/qa_report.json` summarising your findings. Phase 6 reads this
+file verbatim to build the delivery report. The runtime validates
+its presence + JSON syntax + required fields after your dispatch
+returns; if missing or invalid the runtime will re-dispatch you
+once with the failure detail.
+
+The schema (all top-level fields are required):
+
+```json
+{
+  "phase": "qa",
+  "completed_at": "<ISO-8601 UTC timestamp>",
+  "pytest": {
+    "command": "<the exact full-suite command you ran>",
+    "passed": <int>,
+    "failed": <int>,
+    "skipped": <int>,
+    "failed_tests": ["<test_id>", ...]
+  },
+  "ui_validation": {
+    "required": <true|false>,
+    "verdict": "PASS" | "FAILED" | "SKIPPED_HEADLESS_ONLY",
+    "reason": "<one-sentence explanation>"
+  },
+  "product_bugs": [
+    {
+      "module": "<module name>",
+      "function": "<function/method name, optional>",
+      "summary": "<one-sentence description of the real bug you found>"
+    }
+  ],
+  "integration_tests": {
+    "file": "<the integration test file path you wrote>",
+    "scenario_count": <int>
+  }
+}
+```
+
+Field rules:
+
+- The `pytest` object name is historical — fill it for whichever
+  test runner you actually used (pytest / vitest / jest / `go test`
+  / `cargo test` / `mvn test`). `command` records the exact
+  invocation; `passed + failed + skipped` MUST equal the test
+  collector total.
+- `ui_validation.required` MUST equal whether step 3 of the
+  workflow marked the project UI-required. If `required` is
+  `false`, set `verdict` to `"SKIPPED_HEADLESS_ONLY"` and `reason`
+  to a short explanation (e.g. "no UI keywords in
+  docs/requirement.md"). If `required` is `true`, `verdict` must
+  be `"PASS"` or `"FAILED"` based on the UI Validation Step
+  results, and `reason` must explain why.
+- `product_bugs` is the list of REAL product bugs you encountered
+  while writing integration tests (e.g. a function silently
+  ignores an event, a method returns the wrong type). Include
+  every bug you flagged in your response — Phase 6 will list them
+  in the delivery report's Known Issues section. Empty list `[]`
+  is valid only if you genuinely found nothing.
+- `failed_tests` lists the test IDs that failed in your final
+  full-suite run (e.g.
+  `"tests/test_iap.py::TestWebhook::test_webhook_subscription_end_date_is_30_days"`).
+  Empty list `[]` if all tests passed.
+
+Do NOT omit any field. Do NOT use `null` for required fields. Do
+NOT silently downgrade a real bug into a comment in your response —
+it must appear in `product_bugs[]`.
 
 ### Output Rules
 
-- All paths must be RELATIVE (e.g. `tests/test_integration.py`). The runtime rejects absolute paths.
-- Integration test code → `tests/test_integration.py` (or `tests/integration/*.py` for multiple files).
+- All paths must be RELATIVE. The runtime rejects absolute paths.
+- Integration test file: pick the path matching the project's test
+  runner (e.g. `tests/test_integration.py` for pytest,
+  `tests/integration.test.ts` for vitest/jest,
+  `internal/integration_test.go` for Go,
+  `tests/integration.rs` for Rust).
 - Optional test plan document → `docs/integration_test_plan.md`.
-- Each test file must be complete, runnable pytest code — NOT a plan or description.
-- Do NOT duplicate the developer's unit tests (no `tests/test_<module>.py`).
+- Each test file must be complete, runnable code for the chosen
+  test runner — NOT a plan or description.
+- Do NOT duplicate the developer's unit tests.
 - Do NOT respond with "I'll create tests..." — actually write the test files.
 
 ### Document Language
@@ -191,17 +342,20 @@ rule above and apply it consistently.
 
 ### Strict Prohibitions
 
-- Do NOT create runner scripts like `run_pytest.py`, `run_tests.sh`, `pytest_runner.py`, etc.
-  Use the `execute` tool directly.
-- Do NOT write per-module unit tests — only `tests/test_integration.py`.
-- Do NOT re-read files you just wrote to "verify" them; pytest is your
-  verification mechanism.
+- Do NOT create runner scripts (e.g. `run_pytest.py`, `run_tests.sh`,
+  `pytest_runner.py`, `test_runner.js`, `runtests.go`,
+  `RunAllTests.java`). Use the `execute` tool directly.
+- Do NOT write per-module unit tests — only the project's single
+  integration test file (path depends on the test runner; see
+  workflow step 4).
+- Do NOT re-read files you just wrote to "verify" them; running the
+  full test suite is your verification mechanism.
 - Do NOT use the `task` tool (subagent). Read/write files directly.
 
 ## Skills
 
 - test_plan_design: Define testing scope, strategy, and risks
 - test_case_design: Design integration, E2E, and regression test cases
-- test_automation: Generate pytest scripts from test cases
+- test_automation: Generate test scripts (in the project's test runner) from test cases
 - test_review: Validate coverage and quality
 - pr_review: Review pull requests

--- a/src/aise/runtime/agent_runtime.py
+++ b/src/aise/runtime/agent_runtime.py
@@ -269,7 +269,7 @@ class AgentRuntime:
         trace_dir: str | Path | None = None,
         url: str = "",
         checkpointer: Any = None,
-        max_iterations: int = 240,
+        max_iterations: int = 480,
     ) -> None:
         if create_deep_agent is None:
             raise RuntimeError(
@@ -429,6 +429,7 @@ class AgentRuntime:
         *,
         thread_id: str | None = None,
         on_todos_update: Any = None,
+        on_token_usage: Any = None,
     ) -> str:
         """Process an incoming text message and return the agent's response.
 
@@ -447,6 +448,11 @@ class AgentRuntime:
             on_todos_update: Optional callback ``(list[dict]) -> None`` fired
                 whenever the agent invokes deepagents' ``write_todos`` tool.
                 Used by the web UI to surface live progress.
+            on_token_usage: Optional callback ``(dict) -> None`` fired after
+                every LLM round-trip with normalized token counts
+                (``input_tokens`` / ``output_tokens`` / ``total_tokens``).
+                Used to bubble per-dispatch token consumption up to the
+                orchestrator session and the WorkflowRun.
 
         Returns:
             The agent's text response.
@@ -505,11 +511,13 @@ class AgentRuntime:
                 trace_path=trace_path,
                 lock=trace_lock,
                 on_todos_update=on_todos_update,
+                on_token_usage=on_token_usage,
             )
             config.setdefault("callbacks", []).append(llm_tracer)
-        elif on_todos_update is not None:
-            # No trace_dir but still want live todos — attach a lightweight
-            # callback whose only job is to forward ``write_todos`` invocations.
+        elif on_todos_update is not None or on_token_usage is not None:
+            # No trace_dir but still want live todos / token usage —
+            # attach a lightweight callback whose only job is to forward
+            # ``write_todos`` invocations and per-call token counts.
             from .trace_callback import TraceLLMCallback
 
             llm_tracer = TraceLLMCallback(
@@ -517,6 +525,7 @@ class AgentRuntime:
                 trace_path=None,
                 lock=trace_lock,
                 on_todos_update=on_todos_update,
+                on_token_usage=on_token_usage,
             )
             config.setdefault("callbacks", []).append(llm_tracer)
 

--- a/src/aise/runtime/project_session.py
+++ b/src/aise/runtime/project_session.py
@@ -803,7 +803,7 @@ class ProjectSession:
                 "per-subsystem fan-out):\n\n"
                 "Fan-out is performed by the orchestration layer, NOT by\n"
                 "you drafting tasks_json. You make ONE tool call:\n\n"
-                "    dispatch_subsystems(phase=\"implementation\")\n\n"
+                '    dispatch_subsystems(phase="implementation")\n\n'
                 "The primitive reads docs/stack_contract.json's\n"
                 "subsystems[] and dispatches developer in parallel (up to\n"
                 "the runtime cap). Each developer dispatch carries the\n"
@@ -818,7 +818,7 @@ class ProjectSession:
                 "2. Read docs/architecture.md briefly to understand which\n"
                 "   subsystems are NEW or CHANGED (purely informational —\n"
                 "   the dispatch primitive does not need this from you).\n"
-                "3. Call dispatch_subsystems(phase=\"implementation\")\n"
+                '3. Call dispatch_subsystems(phase="implementation")\n'
                 "   exactly once. Each developer dispatch's task\n"
                 "   description carries the full component list for its\n"
                 "   subsystem. For CHANGED components the developer is\n"
@@ -1006,7 +1006,7 @@ class ProjectSession:
                 "Execute Phase 2b — Sprint Execution (AGILE, per-subsystem fan-out):\n\n"
                 "Fan-out is performed by the orchestration layer, NOT by\n"
                 "you drafting tasks_json. You make ONE tool call:\n\n"
-                "    dispatch_subsystems(phase=\"sprint_execution\")\n\n"
+                '    dispatch_subsystems(phase="sprint_execution")\n\n'
                 "The primitive reads docs/stack_contract.json's\n"
                 "subsystems[] and dispatches developer in parallel (up to\n"
                 "the runtime cap). Each developer dispatch carries the\n"
@@ -1015,7 +1015,7 @@ class ProjectSession:
                 "1. Verify docs/stack_contract.json exists and is valid.\n"
                 "   If missing or malformed, STOP and dispatch architect.\n"
                 "2. Read docs/sprint_design.md briefly (informational).\n"
-                "3. Call dispatch_subsystems(phase=\"sprint_execution\")\n"
+                '3. Call dispatch_subsystems(phase="sprint_execution")\n'
                 "   exactly once. Each developer dispatch's task\n"
                 "   description includes the subsystem's components from\n"
                 "   the contract.\n"
@@ -1196,13 +1196,13 @@ class ProjectSession:
                 "per-subsystem fan-out):\n\n"
                 "Fan-out is performed by the orchestration layer. Make ONE\n"
                 "tool call:\n\n"
-                "    dispatch_subsystems(phase=\"sprint_execution\")\n\n"
+                '    dispatch_subsystems(phase="sprint_execution")\n\n'
                 "1. Verify docs/stack_contract.json is up to date with the\n"
                 "   incremental sprint design. If architect should have\n"
                 "   amended subsystems[] / components[] but didn't, STOP\n"
                 "   and dispatch architect to bring the contract in line.\n"
                 "2. Read docs/sprint_design.md briefly (informational).\n"
-                "3. Call dispatch_subsystems(phase=\"sprint_execution\")\n"
+                '3. Call dispatch_subsystems(phase="sprint_execution")\n'
                 "   exactly once. Each developer dispatch's task\n"
                 "   description includes the subsystem's components from\n"
                 "   the contract; CHANGED components are addressed via\n"
@@ -1366,7 +1366,7 @@ class ProjectSession:
                 "Execute Phase 3 — Implementation (TDD, per-subsystem fan-out):\n\n"
                 "Fan-out is performed by the orchestration layer, NOT by you\n"
                 "drafting tasks_json. You make ONE tool call:\n\n"
-                "    dispatch_subsystems(phase=\"implementation\")\n\n"
+                '    dispatch_subsystems(phase="implementation")\n\n'
                 "The primitive reads docs/stack_contract.json's subsystems[]\n"
                 "(written by architect in Phase 2), builds one developer\n"
                 "task description per subsystem deterministically (from the\n"
@@ -1380,7 +1380,7 @@ class ProjectSession:
                 "   reading it once with read_file. If missing or malformed,\n"
                 "   STOP and dispatch architect to produce it; do NOT guess\n"
                 "   the stack.\n"
-                "2. Call dispatch_subsystems(phase=\"implementation\")\n"
+                '2. Call dispatch_subsystems(phase="implementation")\n'
                 "   exactly once. The tool returns an aggregate result with\n"
                 "   per-subsystem pass/fail and component artifact verification.\n"
                 "3. Do NOT call dispatch_task or dispatch_tasks_parallel\n"
@@ -1409,7 +1409,7 @@ class ProjectSession:
                 "be launched directly with a single terminal command. It\n"
                 "is NOT enough to expose a class with a run() method —\n"
                 "the file itself must start the app. Use whatever hook\n"
-                'your language needs (e.g. ``if __name__ == \"__main__\":``\n'
+                'your language needs (e.g. ``if __name__ == "__main__":``\n'
                 "for Python, top-level invocation for Node, ``func main()``\n"
                 "for Go, ``fn main()`` for Rust, ``public static void main``\n"
                 "for Java, ``Program.Main`` for .NET).\n"
@@ -1493,17 +1493,17 @@ class ProjectSession:
                 "1. Read docs/qa_report.json (REQUIRED). The QA engineer\n"
                 "   wrote it in Phase 5. Schema:\n"
                 "     {\n"
-                "       \"pytest\": {\"command\": str, \"passed\": int,\n"
-                "                  \"failed\": int, \"skipped\": int,\n"
-                "                  \"failed_tests\": [str, ...]},\n"
-                "       \"ui_validation\": {\"required\": bool,\n"
-                "                          \"verdict\": \"PASS|FAILED|\n"
-                "                                       SKIPPED_HEADLESS_ONLY\",\n"
-                "                          \"reason\": str},\n"
-                "       \"product_bugs\": [{\"module\": str, \"function\":\n"
-                "                          str, \"summary\": str}, ...],\n"
-                "       \"integration_tests\": {\"file\": str,\n"
-                "                              \"scenario_count\": int}\n"
+                '       "pytest": {"command": str, "passed": int,\n'
+                '                  "failed": int, "skipped": int,\n'
+                '                  "failed_tests": [str, ...]},\n'
+                '       "ui_validation": {"required": bool,\n'
+                '                          "verdict": "PASS|FAILED|\n'
+                '                                       SKIPPED_HEADLESS_ONLY",\n'
+                '                          "reason": str},\n'
+                '       "product_bugs": [{"module": str, "function":\n'
+                '                          str, "summary": str}, ...],\n'
+                '       "integration_tests": {"file": str,\n'
+                '                              "scenario_count": int}\n'
                 "     }\n"
                 "   If docs/qa_report.json is MISSING or invalid JSON, do\n"
                 "   NOT fabricate numbers and do NOT silently re-run\n"
@@ -1537,7 +1537,7 @@ class ProjectSession:
                 "   test in qa_report.pytest.failed_tests verbatim. If\n"
                 "   product_bugs is empty AND failed_tests is empty AND\n"
                 "   ui_validation.verdict is PASS or SKIPPED_HEADLESS_ONLY,\n"
-                "   write \"none\". Otherwise enumerate them. Required\n"
+                '   write "none". Otherwise enumerate them. Required\n'
                 "   sections:\n"
                 "   1. Executive Summary — one paragraph, what was built\n"
                 "      and whether it is production-ready (DERIVE from\n"

--- a/src/aise/runtime/project_session.py
+++ b/src/aise/runtime/project_session.py
@@ -145,6 +145,18 @@ class ProjectSession:
         # for the prefix format, and architect.md / product_manager.md /
         # qa_engineer.md "Document Language" sections for the rule).
         self._ctx.original_requirement = requirement
+
+        # Auto-scale the dispatch cap to the actual architecture size.
+        # The fixed default (128) covers a typical project, but a
+        # 60-component architecture would still exhaust it before
+        # reaching delivery. Read the stack contract (if architect has
+        # already produced one — incremental runs always have one;
+        # fresh runs raise the cap again after architecture phase via
+        # this same method, see ``_apply_dispatch_floor``) and lift
+        # ``max_dispatches`` to ``Σ(1 + components) + buffer`` if the
+        # static default is smaller.
+        self._apply_dispatch_floor(reason="run_start")
+
         try:
             if global_pm_rt is not None:
                 global_pm_rt._state = AgentState.WORKING
@@ -166,6 +178,7 @@ class ProjectSession:
                     "phases": [name for name, _prompt in phases],
                     "total": total_phases,
                     "start_phase_idx": self._start_phase_idx,
+                    "max_dispatches": self._config.safety_limits.max_dispatches,
                     "timestamp": _now(),
                 }
             )
@@ -281,8 +294,25 @@ class ProjectSession:
         crashing the session, we catch the error and return empty so the
         continuation loop can retry.
         """
+
+        def _on_token_usage(counts: dict[str, int]) -> None:
+            self._ctx.emit(
+                {
+                    "type": "token_usage",
+                    "agent": self._orchestrator_name,
+                    "timestamp": _now(),
+                    "input_tokens": int(counts.get("input_tokens", 0) or 0),
+                    "output_tokens": int(counts.get("output_tokens", 0) or 0),
+                    "total_tokens": int(counts.get("total_tokens", 0) or 0),
+                }
+            )
+
         try:
-            return self._pm_runtime.handle_message(prompt, thread_id=self._session_id)
+            return self._pm_runtime.handle_message(
+                prompt,
+                thread_id=self._session_id,
+                on_token_usage=_on_token_usage,
+            )
         except Exception as exc:
             logger.warning(
                 "PM handle_message failed (will retry on next continuation): session=%s error=%s",
@@ -385,7 +415,7 @@ class ProjectSession:
             backend=backend,
             trace_dir=trace_dir,
             checkpointer=MemorySaver(),
-            max_iterations=240,
+            max_iterations=480,
         )
         rt.evoke()
         logger.info(
@@ -412,16 +442,94 @@ class ProjectSession:
         }
     )
 
+    def _apply_dispatch_floor(self, *, reason: str) -> None:
+        """Auto-scale ``max_dispatches`` to the architect's contract.
+
+        Computes ``Σ(1 + len(components)) + DISPATCH_FLOOR_BUFFER``
+        across every subsystem in ``docs/stack_contract.json`` and
+        raises the live ``SafetyLimits.max_dispatches`` if the result
+        exceeds the current cap. Called once at run start (no-op when
+        the contract isn't on disk yet) and again right after the
+        architecture phase finishes (when it just got produced).
+
+        Lowers nothing — only ratchets up — so an explicit project-
+        level override that's already higher than the dynamic floor
+        is preserved.
+        """
+        if self._project_root is None:
+            return
+        contract_path = self._project_root / "docs" / "stack_contract.json"
+        if not contract_path.is_file():
+            return
+        try:
+            import json as _json
+
+            data = _json.loads(contract_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            logger.debug("dispatch floor: contract unreadable (%s): %s", reason, exc)
+            return
+        if not isinstance(data, dict):
+            return
+        subsystems = data.get("subsystems")
+        if not isinstance(subsystems, list) or not subsystems:
+            return
+
+        from .runtime_config import DISPATCH_FLOOR_BUFFER
+
+        total = 0
+        for ss in subsystems:
+            if not isinstance(ss, dict):
+                continue
+            comps = ss.get("components") or []
+            # 1 skeleton + N component dispatches per subsystem.
+            total += 1 + (len(comps) if isinstance(comps, list) else 0)
+        floor = total + DISPATCH_FLOOR_BUFFER
+        current = self._config.safety_limits.max_dispatches
+        if floor <= current:
+            return
+        self._config.safety_limits.max_dispatches = floor
+        logger.info(
+            "Dispatch cap raised: session=%s reason=%s floor=%d (was %d) subsystems=%d components=%d",
+            self._session_id,
+            reason,
+            floor,
+            current,
+            len(subsystems),
+            total - len(subsystems),
+        )
+        self._ctx.emit(
+            {
+                "type": "dispatch_cap_raised",
+                "reason": reason,
+                "from": current,
+                "to": floor,
+                "subsystems": len(subsystems),
+                "components": total - len(subsystems),
+                "timestamp": _now(),
+            }
+        )
+
     def _run_post_phase_hooks(self, phase_idx: int, phase_name: str) -> None:
         """Pure-Python hooks that run after each successful phase.
 
-        The only hook today is the language-idiomatic root config
-        generator (pyproject.toml / package.json / go.mod / Cargo.toml
-        / pom.xml). It's gated by phase so it doesn't run before the
-        developer has produced any source. Any failure here is logged
-        and swallowed — a broken post-phase hook must never mark the
-        whole run as failed.
+        Two hooks today:
+        - Re-apply the dispatch-cap dynamic floor after every phase so
+          a contract produced by the architect mid-run lifts the cap
+          before implementation starts.
+        - Generate the language-idiomatic root config (pyproject.toml /
+          package.json / go.mod / Cargo.toml / pom.xml) once the
+          developer has written enough source. Any failure here is
+          logged and swallowed — a broken post-phase hook must never
+          mark the whole run as failed.
         """
+        # Always re-apply the dispatch-cap floor — cheap, idempotent,
+        # and guards against the case where stack_contract.json
+        # appears mid-run (i.e. right after the architecture phase).
+        try:
+            self._apply_dispatch_floor(reason=f"post_phase_{phase_name}")
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("dispatch-floor reapplication failed: %s", exc)
+
         if phase_name not in self._POST_PHASE_LANG_CONFIG:
             return
         if self._project_root is None:
@@ -682,34 +790,43 @@ class ProjectSession:
                 "C4Component); behavioral views stay on standard Mermaid\n"
                 "types. Validate every ```mermaid block via the mermaid\n"
                 "skill and fix any syntax error before responding.\n"
-                "Pass expected_artifacts=['docs/architecture.md'].\n"
+                "Pass expected_artifacts=['docs/architecture.md',\n"
+                "'docs/stack_contract.json'] so the runtime retries once\n"
+                "if either is missing.\n"
                 "After it completes, STOP.\n"
                 "Do NOT call mark_complete.",
             ),
             (
                 "implementation",
                 f"New requirement to integrate: {requirement}\n\n"
-                "Execute Phase 3 — Implementation (INCREMENTAL, TDD):\n"
-                "1. Read docs/architecture.md to see which modules are NEW or\n"
-                "   CHANGED because of the incremental requirement. Existing\n"
-                "   modules the requirement does not touch must stay\n"
-                "   untouched — read them only to understand interfaces.\n"
-                "2. For EACH new-or-changed module, dispatch developer via\n"
-                "   dispatch_tasks_parallel. In each task description:\n"
-                "   - Include the relevant architecture spec.\n"
-                "   - Instruct strict TDD: write tests/test_<module>.py, then\n"
-                "     src/<module>.py, then run ONLY that module's test file\n"
-                "     (python -m pytest tests/test_<module>.py -q --tb=short).\n"
-                "     Up to 3 fix attempts.\n"
-                "   - For CHANGED modules, the task description must say\n"
-                "     explicitly that the file already exists and the\n"
-                "     developer must EDIT it in place (edit_file), not\n"
-                "     rewrite. Existing tests must keep passing — new tests\n"
-                "     extend the file, not replace it.\n"
-                "   - Set expected_artifacts=['src/<module>.py',\n"
-                "     'tests/test_<module>.py'].\n"
-                "3. Do NOT run the full suite here. That is Phase 5's job.\n"
-                "4. When all dispatches return, STOP.\n"
+                "Execute Phase 3 — Implementation (INCREMENTAL, TDD,\n"
+                "per-subsystem fan-out):\n\n"
+                "Fan-out is performed by the orchestration layer, NOT by\n"
+                "you drafting tasks_json. You make ONE tool call:\n\n"
+                "    dispatch_subsystems(phase=\"implementation\")\n\n"
+                "The primitive reads docs/stack_contract.json's\n"
+                "subsystems[] and dispatches developer in parallel (up to\n"
+                "the runtime cap). Each developer dispatch carries the\n"
+                "STACK CONTRACT and ORIGINAL USER REQUIREMENT blocks\n"
+                "automatically.\n\n"
+                "1. Verify docs/stack_contract.json exists and is valid.\n"
+                "   If the incremental requirement extended subsystems[]\n"
+                "   or added components, architect should already have\n"
+                "   updated the contract; if not, STOP and dispatch\n"
+                "   architect to bring the contract in line with\n"
+                "   docs/architecture.md.\n"
+                "2. Read docs/architecture.md briefly to understand which\n"
+                "   subsystems are NEW or CHANGED (purely informational —\n"
+                "   the dispatch primitive does not need this from you).\n"
+                "3. Call dispatch_subsystems(phase=\"implementation\")\n"
+                "   exactly once. Each developer dispatch's task\n"
+                "   description carries the full component list for its\n"
+                "   subsystem. For CHANGED components the developer is\n"
+                "   instructed (via the rendered task) to EDIT in place.\n"
+                "4. Do NOT call dispatch_task or dispatch_tasks_parallel\n"
+                "   yourself for individual subsystems / components.\n"
+                "5. Do NOT run the full suite here — that is Phase 5's job.\n"
+                "6. When dispatch_subsystems returns, STOP.\n"
                 "Do NOT call mark_complete.",
             ),
             (
@@ -746,15 +863,25 @@ class ProjectSession:
                 "- Instruct the QA agent to read docs/requirement.md\n"
                 "  (including the new Incremental Requirement section) and\n"
                 "  docs/architecture.md so it knows what to cover.\n"
-                "- Extend tests/test_integration.py (edit in place — do\n"
-                "  NOT recreate the file from scratch) with integration\n"
-                "  scenarios for the new requirement. Existing integration\n"
-                "  tests must keep running.\n"
-                "- RUN the FULL suite:\n"
-                '  execute(command="python -m pytest tests/ -q --tb=short")\n'
-                "  and iterate up to 3 times until all tests pass.\n"
+                "- Extend the integration test file already on disk (e.g.\n"
+                "  tests/test_integration.py for pytest,\n"
+                "  tests/integration.test.ts for vitest/jest,\n"
+                "  internal/integration_test.go for Go,\n"
+                "  tests/integration.rs for Rust,\n"
+                "  src/test/java/.../IntegrationTest.java for Java) IN\n"
+                "  PLACE — do NOT recreate the file from scratch — with\n"
+                "  integration scenarios for the new requirement.\n"
+                "  Existing integration tests must keep running.\n"
+                "- RUN the FULL suite using the project's test runner:\n"
+                "    Python:     python -m pytest tests/ -q --tb=short\n"
+                "    TypeScript: npx vitest run  (or npx jest)\n"
+                "    Go:         go test ./...\n"
+                "    Rust:       cargo test\n"
+                "    Java:       mvn test\n"
+                "  Iterate up to 3 times until all tests pass.\n"
                 "- Report final pass/fail counts in the response.\n"
-                "Pass expected_artifacts=['tests/test_integration.py'].\n"
+                "Pass expected_artifacts=[<the chosen integration test\n"
+                "file path>].\n"
                 "After it completes, STOP.\n"
                 "Do NOT call mark_complete.",
             ),
@@ -762,43 +889,59 @@ class ProjectSession:
                 "delivery",
                 f"New requirement to integrate: {requirement}\n\n"
                 "Execute Phase 6 — Delivery Report (INCREMENTAL scope):\n\n"
-                "Collect delta metrics for this incremental run and have\n"
-                "product_manager write a scoped delivery report. Cite real\n"
-                "tool outputs — do not guess numbers.\n\n"
-                "1. Collect incremental metrics:\n"
+                "Assemble the report from the QA engineer's structured\n"
+                "findings — do NOT re-run the test suite yourself (avoids\n"
+                "flakiness covering up QA-flagged failures / product\n"
+                "bugs). Read the project's language from\n"
+                "docs/architecture.md (or docs/stack_contract.json if\n"
+                "present); do NOT default to Python.\n\n"
+                "1. Read docs/qa_report.json (REQUIRED — schema in the\n"
+                "   waterfall Phase-6 prompt; QA writes it in Phase 5).\n"
+                "   If missing or invalid, dispatch qa_engineer to\n"
+                "   produce it, then re-read.\n\n"
+                "2. Collect incremental DELTA metrics QA does not\n"
+                "   produce:\n"
                 "   a) New or modified source files since the previous\n"
                 "      baseline run. Use git where available:\n"
                 "      execute_shell('git status --short 2>/dev/null || echo not-a-git-repo')\n"
                 "      execute_shell('git diff --name-only HEAD~1 2>/dev/null || true')\n"
                 "      Fall back to find -newer if git is not in play.\n"
-                "   b) Current source file count and LOC (full project):\n"
-                "      execute_shell('find src -type f -name \"*.py\" | wc -l')\n"
-                "      execute_shell('find src -type f -name \"*.py\" -exec wc -l {} + | sort -rn | head -30')\n"
-                "   c) Test count + FULL suite result:\n"
-                "      execute_shell('find tests -type f -name \"test_*.py\" 2>/dev/null | wc -l')\n"
-                "      execute_shell('python -m pytest tests/ --collect-only -q 2>&1 | tail -5')\n"
-                "      execute_shell('python -m pytest tests/ -q --tb=line 2>&1 | tail -20')\n\n"
-                "2. Dispatch product_manager to write docs/delivery_report.md.\n"
+                "   b) Current source file count and LOC (full project).\n"
+                "      Pick the row matching your project's language. Run\n"
+                "      each find twice: once with ``| wc -l`` for the\n"
+                "      count, once with ``-exec wc -l {} + | sort -rn |\n"
+                "      head -30`` for per-file LOC.\n"
+                "      - Python:     find src -type f -name '*.py'\n"
+                "      - TypeScript: find src -type f \\( -name '*.ts' -o -name '*.tsx' \\)\n"
+                "      - Go:         find . -type f -name '*.go' -not -path './vendor/*'\n"
+                "      - Rust:       find src -type f -name '*.rs'\n"
+                "      - Java:       find src -type f -name '*.java'\n"
+                "3. Dispatch product_manager to write docs/delivery_report.md.\n"
                 "   Pass expected_artifacts=['docs/delivery_report.md'].\n"
                 "   Require the report to cover:\n"
                 "   - Executive Summary — one paragraph scoped to the new\n"
-                "     requirement and whether the project remains production-ready.\n"
+                "     requirement (production-ready iff qa_report says so).\n"
                 "   - Incremental Delta — bullet list of modules added and\n"
-                "     modules edited. Cite step a) outputs.\n"
-                "   - Full Implementation Metrics — counts from step b).\n"
-                "   - Testing Metrics — FULL-suite pass/fail/skipped from\n"
-                "     step c). Pass rate as a percentage.\n"
-                "   - Known Issues — failing tests with short descriptions,\n"
-                "     or 'none' if green.\n"
-                "   - Conclusion — one or two sentences on readiness AFTER\n"
-                "     the incremental change.\n"
-                "   EMBED the raw tool outputs into the task description so\n"
-                "   PM cites them verbatim (same protocol as initial Phase 6).\n\n"
-                "3. After product_manager returns, call mark_complete with a\n"
-                "   short paragraph that references docs/delivery_report.md.\n"
-                "   Include: project name, 'incremental', pass rate, number\n"
-                "   of new modules + edited modules, and whether the entry\n"
-                "   point verified successfully in Phase 4.",
+                "     modules edited. Cite step 2a outputs.\n"
+                "   - Full Implementation Metrics — counts from step 2b.\n"
+                "   - Testing Metrics — copy qa_report.pytest fields\n"
+                "     verbatim (passed/failed/skipped + pass rate).\n"
+                "   - UI Validation — copy qa_report.ui_validation\n"
+                "     verbatim.\n"
+                "   - Known Issues — list every entry from\n"
+                "     qa_report.product_bugs verbatim AND every test in\n"
+                "     qa_report.pytest.failed_tests verbatim, or 'none'\n"
+                "     when both are empty AND ui_validation passed.\n"
+                "   - Conclusion — one or two sentences on readiness\n"
+                "     AFTER the incremental change.\n"
+                "   EMBED the raw qa_report.json + step 2 tool outputs in\n"
+                "   the task description so PM cites them verbatim.\n\n"
+                "4. After product_manager returns, call mark_complete\n"
+                "   with a short paragraph referencing\n"
+                "   docs/delivery_report.md. Include: project name,\n"
+                "   'incremental', pass rate (from qa_report), number of\n"
+                "   new + edited modules, and whether the entry point\n"
+                "   verified successfully in Phase 4.",
             ),
         ]
 
@@ -852,28 +995,33 @@ class ProjectSession:
                 "  a future sprint.\n"
                 "- Validate every ```mermaid block via the mermaid skill and\n"
                 "  fix any syntax error before responding.\n"
-                "Pass expected_artifacts=['docs/sprint_design.md'].\n"
+                "Pass expected_artifacts=['docs/sprint_design.md',\n"
+                "'docs/stack_contract.json'].\n"
                 "After it completes, STOP.\n"
                 "Do NOT call mark_complete.",
             ),
             (
                 "sprint_execution",
                 f"Project requirement: {requirement}\n\n"
-                "Execute Phase 2b — Sprint Execution (AGILE, rapid TDD):\n"
-                "1. Read docs/sprint_design.md to identify the MVP modules.\n"
-                "2. For EACH MVP module, dispatch developer via\n"
-                "   dispatch_tasks_parallel. Each task description must:\n"
-                "   - Include the module's spec from sprint_design.md.\n"
-                "   - Instruct strict TDD: write tests/test_<module>.py,\n"
-                "     then src/<module>.py, then run ONLY that module's test\n"
-                "     file (python -m pytest tests/test_<module>.py -q\n"
-                "     --tb=short). Up to 3 fix attempts.\n"
-                "   - Keep each module small enough to ship within the sprint.\n"
-                "     If a design element is large, reduce scope rather than\n"
-                "     stretching the sprint.\n"
-                "   - Set expected_artifacts=['src/<module>.py',\n"
-                "     'tests/test_<module>.py'].\n"
-                "3. When all dispatches return, STOP.\n"
+                "Execute Phase 2b — Sprint Execution (AGILE, per-subsystem fan-out):\n\n"
+                "Fan-out is performed by the orchestration layer, NOT by\n"
+                "you drafting tasks_json. You make ONE tool call:\n\n"
+                "    dispatch_subsystems(phase=\"sprint_execution\")\n\n"
+                "The primitive reads docs/stack_contract.json's\n"
+                "subsystems[] and dispatches developer in parallel (up to\n"
+                "the runtime cap). Each developer dispatch carries the\n"
+                "STACK CONTRACT and ORIGINAL USER REQUIREMENT blocks\n"
+                "automatically.\n\n"
+                "1. Verify docs/stack_contract.json exists and is valid.\n"
+                "   If missing or malformed, STOP and dispatch architect.\n"
+                "2. Read docs/sprint_design.md briefly (informational).\n"
+                "3. Call dispatch_subsystems(phase=\"sprint_execution\")\n"
+                "   exactly once. Each developer dispatch's task\n"
+                "   description includes the subsystem's components from\n"
+                "   the contract.\n"
+                "4. Do NOT call dispatch_task or dispatch_tasks_parallel\n"
+                "   yourself for individual subsystems / components.\n"
+                "5. When dispatch_subsystems returns, STOP.\n"
                 "Do NOT call mark_complete.",
             ),
             (
@@ -883,10 +1031,14 @@ class ProjectSession:
                 "1. dispatch_task to developer: 'Write the project's main\n"
                 "   entry-point file that wires all MVP modules together so\n"
                 "   the sprint output can be demoed at review. Use the\n"
-                "   language convention (src/main.py for Python, src/index.js\n"
-                "   for Node, cmd/<app>/main.go for Go, etc.). The file MUST\n"
-                "   boot directly (python src/main.py, node src/index.js,\n"
-                "   go run …). End your response with ONE line:\n"
+                "   language convention (src/main.py for Python, src/index.ts\n"
+                "   for TypeScript, cmd/<app>/main.go for Go, src/main.rs\n"
+                "   for Rust, src/main/java/.../App.java for Java,\n"
+                "   src/Program.cs for .NET). The file MUST boot directly\n"
+                "   with a single terminal command (python src/main.py /\n"
+                "   node src/index.js / go run ./cmd/server / cargo run /\n"
+                "   java -jar ... / dotnet run). End your response with\n"
+                "   ONE line:\n"
                 "       RUN: <command to launch>'\n"
                 "2. Run the RUN command with execute_shell(timeout=5).\n"
                 "   - timeout after 5s → SUCCESS (entered main loop).\n"
@@ -904,17 +1056,23 @@ class ProjectSession:
                 "Execute Phase 3 — Sprint Review & Demo (AGILE):\n"
                 "dispatch_task to qa_engineer. Require the QA agent to:\n"
                 "- Read docs/product_backlog.md AND docs/sprint_design.md.\n"
-                "- Write tests/test_integration.py (ONLY integration tests —\n"
-                "  developers already wrote per-module unit tests). Cover\n"
-                "  every MVP user story's acceptance criteria end-to-end.\n"
-                '- RUN the FULL suite: execute(command="python -m pytest\n'
-                '  tests/ -q --tb=short") and iterate up to 3 times until\n'
-                "  tests pass.\n"
+                "- Write ONE integration test file at the path matching\n"
+                "  the project's test runner (e.g. tests/test_integration.py\n"
+                "  for pytest, tests/integration.test.ts for vitest/jest,\n"
+                "  internal/integration_test.go for Go, tests/integration.rs\n"
+                "  for Rust, src/test/java/.../IntegrationTest.java for\n"
+                "  Java). ONLY integration tests — developers already wrote\n"
+                "  per-module unit tests. Cover every MVP user story's\n"
+                "  acceptance criteria end-to-end.\n"
+                "- RUN the FULL suite using the project's test runner\n"
+                "  (python -m pytest tests/ / npx vitest run / go test ./...\n"
+                "  / cargo test / mvn test) and iterate up to 3 times\n"
+                "  until tests pass.\n"
                 "- Write docs/sprint_review.md with a per-user-story\n"
                 "  PASS/FAIL table so the product owner can verify delivery\n"
-                "  during review. Include pytest final summary.\n"
-                "Pass expected_artifacts=['tests/test_integration.py',\n"
-                "'docs/sprint_review.md'].\n"
+                "  during review. Include the final test summary.\n"
+                "Pass expected_artifacts=[<the integration test file path>,\n"
+                "'docs/sprint_review.md', 'docs/qa_report.json'].\n"
                 "After it completes, STOP.\n"
                 "Do NOT call mark_complete.",
             ),
@@ -942,40 +1100,54 @@ class ProjectSession:
                 f"Project requirement: {requirement}\n\n"
                 "Execute Phase 5 — Sprint Delivery Report (AGILE):\n\n"
                 "Collect real metrics then have product_manager write the\n"
-                "report. Do NOT guess numbers.\n\n"
-                "1. Collect metrics via execute_shell:\n"
-                "   a) Source file count:\n"
-                "      execute_shell('find src -type f -name \"*.py\" | wc -l')\n"
-                "   b) Source LOC (top files + total):\n"
-                "      execute_shell('find src -type f -name \"*.py\" -exec wc -l {} + | sort -rn | head -30')\n"
-                "   c) Test files + collected cases:\n"
-                "      execute_shell('find tests -type f -name \"test_*.py\" 2>/dev/null | wc -l')\n"
-                "      execute_shell('python -m pytest tests/ --collect-only -q 2>&1 | tail -5')\n"
-                "   d) Final pytest summary:\n"
-                "      execute_shell('python -m pytest tests/ -q --tb=line 2>&1 | tail -20')\n\n"
-                "2. Dispatch product_manager to write docs/delivery_report.md.\n"
+                "report. Do NOT guess numbers. Read the project's language\n"
+                "from docs/architecture.md (or docs/stack_contract.json if\n"
+                "present) BEFORE picking the file globs and test runner;\n"
+                "do NOT default to Python.\n\n"
+                "1. Read docs/qa_report.json (REQUIRED — schema in the\n"
+                "   waterfall Phase-6 prompt; QA writes it during Sprint\n"
+                "   Review). If missing or invalid, dispatch qa_engineer\n"
+                "   to produce it, then re-read.\n"
+                "2. Collect non-test metrics via execute_shell. Pick the\n"
+                "   row matching the project's language. Run each find\n"
+                "   twice: once with ``| wc -l`` for the count, once with\n"
+                "   ``-exec wc -l {} + | sort -rn | head -30`` for LOC.\n"
+                "      - Python:     find src -type f -name '*.py'\n"
+                "      - TypeScript: find src -type f \\( -name '*.ts' -o -name '*.tsx' \\)\n"
+                "      - Go:         find . -type f -name '*.go' -not -path './vendor/*'\n"
+                "      - Rust:       find src -type f -name '*.rs'\n"
+                "      - Java:       find src -type f -name '*.java'\n"
+                "3. Dispatch product_manager to write docs/delivery_report.md.\n"
                 "   Pass expected_artifacts=['docs/delivery_report.md'].\n"
                 "   Require the report to cover:\n"
-                "   1. MVP Summary — one paragraph on what shipped this sprint\n"
-                "      and whether it meets the DoD of the in-scope stories.\n"
-                "   2. User Stories Shipped vs Deferred — table with story ID,\n"
-                "      title, status (shipped / deferred / blocked).\n"
+                "   1. MVP Summary — one paragraph on what shipped this\n"
+                "      sprint and whether it meets the DoD of the in-scope\n"
+                "      stories (production-ready iff qa_report says so).\n"
+                "   2. User Stories Shipped vs Deferred — table with story\n"
+                "      ID, title, status (shipped / deferred / blocked).\n"
                 "   3. Design — bullets from docs/sprint_design.md.\n"
-                "   4. Implementation Metrics — source file count, LOC, entry\n"
-                "      point RUN command.\n"
-                "   5. Test Metrics — FULL-suite pass/fail/skipped from step d,\n"
-                "      pass rate percentage.\n"
-                "   6. Retrospective Highlights — 3-5 bullets from\n"
+                "   4. Implementation Metrics — source file count, LOC,\n"
+                "      entry point RUN command.\n"
+                "   5. Test Metrics — copy qa_report.pytest fields\n"
+                "      verbatim (passed/failed/skipped + pass rate). Do\n"
+                "      NOT re-run tests yourself.\n"
+                "   6. UI Validation — copy qa_report.ui_validation\n"
+                "      verbatim.\n"
+                "   7. Known Issues — list every entry from\n"
+                "      qa_report.product_bugs verbatim AND every test in\n"
+                "      qa_report.pytest.failed_tests verbatim, or 'none'.\n"
+                "   8. Retrospective Highlights — 3-5 bullets from\n"
                 "      docs/sprint_retrospective.md.\n"
-                "   7. Next-Sprint Candidates — deferred stories + retro\n"
+                "   9. Next-Sprint Candidates — deferred stories + retro\n"
                 "      action items.\n"
-                "   EMBED the raw tool outputs verbatim so the PM cites real\n"
-                "   numbers.\n\n"
-                "3. After product_manager returns, call mark_complete with a\n"
-                "   short paragraph referencing docs/delivery_report.md.\n"
-                "   Include: project name, 'agile sprint', pass rate, shipped\n"
-                "   user stories count, deferred stories count, entry point\n"
-                "   verification outcome.",
+                "   EMBED the raw qa_report.json + step-2 tool outputs in\n"
+                "   the task description so the PM cites them verbatim.\n\n"
+                "4. After product_manager returns, call mark_complete\n"
+                "   with a short paragraph referencing\n"
+                "   docs/delivery_report.md. Include: project name,\n"
+                "   'agile sprint', pass rate (from qa_report), shipped\n"
+                "   user stories count, deferred stories count, entry\n"
+                "   point verification outcome.",
             ),
         ]
 
@@ -1013,24 +1185,32 @@ class ProjectSession:
                 "- APPEND / UPDATE only the sections the new stories touch.\n"
                 "  Existing design stays. Keep C4 for architecture views.\n"
                 "- Validate every ```mermaid block via the mermaid skill.\n"
-                "Pass expected_artifacts=['docs/sprint_design.md'].\n"
+                "Pass expected_artifacts=['docs/sprint_design.md',\n"
+                "'docs/stack_contract.json'].\n"
                 "STOP. Do NOT call mark_complete.",
             ),
             (
                 "sprint_execution",
                 f"New requirement for the next sprint: {requirement}\n\n"
-                "Execute Phase 2b — Sprint Execution (AGILE, INCREMENTAL):\n"
-                "1. Read docs/sprint_design.md. Identify NEW/CHANGED MVP\n"
-                "   modules for this sprint only.\n"
-                "2. dispatch_tasks_parallel to developer for each module:\n"
-                "   - NEW modules: strict TDD. Write tests then source then\n"
-                "     run per-module tests. Up to 3 fix attempts.\n"
-                "   - CHANGED modules: task MUST say the file exists and\n"
-                "     developer must EDIT in place (edit_file) — never\n"
-                "     rewrite. Existing tests must keep passing.\n"
-                "   - expected_artifacts=['src/<module>.py',\n"
-                "     'tests/test_<module>.py'].\n"
-                "3. STOP. Do NOT call mark_complete.",
+                "Execute Phase 2b — Sprint Execution (AGILE, INCREMENTAL,\n"
+                "per-subsystem fan-out):\n\n"
+                "Fan-out is performed by the orchestration layer. Make ONE\n"
+                "tool call:\n\n"
+                "    dispatch_subsystems(phase=\"sprint_execution\")\n\n"
+                "1. Verify docs/stack_contract.json is up to date with the\n"
+                "   incremental sprint design. If architect should have\n"
+                "   amended subsystems[] / components[] but didn't, STOP\n"
+                "   and dispatch architect to bring the contract in line.\n"
+                "2. Read docs/sprint_design.md briefly (informational).\n"
+                "3. Call dispatch_subsystems(phase=\"sprint_execution\")\n"
+                "   exactly once. Each developer dispatch's task\n"
+                "   description includes the subsystem's components from\n"
+                "   the contract; CHANGED components are addressed via\n"
+                "   the rendered TDD instructions (edit-in-place when the\n"
+                "   file already exists).\n"
+                "4. Do NOT call dispatch_task or dispatch_tasks_parallel\n"
+                "   yourself for individual subsystems / components.\n"
+                "5. STOP. Do NOT call mark_complete.",
             ),
             (
                 "sprint_main_entry",
@@ -1038,7 +1218,8 @@ class ProjectSession:
                 "Execute Phase 2c — Working Entry Point (AGILE,\n"
                 "INCREMENTAL, verify-only):\n"
                 "1. Check whether an entry file exists (src/main.py,\n"
-                "   src/index.js, cmd/<app>/main.go, src/main.rs). If yes,\n"
+                "   src/index.ts, cmd/<app>/main.go, src/main.rs,\n"
+                "   src/main/java/.../App.java, src/Program.cs). If yes,\n"
                 "   jump to step 3 with its RUN command; if no, dispatch\n"
                 "   developer to create one with a RUN: line.\n"
                 "2. Run RUN command via execute_shell(timeout=5). Same\n"
@@ -1055,15 +1236,21 @@ class ProjectSession:
                 "dispatch_task to qa_engineer:\n"
                 "- Read docs/product_backlog.md + docs/sprint_design.md\n"
                 "  (including the new sections).\n"
-                "- EDIT tests/test_integration.py in place (do NOT rewrite)\n"
-                "  to add scenarios for the new MVP stories.\n"
-                '- RUN the FULL suite: execute(command="python -m pytest\n'
-                '  tests/ -q --tb=short") and iterate up to 3 times until\n'
-                "  tests pass.\n"
+                "- EDIT the existing integration test file IN PLACE (e.g.\n"
+                "  tests/test_integration.py for pytest,\n"
+                "  tests/integration.test.ts for vitest/jest,\n"
+                "  internal/integration_test.go for Go,\n"
+                "  tests/integration.rs for Rust,\n"
+                "  src/test/java/.../IntegrationTest.java for Java) — do\n"
+                "  NOT rewrite — to add scenarios for the new MVP stories.\n"
+                "- RUN the FULL suite using the project's test runner\n"
+                "  (python -m pytest tests/ / npx vitest run / go test ./...\n"
+                "  / cargo test / mvn test) and iterate up to 3 times\n"
+                "  until tests pass.\n"
                 "- EDIT docs/sprint_review.md — append a new section for\n"
                 "  this sprint with per-user-story PASS/FAIL.\n"
-                "Pass expected_artifacts=['tests/test_integration.py',\n"
-                "'docs/sprint_review.md'].\n"
+                "Pass expected_artifacts=[<the integration test file path>,\n"
+                "'docs/sprint_review.md', 'docs/qa_report.json'].\n"
                 "STOP. Do NOT call mark_complete.",
             ),
             (
@@ -1083,29 +1270,45 @@ class ProjectSession:
                 f"New requirement for the next sprint: {requirement}\n\n"
                 "Execute Phase 5 — Sprint Delivery Report (AGILE,\n"
                 "INCREMENTAL):\n\n"
-                "Collect delta + full metrics:\n"
+                "Assemble the report from the QA engineer's structured\n"
+                "findings — do NOT re-run tests yourself. Read the\n"
+                "project's language from docs/architecture.md (or\n"
+                "docs/stack_contract.json if present); do NOT default to\n"
+                "Python.\n"
+                "1. Read docs/qa_report.json (REQUIRED — schema in the\n"
+                "   waterfall Phase-6 prompt; QA writes it during Sprint\n"
+                "   Review). If missing or invalid, dispatch qa_engineer\n"
+                "   to produce it, then re-read.\n"
+                "2. Collect delta + non-test metrics:\n"
                 "   a) New or modified files since baseline:\n"
                 "      execute_shell('git status --short 2>/dev/null || true')\n"
                 "      execute_shell('git diff --name-only HEAD~1 2>/dev/null || true')\n"
-                "   b) Full file / LOC count:\n"
-                "      execute_shell('find src -type f -name \"*.py\" | wc -l')\n"
-                "      execute_shell('find src -type f -name \"*.py\" -exec wc -l {} + | sort -rn | head -30')\n"
-                "   c) Test suite:\n"
-                "      execute_shell('find tests -type f -name \"test_*.py\" 2>/dev/null | wc -l')\n"
-                "      execute_shell('python -m pytest tests/ --collect-only -q 2>&1 | tail -5')\n"
-                "      execute_shell('python -m pytest tests/ -q --tb=line 2>&1 | tail -20')\n\n"
-                "Dispatch product_manager to EDIT docs/delivery_report.md\n"
-                "(append a new sprint section — do NOT recreate). Cover:\n"
-                "  1. Sprint Delta Summary — new requirement + shipped /\n"
-                "     deferred stories.\n"
-                "  2. Modules added vs modules edited (from step a).\n"
-                "  3. Updated implementation metrics (step b).\n"
-                "  4. FULL-suite test metrics (step c).\n"
-                "  5. Retrospective bullets for this sprint.\n"
+                "   b) Full file / LOC count, pick the row matching your\n"
+                "      project's language. Run each find twice: once with\n"
+                "      ``| wc -l`` for the count, once with\n"
+                "      ``-exec wc -l {} + | sort -rn | head -30`` for LOC.\n"
+                "      - Python:     find src -type f -name '*.py'\n"
+                "      - TypeScript: find src -type f \\( -name '*.ts' -o -name '*.tsx' \\)\n"
+                "      - Go:         find . -type f -name '*.go' -not -path './vendor/*'\n"
+                "      - Rust:       find src -type f -name '*.rs'\n"
+                "      - Java:       find src -type f -name '*.java'\n"
+                "3. Dispatch product_manager to EDIT docs/delivery_report.md\n"
+                "   (append a new sprint section — do NOT recreate). Cover:\n"
+                "   1. Sprint Delta Summary — new requirement + shipped /\n"
+                "      deferred stories.\n"
+                "   2. Modules added vs modules edited (from step 2a).\n"
+                "   3. Updated implementation metrics (step 2b).\n"
+                "   4. Test metrics — copy qa_report.pytest verbatim.\n"
+                "   5. UI Validation — copy qa_report.ui_validation\n"
+                "      verbatim.\n"
+                "   6. Known Issues — list every entry from\n"
+                "      qa_report.product_bugs verbatim AND every test in\n"
+                "      qa_report.pytest.failed_tests verbatim, or 'none'.\n"
+                "   7. Retrospective bullets for this sprint.\n"
                 "Pass expected_artifacts=['docs/delivery_report.md'].\n"
                 "After it returns, call mark_complete with: project name,\n"
-                "'agile sprint <incremental>', pass rate, shipped stories\n"
-                "count, entry verification outcome.",
+                "'agile sprint <incremental>', pass rate (from qa_report),\n"
+                "shipped stories count, entry verification outcome.",
             ),
         ]
 
@@ -1151,37 +1354,44 @@ class ProjectSession:
                 "After writing, the architect MUST validate every\n"
                 "```mermaid block using the ``mermaid`` skill and fix\n"
                 "any syntax error before responding.\n"
-                "Pass expected_artifacts=['docs/architecture.md'] so the\n"
-                "runtime retries once with context if the file is missing.\n"
+                "Pass expected_artifacts=['docs/architecture.md',\n"
+                "'docs/stack_contract.json'] so the runtime retries once\n"
+                "if either is missing.\n"
                 "After it completes, STOP.\n"
                 "Do NOT call mark_complete.",
             ),
             (
                 "implementation",
                 f"Project requirement: {requirement}\n\n"
-                "Execute Phase 3 — Implementation (TDD, per-module):\n"
-                "1. Read docs/architecture.md to identify all modules.\n"
-                "2. For EACH module, dispatch developer using dispatch_tasks_parallel.\n"
-                "   In each task description, include the architecture spec AND\n"
-                "   explicitly instruct the developer to follow strict TDD:\n"
-                "   first write tests/test_<module>.py, then src/<module>.py,\n"
-                "   then run ONLY that module's test file with\n"
-                '   execute(command="python -m pytest tests/test_<module>.py -q --tb=short")\n'
-                "   and iterate (up to 3 attempts) until that module's tests pass.\n"
-                "   After the module's tests pass, the developer MUST run the\n"
-                "   ``code_inspection`` skill's language-appropriate static\n"
-                "   analyzer against each source file written (for Python:\n"
-                "   ``ruff check <file>`` + ``mypy <file>``) and fix every\n"
-                "   finding before reporting the module done.\n"
-                "   For each task object in the JSON, set\n"
-                "   expected_artifacts=['src/<module>.py', 'tests/test_<module>.py']\n"
-                "   so the runtime retries once with context if either file is missing.\n"
-                "3. Do NOT run the full pytest suite yourself — developers run\n"
-                "   their own per-module tests, and the QA engineer will run\n"
-                "   the full suite in Phase 5. Running full pytest here while\n"
-                "   parallel developer dispatches are still writing files\n"
-                "   causes races and noisy failures.\n"
-                "4. When all dispatches return, STOP.\n"
+                "Execute Phase 3 — Implementation (TDD, per-subsystem fan-out):\n\n"
+                "Fan-out is performed by the orchestration layer, NOT by you\n"
+                "drafting tasks_json. You make ONE tool call:\n\n"
+                "    dispatch_subsystems(phase=\"implementation\")\n\n"
+                "The primitive reads docs/stack_contract.json's subsystems[]\n"
+                "(written by architect in Phase 2), builds one developer\n"
+                "task description per subsystem deterministically (from the\n"
+                "contract's language / test_runner / static_analyzer +\n"
+                "components[] list — no LLM in the loop), and dispatches\n"
+                "developer in parallel up to the runtime cap\n"
+                "(safety_limits.max_concurrent_subsystem_dispatches, default\n"
+                "4). Each developer dispatch carries the STACK CONTRACT and\n"
+                "ORIGINAL USER REQUIREMENT blocks automatically.\n\n"
+                "1. Verify docs/stack_contract.json exists and is valid by\n"
+                "   reading it once with read_file. If missing or malformed,\n"
+                "   STOP and dispatch architect to produce it; do NOT guess\n"
+                "   the stack.\n"
+                "2. Call dispatch_subsystems(phase=\"implementation\")\n"
+                "   exactly once. The tool returns an aggregate result with\n"
+                "   per-subsystem pass/fail and component artifact verification.\n"
+                "3. Do NOT call dispatch_task or dispatch_tasks_parallel\n"
+                "   yourself for individual subsystems / components — the\n"
+                "   primitive does the fan-out so a weak orchestrator LLM\n"
+                "   that can only emit one tool call per turn still gets\n"
+                "   real parallelism on the worker side.\n"
+                "4. Do NOT run the full test suite — developers run their\n"
+                "   own per-component tests inside each subsystem dispatch,\n"
+                "   and the QA engineer runs the full suite in Phase 5.\n"
+                "5. When dispatch_subsystems returns, STOP.\n"
                 "Do NOT call mark_complete.",
             ),
             (
@@ -1189,25 +1399,34 @@ class ProjectSession:
                 f"Project requirement: {requirement}\n\n"
                 "Execute Phase 4 — Main Entry Point (language-agnostic):\n\n"
                 "1. dispatch_task to developer with this task:\n"
-                "'Write the project's main entry-point file. Use whatever\n"
-                "path and format your language\\'s conventions dictate — e.g.\n"
-                "src/main.py (Python), src/index.js (Node), cmd/<app>/main.go\n"
-                "(Go), src/main.rs (Rust). Read the existing source files\n"
-                "first to understand the module APIs. The file MUST be a\n"
-                "real BOOT SCRIPT that can be launched directly (python\n"
-                "src/main.py, node src/index.js, go run …). It is NOT enough\n"
-                "to expose a class with a run() method — the file itself\n"
-                "must start the app. Use whatever hook your language needs\n"
-                '(``if __name__ == "__main__":`` for Python, top-level\n'
-                "invocation for Node, ``func main()`` for Go, etc.).\n"
-                "Also write the corresponding unit test file and verify it\n"
-                "passes for that module only (do NOT run the full suite).\n"
+                "'Write the project's main entry-point file. Use the path\n"
+                "and format your project's language conventions dictate —\n"
+                "e.g. src/main.py (Python), src/index.ts (TypeScript),\n"
+                "cmd/<app>/main.go (Go), src/main.rs (Rust),\n"
+                "src/main/java/.../App.java (Java), src/Program.cs (.NET).\n"
+                "Read the existing source files first to understand the\n"
+                "module APIs. The file MUST be a real BOOT SCRIPT that can\n"
+                "be launched directly with a single terminal command. It\n"
+                "is NOT enough to expose a class with a run() method —\n"
+                "the file itself must start the app. Use whatever hook\n"
+                'your language needs (e.g. ``if __name__ == \"__main__\":``\n'
+                "for Python, top-level invocation for Node, ``func main()``\n"
+                "for Go, ``fn main()`` for Rust, ``public static void main``\n"
+                "for Java, ``Program.Main`` for .NET).\n"
+                "Also write the corresponding unit test file (using the\n"
+                "language's test runner) and verify it passes for that\n"
+                "module only (do NOT run the full suite).\n"
                 "End your response with ONE line in the EXACT format:\n"
                 "    RUN: <command to launch the app from project root>\n"
-                "Examples:\n"
-                "    RUN: python src/main.py\n"
+                "Examples (alphabetical, pick the row matching your stack):\n"
+                "    RUN: cargo run --release\n"
+                "    RUN: dotnet run --project src/\n"
+                "    RUN: go run ./cmd/server\n"
+                "    RUN: java -jar target/app.jar\n"
                 "    RUN: node src/index.js\n"
-                "    RUN: go run ./cmd/server'\n\n"
+                "    RUN: npm run dev\n"
+                "    RUN: npx tsx src/index.ts\n"
+                "    RUN: python src/main.py'\n\n"
                 "2. After the dispatch returns, extract the RUN: line from\n"
                 "   the response's output_preview (format: ``RUN: <cmd>``).\n"
                 "   Run the extracted command with execute_shell using\n"
@@ -1218,11 +1437,14 @@ class ProjectSession:
                 "     and servers.\n"
                 "   - exit_code == 0 with normal output is also SUCCESS:\n"
                 "     the app booted and exited cleanly (CLI-style tools).\n"
-                "   - exit_code != 0 with output containing ImportError,\n"
-                "     SyntaxError, ModuleNotFoundError, NameError,\n"
-                "     AttributeError at top level, ``No such file``,\n"
-                "     ``cannot find module``, or similar startup failures\n"
-                "     is FAILURE.\n"
+                "   - exit_code != 0 with output containing ImportError /\n"
+                "     ModuleNotFoundError / NameError / AttributeError\n"
+                "     (Python), Cannot find module / TypeError\n"
+                "     (Node / TS), undefined: ... / cannot find package\n"
+                "     (Go), error[E0...] / unresolved import (Rust),\n"
+                "     ClassNotFoundException / NoSuchMethodError (Java),\n"
+                "     ``No such file``, or similar startup failures is\n"
+                "     FAILURE.\n"
                 "   - No RUN: line present in the response is FAILURE.\n\n"
                 "3. If step 2 reported FAILURE, dispatch developer AGAIN\n"
                 "   with the failure text and request a fix. Allow up to 3\n"
@@ -1236,15 +1458,25 @@ class ProjectSession:
                 f"Project requirement: {requirement}\n\n"
                 "Execute Phase 5 — Integration Testing (QA runs the suite):\n"
                 "dispatch_task to qa_engineer with this task:\n"
-                "'Write tests/test_integration.py ONLY — integration tests for\n"
-                "cross-module interactions and end-to-end flows. Do NOT write\n"
-                "per-module unit tests (developer already did that in Phase 3).\n"
-                "After writing, RUN the full suite yourself with\n"
-                'execute(command="python -m pytest tests/ -q --tb=short")\n'
-                "and iterate up to 3 times until tests pass. Report the final\n"
-                "pytest result in your response.'\n"
-                "Pass expected_artifacts=['tests/test_integration.py'] so the\n"
-                "runtime retries once with context if the file is missing.\n"
+                "'Write ONE integration test file at the path matching the\n"
+                "project's test runner — e.g. tests/test_integration.py\n"
+                "(pytest), tests/integration.test.ts (vitest / jest),\n"
+                "internal/integration_test.go (Go), tests/integration.rs\n"
+                "(Rust), src/test/java/.../IntegrationTest.java (Java).\n"
+                "Cover cross-module interactions and end-to-end flows.\n"
+                "Do NOT write per-module unit tests (developer already did\n"
+                "that in Phase 3). After writing, RUN the full suite\n"
+                "yourself using the project's full-suite test command:\n"
+                "  - Python:     python -m pytest tests/ -q --tb=short\n"
+                "  - TypeScript: npx vitest run  (or npx jest)\n"
+                "  - Go:         go test ./...\n"
+                "  - Rust:       cargo test\n"
+                "  - Java:       mvn test\n"
+                "Iterate up to 3 times until tests pass. Report the final\n"
+                "test result in your response.'\n"
+                "Pass expected_artifacts=[<the chosen integration test\n"
+                "file path>, 'docs/qa_report.json'] so the runtime\n"
+                "retries once if either is missing.\n"
                 "After it completes, STOP.\n"
                 "Do NOT call mark_complete.",
             ),
@@ -1252,60 +1484,83 @@ class ProjectSession:
                 "delivery",
                 f"Project requirement: {requirement}\n\n"
                 "Execute Phase 6 — Delivery Report:\n\n"
-                "Your job is to collect hard metrics about what was built,\n"
-                "then have the product_manager agent write them up as a\n"
-                "proper delivery report. Do NOT guess numbers — every\n"
-                "figure in the report must come from a real tool output.\n\n"
-                "1. Collect development metrics. Use execute_shell to run\n"
-                "   each command below and keep the output text. If a\n"
-                "   command fails or returns nothing, note that fact and\n"
-                "   continue — do not retry more than once per command.\n\n"
-                "   a) Source file count. Pick the right find expression\n"
-                "      for the language(s) used in this project — typical\n"
-                "      source extensions are .py .js .ts .go .rs .java\n"
-                "      .cpp .c .cs etc. Example:\n"
-                "      execute_shell('find src -type f -name \"*.py\" | wc -l')\n"
-                "   b) Source lines of code. Top files first, then total:\n"
-                "      execute_shell('find src -type f -name \"*.py\" -exec wc -l {} + | sort -rn | head -30')\n"
-                "   c) Test file list + counts:\n"
-                "      execute_shell('find tests -type f -name \"test_*.py\" 2>/dev/null | wc -l')\n"
-                "      execute_shell('python -m pytest tests/ --collect-only -q 2>&1 | tail -5')\n"
-                "   d) Test pass/fail summary (final run):\n"
-                "      execute_shell('python -m pytest tests/ -q --tb=line 2>&1 | tail -20')\n"
-                "   e) Coverage (optional — may fail if pytest-cov not installed):\n"
-                "      execute_shell('python -m pytest tests/ --cov=src --cov-report=term 2>&1 | tail -25')\n\n"
-                "2. Dispatch product_manager to write the final report.\n"
-                "   Pass expected_artifacts=['docs/delivery_report.md'] so\n"
-                "   the runtime retries once with context if the file is\n"
-                "   missing.\n"
-                "   Embed the ACTUAL tool outputs you gathered above into\n"
-                "   the task description so product_manager has the raw\n"
-                "   numbers to cite. Use a task description like:\n\n"
+                "Your job is to assemble a delivery report from the QA\n"
+                "engineer's structured findings — NOT to re-run the test\n"
+                "suite yourself. Re-running pytest / vitest / etc. here\n"
+                "introduces flakiness (a test that intermittently fails\n"
+                "may pass this time and the QA-flagged failure / product\n"
+                "bugs disappear from the final report).\n\n"
+                "1. Read docs/qa_report.json (REQUIRED). The QA engineer\n"
+                "   wrote it in Phase 5. Schema:\n"
+                "     {\n"
+                "       \"pytest\": {\"command\": str, \"passed\": int,\n"
+                "                  \"failed\": int, \"skipped\": int,\n"
+                "                  \"failed_tests\": [str, ...]},\n"
+                "       \"ui_validation\": {\"required\": bool,\n"
+                "                          \"verdict\": \"PASS|FAILED|\n"
+                "                                       SKIPPED_HEADLESS_ONLY\",\n"
+                "                          \"reason\": str},\n"
+                "       \"product_bugs\": [{\"module\": str, \"function\":\n"
+                "                          str, \"summary\": str}, ...],\n"
+                "       \"integration_tests\": {\"file\": str,\n"
+                "                              \"scenario_count\": int}\n"
+                "     }\n"
+                "   If docs/qa_report.json is MISSING or invalid JSON, do\n"
+                "   NOT fabricate numbers and do NOT silently re-run\n"
+                "   tests. Instead: dispatch qa_engineer to produce the\n"
+                "   missing report (the QA agent's prompt requires it),\n"
+                "   then re-read the file. Only after a valid report is\n"
+                "   on disk continue to step 2.\n\n"
+                "2. Collect non-test development metrics that QA does NOT\n"
+                "   produce — source file count + per-file LOC. Read the\n"
+                "   project's language from docs/architecture.md (or\n"
+                "   docs/stack_contract.json if present) BEFORE picking\n"
+                "   the file glob; do NOT default to Python. Run each\n"
+                "   find twice: once with ``| wc -l`` for the count,\n"
+                "   once with ``-exec wc -l {} + | sort -rn | head -30``\n"
+                "   for per-file LOC.\n"
+                "      - Python:     find src -type f -name '*.py'\n"
+                "      - TypeScript: find src -type f \\( -name '*.ts' -o -name '*.tsx' \\)\n"
+                "      - Go:         find . -type f -name '*.go' -not -path './vendor/*'\n"
+                "      - Rust:       find src -type f -name '*.rs'\n"
+                "      - Java:       find src -type f -name '*.java'\n"
+                "      - C# / .NET:  find . -type f -name '*.cs' -not -path './bin/*' -not -path './obj/*'\n"
+                "3. Dispatch product_manager to write the final report.\n"
+                "   Pass expected_artifacts=['docs/delivery_report.md'].\n"
+                "   Embed the qa_report.json fields VERBATIM into the\n"
+                "   task description so product_manager cannot rewrite\n"
+                "   the conclusion. Use a task description like:\n\n"
                 "   'Write docs/delivery_report.md — the project delivery\n"
-                "   report. Use the data I pass you; do not invent numbers.\n"
-                "   Required sections:\n"
+                "   report. Use the data I pass you; do not invent\n"
+                "   numbers. The Known Issues section MUST list every\n"
+                "   entry from qa_report.product_bugs verbatim AND every\n"
+                "   test in qa_report.pytest.failed_tests verbatim. If\n"
+                "   product_bugs is empty AND failed_tests is empty AND\n"
+                "   ui_validation.verdict is PASS or SKIPPED_HEADLESS_ONLY,\n"
+                "   write \"none\". Otherwise enumerate them. Required\n"
+                "   sections:\n"
                 "   1. Executive Summary — one paragraph, what was built\n"
-                "      and whether it is production-ready.\n"
+                "      and whether it is production-ready (DERIVE from\n"
+                "      qa_report — production-ready iff failed==0 AND\n"
+                "      product_bugs is empty AND ui_validation.verdict\n"
+                "      != FAILED).\n"
                 "   2. Design — summarize docs/architecture.md (read it\n"
                 "      yourself) in a few bullets: module decomposition,\n"
-                "      key technology choices.\n"
-                "   3. Implementation Metrics:\n"
-                "      - Source file count\n"
-                "      - Total lines of code (from wc -l output)\n"
-                "      - Per-module breakdown (top files by LOC)\n"
-                "      - Entry point location and RUN command\n"
-                "   4. Testing Metrics:\n"
-                "      - Test file count\n"
-                "      - Total test cases collected (pytest --collect-only)\n"
-                "      - Pass / fail / skipped counts (pytest final run)\n"
-                "      - Overall pass rate as a percentage\n"
-                "      - Coverage percentage IF available (otherwise\n"
-                '        explicitly state "coverage not measured")\n'
-                "   5. Known Issues — list any failing tests with short\n"
-                '      descriptions, or "none" if all green.\n'
-                "   6. Conclusion — one or two sentences on readiness.\n\n"
-                "   RAW TOOL OUTPUTS (cite these, do not fabricate):\n"
-                "   <paste the actual execute_shell outputs from step 1>'\n\n"
+                "      key technology choices (language, frameworks).\n"
+                "   3. Implementation Metrics — source file count, LOC,\n"
+                "      top files by LOC, entry point location + RUN cmd.\n"
+                "   4. Testing Metrics — copy qa_report.pytest fields\n"
+                "      verbatim: passed / failed / skipped counts and\n"
+                "      pass rate (passed / (passed+failed+skipped)).\n"
+                "      Do NOT re-run pytest yourself.\n"
+                "   5. UI Validation — copy qa_report.ui_validation\n"
+                "      verbatim (required, verdict, reason).\n"
+                "   6. Known Issues — list as required above.\n"
+                "   7. Conclusion — one or two sentences on readiness.\n\n"
+                "   RAW QA REPORT JSON (cite verbatim, do not paraphrase):\n"
+                "   <paste the contents of docs/qa_report.json>\n"
+                "   RAW LOC TOOL OUTPUTS (from step 2):\n"
+                "   <paste the find / wc -l outputs>'\n\n"
                 "3. After product_manager returns, call mark_complete with\n"
                 "   a short paragraph summary that references\n"
                 "   docs/delivery_report.md for details. The summary\n"
@@ -1382,21 +1637,28 @@ class ProjectSession:
                 return (
                     f"Implementation: {developer_dispatches} developer dispatches, "
                     f"{developer_completed} completed. "
-                    "Run execute_shell('python -m pytest tests/ -q --tb=short') to check. "
+                    "Run the project's full-suite test command to check "
+                    "(python -m pytest tests/ for Python, npx vitest run for "
+                    "TypeScript/vitest, npx jest for jest, go test ./... for Go, "
+                    "cargo test for Rust, mvn test for Java). "
                     "If tests fail, dispatch developer to fix. "
                     "Do NOT proceed until tests pass."
                 )
-            # Tests pass → dispatch main.py
+            # Tests pass → dispatch main entry point
             return (
-                "Module tests pass. Now dispatch developer to write src/main.py — "
-                "the main entry point. Call:\n"
+                "Module tests pass. Now dispatch developer to write the main "
+                "entry-point file at the path matching the project's language "
+                "(src/main.py for Python, src/index.ts for TypeScript, "
+                "cmd/<app>/main.go for Go, src/main.rs for Rust, "
+                "src/main/java/.../App.java for Java, src/Program.cs for .NET). "
+                "Call:\n"
                 "dispatch_task(agent_name='developer', "
-                "task_description='Write src/main.py — the main entry point that "
+                "task_description='Write the main entry point that "
                 "imports and uses ALL implemented modules (read src/ to see what exists). "
-                "Create a real game loop: initialize Snake, Food, Engine, GameState, Scoring etc., "
-                "then run an update loop that moves the snake, checks collisions, spawns food, "
-                "and tracks score. NOT a stub — real working game logic. "
-                "Also write tests/test_main.py to verify the game initializes and runs.', "
+                "Create real bootstrap logic — initialise the modules and run the "
+                "main loop / start the server / open the window etc. NOT a stub. "
+                "Also write the corresponding unit test file in the language\\'s "
+                "idiomatic test location to verify the entry initialises and runs.', "
                 "step_id='step_integrate_main', phase='implementation')"
             )
 
@@ -1404,15 +1666,22 @@ class ProjectSession:
             return (
                 "Main entry point done. Dispatch qa_engineer for integration testing.\n"
                 "dispatch_task(agent_name='qa_engineer', "
-                "task_description='Read src/ and tests/ to understand the system. "
-                "Write integration tests to tests/test_integration.py covering "
+                "task_description='Read src/ and tests/ (or the language\\'s "
+                "idiomatic source/test directories) to understand the system. "
+                "Write integration tests at the path matching the project\\'s "
+                "test runner (tests/test_integration.py for pytest, "
+                "tests/integration.test.ts for vitest/jest, "
+                "internal/integration_test.go for Go, tests/integration.rs for "
+                "Rust, src/test/java/.../IntegrationTest.java for Java) covering "
                 "cross-module interactions.', "
                 "step_id='step_integration_test', phase='verification')"
             )
 
         if "qa_engineer" in agents_dispatched:
             return (
-                "All phases done. Run execute_shell('python -m pytest tests/ -q --tb=short'). "
+                "All phases done. Run the project's full-suite test command "
+                "(python -m pytest tests/ / npx vitest run / npx jest / "
+                "go test ./... / cargo test / mvn test). "
                 "If all pass, call mark_complete with a delivery report. "
                 "If tests fail, dispatch developer to fix, then re-check."
             )

--- a/src/aise/runtime/runtime_config.py
+++ b/src/aise/runtime/runtime_config.py
@@ -25,9 +25,32 @@ from .models import ProcessCaps
 
 # Defaults preserve the prior in-code constants so behavior is unchanged
 # until a project explicitly overrides them.
-DEFAULT_MAX_DISPATCHES = 30
+#
+# ``max_dispatches`` was 30 historically. With the two-stage skeleton +
+# per-component fan-out (``dispatch_subsystems``), a 5-subsystem / 32-
+# component architecture needs:
+#
+#   5 (skeletons) + 32 (components) + 6 (PM, architect, main_entry,
+#   qa, delivery, retries) ≈ 50–60 dispatches
+#
+# 30 truncates the last subsystem deterministically (project_7-tower
+# regression). 128 covers a 50+ component architecture with headroom;
+# ``ProjectSession.run`` ALSO computes a per-run dynamic floor from
+# the architect's ``stack_contract.json`` so the cap auto-scales for
+# bigger architectures without re-tuning this default.
+DEFAULT_MAX_DISPATCHES = 128
 DEFAULT_MAX_CONTINUATIONS = 15
+# Buffer added on top of the architect's declared ``Σ(1 + components)``
+# when computing a per-run dispatch-cap floor. Covers PM / architect /
+# main_entry / qa / delivery + a margin for retries.
+DISPATCH_FLOOR_BUFFER = 16
 DEFAULT_PER_PHASE_TIMEOUT_SECONDS = 600
+# Cap concurrent worker dispatches from ``dispatch_subsystems``.
+# Sized for parallel-friendly serving infrastructure (hosted APIs or
+# multi-GPU vLLM): 16 in-flight workers + the orchestrator's
+# occasional LLM call. Lower it per-project if the local serving
+# layer cannot keep that many requests warm.
+DEFAULT_MAX_CONCURRENT_SUBSYSTEM_DISPATCHES = 16
 
 
 @dataclass
@@ -37,6 +60,11 @@ class SafetyLimits:
     max_dispatches: int = DEFAULT_MAX_DISPATCHES
     max_continuations: int = DEFAULT_MAX_CONTINUATIONS
     per_phase_timeout_seconds: int = DEFAULT_PER_PHASE_TIMEOUT_SECONDS
+    # Throttle for ``dispatch_subsystems`` — the deterministic phase-3
+    # fan-out that reads ``docs/stack_contract.json`` and dispatches
+    # one developer per subsystem in parallel. Without a cap a project
+    # with 10+ subsystems would saturate the LLM serving layer.
+    max_concurrent_subsystem_dispatches: int = DEFAULT_MAX_CONCURRENT_SUBSYSTEM_DISPATCHES
 
     def overlay(self, caps: ProcessCaps | None) -> SafetyLimits:
         """Return a new SafetyLimits with non-None ``caps`` fields applied."""
@@ -52,6 +80,10 @@ class SafetyLimits:
                 if caps.per_phase_timeout_seconds is not None
                 else self.per_phase_timeout_seconds
             ),
+            # max_concurrent_subsystem_dispatches is not exposed via
+            # ProcessCaps yet — falls back to the field default. Add
+            # to ProcessCaps if/when per-process tuning is needed.
+            max_concurrent_subsystem_dispatches=self.max_concurrent_subsystem_dispatches,
         )
 
 

--- a/src/aise/runtime/safety_net.py
+++ b/src/aise/runtime/safety_net.py
@@ -322,6 +322,7 @@ def _repair_remove_leftover(project_root: Path, ctx: dict[str, Any]) -> None:
         target.unlink()
     elif target.is_dir():
         import shutil
+
         shutil.rmtree(target)
     logger.info("safety_net: removed leftover %s", target)
 
@@ -415,6 +416,7 @@ def _stack_contract_valid(target: Path) -> bool:
     detail.
     """
     import json as _json
+
     if not target.is_file():
         return False
     try:
@@ -451,7 +453,8 @@ def _stack_contract_valid(target: Path) -> bool:
         if not components:
             logger.warning(
                 "stack_contract: subsystem %r has zero components in %s",
-                name, target,
+                name,
+                target,
             )
         for comp in components:
             if not isinstance(comp, dict):
@@ -470,16 +473,19 @@ def _stack_contract_valid(target: Path) -> bool:
             # different name.
             if not cfile.startswith(src_dir.rstrip("/") + "/") and cfile != src_dir.rstrip("/"):
                 logger.warning(
-                    "stack_contract: component %r file %r not under "
-                    "subsystem src_dir %r",
-                    cname, cfile, src_dir,
+                    "stack_contract: component %r file %r not under subsystem src_dir %r",
+                    cname,
+                    cfile,
+                    src_dir,
                 )
                 return False
     if len(subsystems) > _SUBSYSTEM_COUNT_SOFT_CAP:
         logger.warning(
             "stack_contract: %d subsystems exceeds soft cap of %d in "
             "%s — architect may be flat-listing components again",
-            len(subsystems), _SUBSYSTEM_COUNT_SOFT_CAP, target,
+            len(subsystems),
+            _SUBSYSTEM_COUNT_SOFT_CAP,
+            target,
         )
     return True
 
@@ -513,6 +519,7 @@ def _artifact_present(project_root: Path, artifact: ExpectedArtifact) -> bool:
             return False
         try:
             import json as _json
+
             _json.loads(target.read_text(encoding="utf-8"))
         except Exception:
             return False
@@ -800,43 +807,44 @@ def scaffolding_expectations() -> tuple[ExpectedArtifact, ...]:
         # Letting them survive into a new run with a different stack
         # produced project_7-tower's three-stacks-coexist failure
         # mode. Repair = delete.
-        ExpectedArtifact(path="package.json", kind="must_not_exist",
-                         description="leftover package.json from prior run"),
-        ExpectedArtifact(path="package-lock.json", kind="must_not_exist",
-                         description="leftover npm lockfile from prior run"),
-        ExpectedArtifact(path="pnpm-lock.yaml", kind="must_not_exist",
-                         description="leftover pnpm lockfile from prior run"),
-        ExpectedArtifact(path="yarn.lock", kind="must_not_exist",
-                         description="leftover yarn lockfile from prior run"),
-        ExpectedArtifact(path="tsconfig.json", kind="must_not_exist",
-                         description="leftover tsconfig from prior run"),
-        ExpectedArtifact(path="vitest.config.ts", kind="must_not_exist",
-                         description="leftover vitest config from prior run"),
-        ExpectedArtifact(path="vite.config.ts", kind="must_not_exist",
-                         description="leftover vite config from prior run"),
-        ExpectedArtifact(path="node_modules", kind="must_not_exist",
-                         description="leftover node_modules from prior run"),
-        ExpectedArtifact(path="Cargo.toml", kind="must_not_exist",
-                         description="leftover Cargo.toml from prior run"),
-        ExpectedArtifact(path="Cargo.lock", kind="must_not_exist",
-                         description="leftover Cargo.lock from prior run"),
-        ExpectedArtifact(path="target", kind="must_not_exist",
-                         description="leftover Rust target/ from prior run"),
-        ExpectedArtifact(path="go.mod", kind="must_not_exist",
-                         description="leftover go.mod from prior run"),
-        ExpectedArtifact(path="go.sum", kind="must_not_exist",
-                         description="leftover go.sum from prior run"),
-        ExpectedArtifact(path="vendor", kind="must_not_exist",
-                         description="leftover Go vendor/ from prior run"),
-        ExpectedArtifact(path="pom.xml", kind="must_not_exist",
-                         description="leftover Maven pom.xml from prior run"),
-        ExpectedArtifact(path="build.gradle.kts", kind="must_not_exist",
-                         description="leftover Gradle build from prior run"),
-        ExpectedArtifact(path="pyproject.toml", kind="must_not_exist",
-                         description="leftover pyproject.toml from prior run "
-                                     "(architect re-creates if Python is the chosen stack)"),
-        ExpectedArtifact(path=".coverage", kind="must_not_exist",
-                         description="leftover coverage artifact from prior run"),
+        ExpectedArtifact(
+            path="package.json", kind="must_not_exist", description="leftover package.json from prior run"
+        ),
+        ExpectedArtifact(
+            path="package-lock.json", kind="must_not_exist", description="leftover npm lockfile from prior run"
+        ),
+        ExpectedArtifact(
+            path="pnpm-lock.yaml", kind="must_not_exist", description="leftover pnpm lockfile from prior run"
+        ),
+        ExpectedArtifact(path="yarn.lock", kind="must_not_exist", description="leftover yarn lockfile from prior run"),
+        ExpectedArtifact(path="tsconfig.json", kind="must_not_exist", description="leftover tsconfig from prior run"),
+        ExpectedArtifact(
+            path="vitest.config.ts", kind="must_not_exist", description="leftover vitest config from prior run"
+        ),
+        ExpectedArtifact(
+            path="vite.config.ts", kind="must_not_exist", description="leftover vite config from prior run"
+        ),
+        ExpectedArtifact(
+            path="node_modules", kind="must_not_exist", description="leftover node_modules from prior run"
+        ),
+        ExpectedArtifact(path="Cargo.toml", kind="must_not_exist", description="leftover Cargo.toml from prior run"),
+        ExpectedArtifact(path="Cargo.lock", kind="must_not_exist", description="leftover Cargo.lock from prior run"),
+        ExpectedArtifact(path="target", kind="must_not_exist", description="leftover Rust target/ from prior run"),
+        ExpectedArtifact(path="go.mod", kind="must_not_exist", description="leftover go.mod from prior run"),
+        ExpectedArtifact(path="go.sum", kind="must_not_exist", description="leftover go.sum from prior run"),
+        ExpectedArtifact(path="vendor", kind="must_not_exist", description="leftover Go vendor/ from prior run"),
+        ExpectedArtifact(path="pom.xml", kind="must_not_exist", description="leftover Maven pom.xml from prior run"),
+        ExpectedArtifact(
+            path="build.gradle.kts", kind="must_not_exist", description="leftover Gradle build from prior run"
+        ),
+        ExpectedArtifact(
+            path="pyproject.toml",
+            kind="must_not_exist",
+            description="leftover pyproject.toml from prior run (architect re-creates if Python is the chosen stack)",
+        ),
+        ExpectedArtifact(
+            path=".coverage", kind="must_not_exist", description="leftover coverage artifact from prior run"
+        ),
     )
 
 
@@ -852,10 +860,13 @@ def architecture_expectations() -> tuple[ExpectedArtifact, ...]:
     failure detail.
     """
     return (
-        ExpectedArtifact(path="docs/architecture.md", kind="file", non_empty=True,
-                         description="architecture document"),
-        ExpectedArtifact(path="docs/stack_contract.json", kind="stack_contract", non_empty=True,
-                         description="stack contract JSON with two-level subsystems[].components[] schema"),
+        ExpectedArtifact(path="docs/architecture.md", kind="file", non_empty=True, description="architecture document"),
+        ExpectedArtifact(
+            path="docs/stack_contract.json",
+            kind="stack_contract",
+            non_empty=True,
+            description="stack contract JSON with two-level subsystems[].components[] schema",
+        ),
     )
 
 
@@ -872,6 +883,7 @@ def qa_expectations() -> tuple[ExpectedArtifact, ...]:
     real findings.
     """
     return (
-        ExpectedArtifact(path="docs/qa_report.json", kind="json_file", non_empty=True,
-                         description="QA report JSON for Phase 6"),
+        ExpectedArtifact(
+            path="docs/qa_report.json", kind="json_file", non_empty=True, description="QA report JSON for Phase 6"
+        ),
     )

--- a/src/aise/runtime/safety_net.py
+++ b/src/aise/runtime/safety_net.py
@@ -115,6 +115,19 @@ class ExpectedArtifact:
     - ``"dir"`` — ``path`` must be a directory (exists + is_dir).
     - ``"file"`` — ``path`` must be a regular file; if ``non_empty`` is
       true, also requires size > 0.
+    - ``"json_file"`` — ``path`` must be a regular file containing
+      valid JSON; if ``non_empty`` is true, also requires size > 0.
+    - ``"stack_contract"`` — ``path`` must be a valid
+      ``docs/stack_contract.json`` with the new two-level schema:
+      a ``subsystems[]`` array, each entry with ``name`` /
+      ``src_dir`` / ``components[]``, where every
+      ``components[].file`` is prefixed by its parent's ``src_dir``.
+      Catches the "architect produced a flat 24-component list"
+      regression that this kind exists to prevent.
+    - ``"must_not_exist"`` — ``path`` must NOT exist on disk. Used to
+      catch leftover files from prior runs (e.g. a stale
+      ``package.json`` from a previous Phaser project that was never
+      cleaned up before a new run started).
     - ``"git_repo"`` — ``path`` must contain a ``.git`` entry (dir or
       worktree reference); other fields ignored.
     - ``"git_tag"`` — ``tag_name`` (required) must be present in the
@@ -275,12 +288,51 @@ def _repair_create_phase_tag(project_root: Path, ctx: dict[str, Any]) -> None:
         raise RuntimeError(f"git tag {tag} failed: {stderr[:200]}")
 
 
+def _repair_remove_leftover(project_root: Path, ctx: dict[str, Any]) -> None:
+    """Delete a leftover file that the ``must_not_exist`` check flagged.
+
+    A previous run (typically a project that was scaffolded with a
+    different stack — e.g. Phaser ``package.json`` — and never
+    cleaned) left a file at ``ctx["path"]``. We remove it so the new
+    run can scaffold its own version freely. ``ctx["path"]`` MUST be
+    a project-relative path; absolute paths are rejected as a safety
+    measure to prevent accidental host-filesystem deletion.
+    """
+    rel = str(ctx.get("path") or "").strip()
+    if not rel:
+        return
+    if rel.startswith("/") or ".." in rel.split("/"):
+        logger.warning(
+            "safety_net: refusing to remove leftover file with unsafe path %r",
+            rel,
+        )
+        return
+    target = (project_root / rel).resolve()
+    try:
+        target.relative_to(project_root.resolve())
+    except ValueError:
+        logger.warning(
+            "safety_net: refusing to remove leftover file outside project root: %s",
+            target,
+        )
+        return
+    if not target.exists():
+        return
+    if target.is_file() or target.is_symlink():
+        target.unlink()
+    elif target.is_dir():
+        import shutil
+        shutil.rmtree(target)
+    logger.info("safety_net: removed leftover %s", target)
+
+
 REPAIR_ACTIONS: dict[str, Callable[[Path, dict[str, Any]], None]] = {
     "missing_git_repo": _repair_git_init,
     "missing_gitignore": _repair_seed_gitignore,
     "missing_standard_subdirs": _repair_create_standard_subdirs,
     "uncommitted_changes": _repair_autocommit,
     "missing_phase_tag": _repair_create_phase_tag,
+    "leftover_file": _repair_remove_leftover,
 }
 
 
@@ -329,6 +381,110 @@ LAYER_A_INVARIANTS: dict[str, list[Callable[[Path], str | None]]] = {
 
 
 # ---------------------------------------------------------------------------
+# Stack-contract validation
+# ---------------------------------------------------------------------------
+
+
+# Soft cap on subsystem count. The architect's job is to roll up
+# components into a small number of architecturally meaningful
+# subsystems; if more than this slip through it usually means the
+# architect went back to flat-listing components. Exceeding the cap
+# does NOT fail the check (some legitimately large projects might
+# need more) — it triggers a logged warning that the orchestrator
+# can surface for human review.
+_SUBSYSTEM_COUNT_SOFT_CAP = 10
+
+
+def _stack_contract_valid(target: Path) -> bool:
+    """Validate ``docs/stack_contract.json`` against the new
+    two-level schema:
+
+    - File exists, parseable JSON, top level is an object.
+    - Has a non-empty ``subsystems`` array.
+    - Each subsystem entry has ``name`` (snake_case str), ``src_dir``
+      (str), ``components`` (list of dicts).
+    - Each component entry has ``name`` (str) and ``file`` (str
+      starting with the parent's ``src_dir``).
+
+    Soft warnings (logged, do not fail validation):
+    - Subsystem count exceeds ``_SUBSYSTEM_COUNT_SOFT_CAP``.
+    - Subsystem with zero components.
+
+    Hard failures cause the layer-B check to mark the artifact
+    missing, which in turn re-dispatches architect with the failure
+    detail.
+    """
+    import json as _json
+    if not target.is_file():
+        return False
+    try:
+        data = _json.loads(target.read_text(encoding="utf-8"))
+    except Exception:
+        return False
+    if not isinstance(data, dict):
+        return False
+    subsystems = data.get("subsystems")
+    if not isinstance(subsystems, list) or not subsystems:
+        # New schema requires a non-empty subsystems[]. Reject the
+        # legacy flat ``modules[]`` schema even though the loader
+        # tolerates it for in-flight projects — at validation time
+        # we want architect to upgrade.
+        logger.warning(
+            "stack_contract: missing or empty subsystems[] in %s "
+            "(legacy modules[] schema is deprecated; architect must "
+            "produce the two-level schema)",
+            target,
+        )
+        return False
+    for ss in subsystems:
+        if not isinstance(ss, dict):
+            return False
+        name = ss.get("name")
+        src_dir = ss.get("src_dir")
+        components = ss.get("components")
+        if not isinstance(name, str) or not name:
+            return False
+        if not isinstance(src_dir, str) or not src_dir:
+            return False
+        if not isinstance(components, list):
+            return False
+        if not components:
+            logger.warning(
+                "stack_contract: subsystem %r has zero components in %s",
+                name, target,
+            )
+        for comp in components:
+            if not isinstance(comp, dict):
+                return False
+            cname = comp.get("name")
+            cfile = comp.get("file")
+            if not isinstance(cname, str) or not cname:
+                return False
+            if not isinstance(cfile, str) or not cfile:
+                return False
+            # Each component file must live inside its parent
+            # subsystem's directory. This is the load-bearing check
+            # that prevents the architect from listing a "subsystem"
+            # but pointing every component at a sibling top-level
+            # path, which would re-create the flat layout under a
+            # different name.
+            if not cfile.startswith(src_dir.rstrip("/") + "/") and cfile != src_dir.rstrip("/"):
+                logger.warning(
+                    "stack_contract: component %r file %r not under "
+                    "subsystem src_dir %r",
+                    cname, cfile, src_dir,
+                )
+                return False
+    if len(subsystems) > _SUBSYSTEM_COUNT_SOFT_CAP:
+        logger.warning(
+            "stack_contract: %d subsystems exceeds soft cap of %d in "
+            "%s — architect may be flat-listing components again",
+            len(subsystems), _SUBSYSTEM_COUNT_SOFT_CAP, target,
+        )
+    return True
+
+
+# ---------------------------------------------------------------------------
 # Layer B evaluation
 # ---------------------------------------------------------------------------
 
@@ -350,6 +506,24 @@ def _artifact_present(project_root: Path, artifact: ExpectedArtifact) -> bool:
         if artifact.non_empty and target.stat().st_size == 0:
             return False
         return True
+    if artifact.kind == "json_file":
+        if not target.is_file():
+            return False
+        if artifact.non_empty and target.stat().st_size == 0:
+            return False
+        try:
+            import json as _json
+            _json.loads(target.read_text(encoding="utf-8"))
+        except Exception:
+            return False
+        return True
+    if artifact.kind == "stack_contract":
+        return _stack_contract_valid(target)
+    if artifact.kind == "must_not_exist":
+        # Inverted check: present means FAIL. Catches leftover files
+        # from earlier runs (e.g. stale package.json / node_modules from
+        # a prior project that never got cleaned up).
+        return not target.exists()
     if artifact.kind == "git_repo":
         return (project_root / ".git").exists()
     if artifact.kind == "git_tag":
@@ -390,6 +564,12 @@ def _repair_action_for_artifact(artifact: ExpectedArtifact) -> str | None:
         return "uncommitted_changes"
     if artifact.kind == "git_tag":
         return "missing_phase_tag"
+    if artifact.kind == "must_not_exist":
+        return "leftover_file"
+    if artifact.kind == "json_file":
+        return "missing_or_invalid_json"
+    if artifact.kind == "stack_contract":
+        return "missing_or_invalid_stack_contract"
     return None
 
 
@@ -496,7 +676,13 @@ def run_post_step_check(
             continue
         outcome.layer_b_missing.append(artifact)
         repair_key = _repair_action_for_artifact(artifact)
-        _run_repair(project_root, repair_key, artifact.describe(), "B", outcome, repair_ctx)
+        # Per-artifact repair context: must_not_exist needs the path
+        # to delete; git_tag needs the tag name; others use the shared
+        # repair_ctx unchanged.
+        per_artifact_ctx = dict(repair_ctx)
+        if artifact.kind == "must_not_exist":
+            per_artifact_ctx["path"] = artifact.path
+        _run_repair(project_root, repair_key, artifact.describe(), "B", outcome, per_artifact_ctx)
 
     # -- Layer A ------------------------------------------------------------
     # Only run layer A if layer B passed (or had nothing to check).
@@ -607,4 +793,85 @@ def scaffolding_expectations() -> tuple[ExpectedArtifact, ...]:
         ExpectedArtifact(path="config", kind="dir"),
         ExpectedArtifact(path="artifacts", kind="dir"),
         ExpectedArtifact(path="trace", kind="dir"),
+        # Leftover-file guards: nothing scaffolds these files yet, so
+        # if any are present they're carryover from a prior run on the
+        # same project_id (e.g. a Phaser package.json + node_modules
+        # that survived because the previous run wasn't fully reset).
+        # Letting them survive into a new run with a different stack
+        # produced project_7-tower's three-stacks-coexist failure
+        # mode. Repair = delete.
+        ExpectedArtifact(path="package.json", kind="must_not_exist",
+                         description="leftover package.json from prior run"),
+        ExpectedArtifact(path="package-lock.json", kind="must_not_exist",
+                         description="leftover npm lockfile from prior run"),
+        ExpectedArtifact(path="pnpm-lock.yaml", kind="must_not_exist",
+                         description="leftover pnpm lockfile from prior run"),
+        ExpectedArtifact(path="yarn.lock", kind="must_not_exist",
+                         description="leftover yarn lockfile from prior run"),
+        ExpectedArtifact(path="tsconfig.json", kind="must_not_exist",
+                         description="leftover tsconfig from prior run"),
+        ExpectedArtifact(path="vitest.config.ts", kind="must_not_exist",
+                         description="leftover vitest config from prior run"),
+        ExpectedArtifact(path="vite.config.ts", kind="must_not_exist",
+                         description="leftover vite config from prior run"),
+        ExpectedArtifact(path="node_modules", kind="must_not_exist",
+                         description="leftover node_modules from prior run"),
+        ExpectedArtifact(path="Cargo.toml", kind="must_not_exist",
+                         description="leftover Cargo.toml from prior run"),
+        ExpectedArtifact(path="Cargo.lock", kind="must_not_exist",
+                         description="leftover Cargo.lock from prior run"),
+        ExpectedArtifact(path="target", kind="must_not_exist",
+                         description="leftover Rust target/ from prior run"),
+        ExpectedArtifact(path="go.mod", kind="must_not_exist",
+                         description="leftover go.mod from prior run"),
+        ExpectedArtifact(path="go.sum", kind="must_not_exist",
+                         description="leftover go.sum from prior run"),
+        ExpectedArtifact(path="vendor", kind="must_not_exist",
+                         description="leftover Go vendor/ from prior run"),
+        ExpectedArtifact(path="pom.xml", kind="must_not_exist",
+                         description="leftover Maven pom.xml from prior run"),
+        ExpectedArtifact(path="build.gradle.kts", kind="must_not_exist",
+                         description="leftover Gradle build from prior run"),
+        ExpectedArtifact(path="pyproject.toml", kind="must_not_exist",
+                         description="leftover pyproject.toml from prior run "
+                                     "(architect re-creates if Python is the chosen stack)"),
+        ExpectedArtifact(path=".coverage", kind="must_not_exist",
+                         description="leftover coverage artifact from prior run"),
+    )
+
+
+def architecture_expectations() -> tuple[ExpectedArtifact, ...]:
+    """The layer-B expectations the architect agent's Phase-2 dispatch
+    must satisfy. Currently:
+    - docs/architecture.md exists and is non-empty
+    - docs/stack_contract.json exists and is valid JSON
+
+    Callers in ``project_session.py`` invoke ``run_post_step_check``
+    with this list after the architect dispatch returns. Missing /
+    malformed contract triggers an architect re-dispatch with the
+    failure detail.
+    """
+    return (
+        ExpectedArtifact(path="docs/architecture.md", kind="file", non_empty=True,
+                         description="architecture document"),
+        ExpectedArtifact(path="docs/stack_contract.json", kind="stack_contract", non_empty=True,
+                         description="stack contract JSON with two-level subsystems[].components[] schema"),
+    )
+
+
+def qa_expectations() -> tuple[ExpectedArtifact, ...]:
+    """The layer-B expectations the qa_engineer agent's Phase-5
+    dispatch must satisfy. Currently:
+    - docs/qa_report.json exists and is valid JSON
+
+    Callers in ``project_session.py`` invoke ``run_post_step_check``
+    with this list after the QA dispatch returns. Missing /
+    malformed report triggers a QA re-dispatch with the failure
+    detail. Phase 6 reads the report verbatim — without this guard
+    a flaky pytest run in Phase 6 would silently overwrite QA's
+    real findings.
+    """
+    return (
+        ExpectedArtifact(path="docs/qa_report.json", kind="json_file", non_empty=True,
+                         description="QA report JSON for Phase 6"),
     )

--- a/src/aise/runtime/tool_primitives.py
+++ b/src/aise/runtime/tool_primitives.py
@@ -378,7 +378,9 @@ def _build_component_implementation_task(
 
     upper_initial = (cname[:1].upper() + cname[1:]) if cname else "?"
     test_file = component.get("test_file") or toolchain["test_path_pattern"].format(
-        subsystem=sname, component=cname, Component=upper_initial,
+        subsystem=sname,
+        component=cname,
+        Component=upper_initial,
     )
     interface_path = _interface_module_path(language, sname, src_dir)
 
@@ -388,13 +390,13 @@ def _build_component_implementation_task(
 
     test_cmd = toolchain["test_cmd"].format_map(
         _PlaceholderDict(
-            test_path=test_file, component=cname,
-            Component=upper_initial, subsystem=sname,
+            test_path=test_file,
+            component=cname,
+            Component=upper_initial,
+            subsystem=sname,
         )
     )
-    static_check = toolchain["static_check"].format_map(
-        _PlaceholderDict(src_path=cfile, subsystem=sname)
-    )
+    static_check = toolchain["static_check"].format_map(_PlaceholderDict(src_path=cfile, subsystem=sname))
 
     return (
         f"## Component implementation task: {sname}.{cname}\n\n"
@@ -464,14 +466,12 @@ def _build_subsystem_task_description(
         # language's pattern. If the contract already specifies a
         # test_file we honour it; otherwise compute one.
         test_file = c.get("test_file") or toolchain["test_path_pattern"].format(
-            subsystem=name, component=cname,
+            subsystem=name,
+            component=cname,
             Component=cname[:1].upper() + cname[1:],
         )
         component_lines.append(
-            f"  - {cname}\n"
-            f"      source: {cfile}\n"
-            f"      test:   {test_file}\n"
-            f"      responsibility: {cresp}"
+            f"  - {cname}\n      source: {cfile}\n      test:   {test_file}\n      responsibility: {cresp}"
         )
     components_block = "\n".join(component_lines) if component_lines else "  (no components declared)"
 
@@ -484,10 +484,13 @@ def _build_subsystem_task_description(
     class _PlaceholderDict(dict):
         def __missing__(self, key: str) -> str:
             return f"<{key}>"
+
     test_cmd_template = toolchain["test_cmd"].format_map(
         _PlaceholderDict(
-            test_path="<test file>", component="<component>",
-            Component="<Component>", subsystem=name,
+            test_path="<test file>",
+            component="<component>",
+            Component="<Component>",
+            subsystem=name,
         )
     )
     static_check_template = toolchain["static_check"].format_map(
@@ -546,8 +549,7 @@ def _load_stack_contract_block(project_root: Path | None) -> str:
     if not isinstance(data, dict):
         return ""
     lines = [
-        "=== STACK CONTRACT (architect-defined, FOLLOW EXACTLY — "
-        "do NOT translate to another language/framework) ===",
+        "=== STACK CONTRACT (architect-defined, FOLLOW EXACTLY — do NOT translate to another language/framework) ===",
     ]
     for key in _STACK_CONTRACT_KEYS:
         if key not in data:
@@ -1093,23 +1095,26 @@ def make_dispatch_tools(ctx: ToolContext) -> list[BaseTool]:
         """
         contract = _load_stack_contract_data(ctx.project_root)
         if contract is None:
-            return json.dumps({
-                "status": "failed",
-                "error": (
-                    "docs/stack_contract.json missing or unparseable. "
-                    "Dispatch architect first to produce it."
-                ),
-            })
+            return json.dumps(
+                {
+                    "status": "failed",
+                    "error": (
+                        "docs/stack_contract.json missing or unparseable. Dispatch architect first to produce it."
+                    ),
+                }
+            )
         subsystems = contract.get("subsystems")
         if not isinstance(subsystems, list) or not subsystems:
-            return json.dumps({
-                "status": "failed",
-                "error": (
-                    "docs/stack_contract.json has no subsystems[] array. "
-                    "Architect must use the two-level subsystems[].components[] "
-                    "schema (legacy flat modules[] is no longer supported here)."
-                ),
-            })
+            return json.dumps(
+                {
+                    "status": "failed",
+                    "error": (
+                        "docs/stack_contract.json has no subsystems[] array. "
+                        "Architect must use the two-level subsystems[].components[] "
+                        "schema (legacy flat modules[] is no longer supported here)."
+                    ),
+                }
+            )
 
         max_workers = max(1, ctx.config.safety_limits.max_concurrent_subsystem_dispatches)
         language = (contract.get("language") or "python").lower()
@@ -1139,31 +1144,35 @@ def make_dispatch_tools(ctx: ToolContext) -> list[BaseTool]:
                 cname = comp.get("name", "?")
                 upper_initial = (cname[:1].upper() + cname[1:]) if cname else "?"
                 tfile = comp.get("test_file") or toolchain["test_path_pattern"].format(
-                    subsystem=sname, component=cname, Component=upper_initial,
+                    subsystem=sname,
+                    component=cname,
+                    Component=upper_initial,
                 )
-                component_items.append({
-                    "subsystem": sname,
-                    "component": cname,
-                    "task_description": _build_component_implementation_task(
-                        ss, comp, contract, phase=phase
-                    ),
-                    "step_id": f"phase_{phase}_component_{sname}_{cname}",
-                    "phase": f"{phase}_component",
-                    "expected_artifacts": [p for p in (cf, tfile) if p],
-                })
+                component_items.append(
+                    {
+                        "subsystem": sname,
+                        "component": cname,
+                        "task_description": _build_component_implementation_task(ss, comp, contract, phase=phase),
+                        "step_id": f"phase_{phase}_component_{sname}_{cname}",
+                        "phase": f"{phase}_component",
+                        "expected_artifacts": [p for p in (cf, tfile) if p],
+                    }
+                )
             skel_expected.append(interface_path)
 
-            subsystem_plans.append({
-                "subsystem": sname,
-                "skeleton": {
+            subsystem_plans.append(
+                {
                     "subsystem": sname,
-                    "task_description": _build_subsystem_skeleton_task(ss, contract, phase=phase),
-                    "step_id": f"phase_{phase}_skeleton_{sname}",
-                    "phase": f"{phase}_skeleton",
-                    "expected_artifacts": skel_expected,
-                },
-                "components": component_items,
-            })
+                    "skeleton": {
+                        "subsystem": sname,
+                        "task_description": _build_subsystem_skeleton_task(ss, contract, phase=phase),
+                        "step_id": f"phase_{phase}_skeleton_{sname}",
+                        "phase": f"{phase}_skeleton",
+                        "expected_artifacts": skel_expected,
+                    },
+                    "components": component_items,
+                }
+            )
 
         # Cross-subsystem global throttle. Outer (subsystem) and inner
         # (component) executors are nested, so a naïve ``max_workers``
@@ -1176,13 +1185,15 @@ def make_dispatch_tools(ctx: ToolContext) -> list[BaseTool]:
 
         def _run_dispatch(item: dict[str, Any]) -> dict[str, Any]:
             with global_throttle:
-                raw = dispatch_task.invoke({
-                    "agent_name": agent_name,
-                    "task_description": item["task_description"],
-                    "step_id": item["step_id"],
-                    "phase": item["phase"],
-                    "expected_artifacts": item["expected_artifacts"] or None,
-                })
+                raw = dispatch_task.invoke(
+                    {
+                        "agent_name": agent_name,
+                        "task_description": item["task_description"],
+                        "step_id": item["step_id"],
+                        "phase": item["phase"],
+                        "expected_artifacts": item["expected_artifacts"] or None,
+                    }
+                )
             try:
                 parsed = json.loads(raw)
             except Exception:
@@ -1264,24 +1275,27 @@ def make_dispatch_tools(ctx: ToolContext) -> list[BaseTool]:
         comp_ok = sum(1 for r in component_results if r.get("status") == "completed")
         comp_fail = sum(1 for r in component_results if r.get("status") == "failed")
 
-        return json.dumps({
-            "phase": phase,
-            "agent_name": agent_name,
-            "subsystems_dispatched": len(subsystem_plans),
-            "components_dispatched": len(component_results),
-            "max_concurrent": max_workers,
-            "skeleton_completed": skel_ok,
-            "skeleton_failed": skel_fail,
-            "components_completed": comp_ok,
-            "components_failed": comp_fail,
-            # Aggregate roll-up across both stages so callers that just
-            # want pass/fail counts don't have to add the four numbers
-            # themselves.
-            "completed": skel_ok + comp_ok,
-            "failed": skel_fail + comp_fail,
-            "skeleton_results": skeleton_results,
-            "results": component_results,
-        }, ensure_ascii=False)
+        return json.dumps(
+            {
+                "phase": phase,
+                "agent_name": agent_name,
+                "subsystems_dispatched": len(subsystem_plans),
+                "components_dispatched": len(component_results),
+                "max_concurrent": max_workers,
+                "skeleton_completed": skel_ok,
+                "skeleton_failed": skel_fail,
+                "components_completed": comp_ok,
+                "components_failed": comp_fail,
+                # Aggregate roll-up across both stages so callers that just
+                # want pass/fail counts don't have to add the four numbers
+                # themselves.
+                "completed": skel_ok + comp_ok,
+                "failed": skel_fail + comp_fail,
+                "skeleton_results": skeleton_results,
+                "results": component_results,
+            },
+            ensure_ascii=False,
+        )
 
     return [dispatch_task, dispatch_tasks_parallel, dispatch_subsystems]
 

--- a/src/aise/runtime/tool_primitives.py
+++ b/src/aise/runtime/tool_primitives.py
@@ -36,6 +36,7 @@ manager, the project root, the safety limits, the event sink). Each
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import threading
 import uuid
@@ -128,6 +129,456 @@ def _build_retry_prompt(original_task: str, previous_response: str) -> str:
     else:
         echoed = prev[-_RETRY_PREV_MAX_BYTES:]
     return _RETRY_CONTEXT_TEMPLATE.format(prev=echoed, task=original_task)
+
+
+# Tech-stack contract that the architect writes in Phase 2 and that
+# every downstream worker dispatch must respect. Worker prompts get
+# this block prepended so the orchestrator LLM cannot translate the
+# language / framework / test runner into something else.
+#
+# Two structural fields beyond the simple stack identifiers:
+#   - ``subsystems`` (NEW SCHEMA, preferred) — a list of dicts with
+#     ``name`` / ``src_dir`` / ``responsibilities`` /
+#     ``components[]``. Each subsystem is one ``src/<name>/`` directory;
+#     each component is a file inside it. This is the layout the
+#     architect must produce going forward.
+#   - ``modules`` (LEGACY) — a flat list of module dicts with
+#     ``name`` / ``src_dir``. Emitted by the old prompt that
+#     conflated "subsystem" and "component" levels. Loader still
+#     accepts it (with a deprecation marker in the rendered block)
+#     so any in-flight projects from before the schema upgrade keep
+#     dispatching cleanly.
+_STACK_CONTRACT_KEYS = (
+    "language",
+    "runtime",
+    "framework_backend",
+    "framework_frontend",
+    "package_manager",
+    "project_config_file",
+    "test_runner",
+    "static_analyzer",
+    "entry_point",
+    "run_command",
+    "ui_required",
+    "ui_kind",
+)
+
+
+def _render_subsystems_summary(subsystems: list[Any]) -> str:
+    """Render the ``subsystems`` list as a one-line-per-subsystem
+    summary suitable for worker prompts. Components are shown as a
+    count, not enumerated — keeping the contract block short. A
+    well-formed entry is ``{"name": str, "components": [...]}``;
+    malformed entries fall back to a placeholder line so the block
+    is always parseable downstream.
+    """
+    parts = []
+    for ss in subsystems:
+        if not isinstance(ss, dict):
+            parts.append("  - <invalid subsystem entry>")
+            continue
+        name = ss.get("name", "?")
+        src_dir = ss.get("src_dir", "")
+        components = ss.get("components", []) or []
+        n = len(components) if isinstance(components, list) else 0
+        suffix = f" ({n} component{'s' if n != 1 else ''})" if n else ""
+        path_suffix = f" [{src_dir}]" if src_dir else ""
+        parts.append(f"  - {name}{path_suffix}{suffix}")
+    return "\n".join(parts) if parts else "  (no subsystems declared)"
+
+
+def _load_stack_contract_data(project_root: Path | None) -> dict[str, Any] | None:
+    """Read and parse ``docs/stack_contract.json`` from the project
+    root. Returns ``None`` when the file is missing, malformed, or not
+    a JSON object. Used by ``dispatch_subsystems`` to discover the
+    fan-out targets without going through the orchestrator LLM.
+    """
+    if project_root is None:
+        return None
+    contract_path = project_root / "docs" / "stack_contract.json"
+    if not contract_path.is_file():
+        return None
+    try:
+        data = json.loads(contract_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+# Per-language test-runner / static-analyzer rows. Used by
+# ``dispatch_subsystems`` to build a deterministic developer task
+# description from the architect's stack contract — no LLM
+# decision-making in the loop.
+_LANGUAGE_TOOLCHAIN: dict[str, dict[str, str]] = {
+    "python": {
+        "test_cmd": "python -m pytest {test_path} -q --tb=short",
+        "test_path_pattern": "tests/{subsystem}/test_{component}.py",
+        "src_path_pattern": "src/{subsystem}/{component}.py",
+        "static_check": "ruff check {src_path} && mypy {src_path}",
+    },
+    "typescript": {
+        "test_cmd": "npx vitest run {test_path}",
+        "test_path_pattern": "tests/{subsystem}/{component}.test.ts",
+        "src_path_pattern": "src/{subsystem}/{component}.ts",
+        "static_check": "eslint {src_path} && npx tsc --noEmit",
+    },
+    "javascript": {
+        "test_cmd": "npx vitest run {test_path}",
+        "test_path_pattern": "tests/{subsystem}/{component}.test.js",
+        "src_path_pattern": "src/{subsystem}/{component}.js",
+        "static_check": "eslint {src_path}",
+    },
+    "go": {
+        "test_cmd": "go test ./internal/{subsystem}/...",
+        "test_path_pattern": "internal/{subsystem}/{component}_test.go",
+        "src_path_pattern": "internal/{subsystem}/{component}.go",
+        "static_check": "go vet ./internal/{subsystem}/... && gofmt -l {src_path}",
+    },
+    "rust": {
+        "test_cmd": "cargo test --test {component}",
+        "test_path_pattern": "tests/{subsystem}/{component}.rs",
+        "src_path_pattern": "src/{subsystem}/{component}.rs",
+        "static_check": "cargo clippy -- -D warnings && cargo check",
+    },
+    "java": {
+        "test_cmd": "mvn test -Dtest={Component}Test",
+        "test_path_pattern": "src/test/java/{subsystem}/{Component}Test.java",
+        "src_path_pattern": "src/main/java/{subsystem}/{Component}.java",
+        "static_check": "mvn -q compile",
+    },
+}
+
+
+# Per-language convention for the "subsystem interface module" — the
+# file the skeleton phase writes so sibling subsystems and downstream
+# component dispatches have a single, stable place to import the
+# subsystem's public API from. Keeping this language-keyed avoids
+# Python-isms leaking into TS/Go/Rust skeleton tasks.
+_INTERFACE_FILENAME: dict[str, str] = {
+    "python": "__init__.py",
+    "py": "__init__.py",
+    "typescript": "index.ts",
+    "ts": "index.ts",
+    "javascript": "index.js",
+    "js": "index.js",
+    "go": "doc.go",
+    "rust": "mod.rs",
+    "java": "package-info.java",
+}
+
+
+def _interface_module_path(language: str, subsystem_name: str, src_dir: str) -> str:
+    """Return the conventional public-API module path for ``subsystem``.
+
+    The skeleton phase writes this file so component dispatches and
+    sibling subsystems can ``import`` against a single declared API
+    surface instead of fishing through individual component files.
+    """
+    base = (src_dir or f"src/{subsystem_name}").rstrip("/")
+    fname = _INTERFACE_FILENAME.get(language.lower(), "__init__.py")
+    return f"{base}/{fname}"
+
+
+def _build_subsystem_skeleton_task(
+    subsystem: dict[str, Any],
+    contract: dict[str, Any],
+    phase: str,
+) -> str:
+    """Render the *stage 1* developer task: scaffold module files and
+    inter-module interfaces for one subsystem, WITHOUT implementing
+    bodies or tests.
+
+    The output is small and deterministic (no LLM in this loop), so the
+    dispatch budget per subsystem stays well under the recursion limit
+    even for very weak workers — the only LLM decisions are *which*
+    types/signatures to declare for each component, derived from
+    ``docs/architecture.md`` and the component's responsibility.
+    """
+    name = subsystem.get("name", "?")
+    src_dir = subsystem.get("src_dir", "")
+    responsibilities = subsystem.get("responsibilities", "")
+    components = subsystem.get("components", []) or []
+    language = (contract.get("language") or "python").lower()
+
+    component_lines: list[str] = []
+    for c in components:
+        if not isinstance(c, dict):
+            continue
+        cname = c.get("name", "?")
+        cfile = c.get("file", "")
+        cresp = c.get("responsibility", "")
+        component_lines.append(f"  - {cname}\n      file: {cfile}\n      responsibility: {cresp}")
+    components_block = "\n".join(component_lines) if component_lines else "  (no components declared)"
+    interface_path = _interface_module_path(language, name, src_dir)
+
+    return (
+        f"## Subsystem skeleton task: {name}\n\n"
+        f"Phase: {phase} (stage 1: skeletons + interfaces)\n"
+        f"Subsystem directory: {src_dir}\n"
+        f"Subsystem responsibility: {responsibilities}\n"
+        f"Project language: {language}\n\n"
+        f"### Components in this subsystem\n\n"
+        f"{components_block}\n\n"
+        f"### What to do (skeleton ONLY — NO logic, NO tests)\n\n"
+        f"Read ``docs/architecture.md`` first to understand this subsystem's\n"
+        f"role and how it talks to siblings. Then:\n\n"
+        f"1. Create the subsystem directory ({src_dir}) if it does not\n"
+        f"   already exist.\n"
+        f"2. For EACH component above, create the source file at the\n"
+        f"   listed path with **only**:\n"
+        f"     - module-level docstring naming the component and its\n"
+        f"       responsibility;\n"
+        f"     - public type / class / function declarations with full\n"
+        f"       signatures and docstrings (no implementation — bodies\n"
+        f"       must be ``pass`` / ``raise NotImplementedError`` /\n"
+        f"       language-equivalent stubs);\n"
+        f"     - the imports the public API requires.\n"
+        f"3. Create / update the subsystem interface module at\n"
+        f"   ``{interface_path}`` so sibling subsystems can import this\n"
+        f"   subsystem's public API from a single place. Re-export every\n"
+        f"   component's public types / classes / functions and add a\n"
+        f"   one-paragraph docstring describing the cross-subsystem\n"
+        f"   contracts the architecture defines for this module.\n"
+        f"4. Do NOT write any test files. Do NOT fill in function bodies.\n"
+        f"   The next stage dispatches one task per component to do TDD\n"
+        f"   in parallel against the skeletons you produced.\n\n"
+        f"Stay strictly inside ``{src_dir}``. Other subsystems' skeletons\n"
+        f"are being produced in parallel by sibling dispatches — do not\n"
+        f"touch their files.\n"
+    )
+
+
+def _build_component_implementation_task(
+    subsystem: dict[str, Any],
+    component: dict[str, Any],
+    contract: dict[str, Any],
+    phase: str,
+) -> str:
+    """Render the *stage 2* developer task: implement ONE component
+    (test + source body) on top of the skeleton produced in stage 1.
+
+    Single-component scope keeps each dispatch's recursion budget
+    bounded, so a 10-component subsystem becomes 10 small dispatches
+    that fan out concurrently instead of one mega-dispatch that runs
+    out of recursion / context budget after the 7th component.
+    """
+    sname = subsystem.get("name", "?")
+    src_dir = subsystem.get("src_dir", "")
+    cname = component.get("name", "?")
+    cfile = component.get("file", "")
+    cresp = component.get("responsibility", "")
+    language = (contract.get("language") or "python").lower()
+    toolchain = _LANGUAGE_TOOLCHAIN.get(language, _LANGUAGE_TOOLCHAIN["python"])
+    test_runner = contract.get("test_runner", "")
+    static_analyzer = contract.get("static_analyzer", "")
+    if isinstance(static_analyzer, list):
+        static_analyzer = " ; ".join(str(s) for s in static_analyzer)
+
+    upper_initial = (cname[:1].upper() + cname[1:]) if cname else "?"
+    test_file = component.get("test_file") or toolchain["test_path_pattern"].format(
+        subsystem=sname, component=cname, Component=upper_initial,
+    )
+    interface_path = _interface_module_path(language, sname, src_dir)
+
+    class _PlaceholderDict(dict):
+        def __missing__(self, key: str) -> str:
+            return f"<{key}>"
+
+    test_cmd = toolchain["test_cmd"].format_map(
+        _PlaceholderDict(
+            test_path=test_file, component=cname,
+            Component=upper_initial, subsystem=sname,
+        )
+    )
+    static_check = toolchain["static_check"].format_map(
+        _PlaceholderDict(src_path=cfile, subsystem=sname)
+    )
+
+    return (
+        f"## Component implementation task: {sname}.{cname}\n\n"
+        f"Phase: {phase} (stage 2: per-component TDD)\n"
+        f"Subsystem directory: {src_dir}\n"
+        f"Component responsibility: {cresp}\n"
+        f"Project language: {language}\n"
+        f"Test runner: {test_runner}\n"
+        f"Static analyzer: {static_analyzer}\n\n"
+        f"### Files\n"
+        f"  source:    {cfile}   (skeleton already exists — fill in bodies)\n"
+        f"  test:      {test_file}\n"
+        f"  interface: {interface_path}   (do NOT modify; import from here\n"
+        f"             when you need types / functions from sibling\n"
+        f"             components in the same subsystem)\n\n"
+        f"### Workflow (strict TDD, ONE component only)\n\n"
+        f"1. RED — write the test file at the listed path. Cover the\n"
+        f"   public API the skeleton already declares for this component.\n"
+        f"2. GREEN — replace the stub bodies in ``{cfile}`` with real\n"
+        f"   implementations. Keep the public API EXACTLY as the\n"
+        f"   skeleton declared it; sibling components / subsystems\n"
+        f"   already import that contract.\n"
+        f"3. VERIFY — run the per-file test command:\n"
+        f"     {test_cmd}\n"
+        f"4. INSPECT — run the static analyzer on the source file:\n"
+        f"     {static_check}\n"
+        f"   Fix every finding before returning.\n"
+        f"5. Up to 3 fix attempts, then return.\n\n"
+        f"DO NOT modify any source file other than ``{cfile}`` and ``{test_file}``.\n"
+        f"All other components in this subsystem are being implemented\n"
+        f"concurrently by sibling dispatches; touching them races.\n"
+        f"Cross-component imports MUST go through the interface module\n"
+        f"``{interface_path}`` so the skeleton's contract stays the\n"
+        f"single source of truth.\n"
+    )
+
+
+def _build_subsystem_task_description(
+    subsystem: dict[str, Any],
+    contract: dict[str, Any],
+    phase: str,
+) -> str:
+    """Render the developer task description for one subsystem
+    deterministically from the stack contract. The LLM is NOT in
+    this loop — the resulting text is stable, complete, and
+    multilingual based on ``contract.language``.
+    """
+    name = subsystem.get("name", "?")
+    src_dir = subsystem.get("src_dir", "")
+    responsibilities = subsystem.get("responsibilities", "")
+    components = subsystem.get("components", []) or []
+    language = (contract.get("language") or "python").lower()
+    toolchain = _LANGUAGE_TOOLCHAIN.get(language, _LANGUAGE_TOOLCHAIN["python"])
+    test_runner = contract.get("test_runner", "")
+    static_analyzer = contract.get("static_analyzer", "")
+    if isinstance(static_analyzer, list):
+        static_analyzer = " ; ".join(str(s) for s in static_analyzer)
+
+    component_lines = []
+    for c in components:
+        if not isinstance(c, dict):
+            continue
+        cname = c.get("name", "?")
+        cfile = c.get("file", "")
+        cresp = c.get("responsibility", "")
+        # Derive test path from the source file path using the
+        # language's pattern. If the contract already specifies a
+        # test_file we honour it; otherwise compute one.
+        test_file = c.get("test_file") or toolchain["test_path_pattern"].format(
+            subsystem=name, component=cname,
+            Component=cname[:1].upper() + cname[1:],
+        )
+        component_lines.append(
+            f"  - {cname}\n"
+            f"      source: {cfile}\n"
+            f"      test:   {test_file}\n"
+            f"      responsibility: {cresp}"
+        )
+    components_block = "\n".join(component_lines) if component_lines else "  (no components declared)"
+
+    # Render the per-component test/static-analysis commands as
+    # *templates* (with ``<placeholder>`` slots) rather than concrete
+    # calls — the developer fills them in per component when they
+    # actually run them. Using a placeholder dict keeps any unknown
+    # template variable in the toolchain row from raising KeyError;
+    # extras are simply rendered as their literal name.
+    class _PlaceholderDict(dict):
+        def __missing__(self, key: str) -> str:
+            return f"<{key}>"
+    test_cmd_template = toolchain["test_cmd"].format_map(
+        _PlaceholderDict(
+            test_path="<test file>", component="<component>",
+            Component="<Component>", subsystem=name,
+        )
+    )
+    static_check_template = toolchain["static_check"].format_map(
+        _PlaceholderDict(src_path="<source file>", subsystem=name)
+    )
+
+    return (
+        f"## Subsystem implementation task: {name}\n\n"
+        f"Phase: {phase}\n"
+        f"Subsystem directory: {src_dir}\n"
+        f"Subsystem responsibility: {responsibilities}\n"
+        f"Project language: {language}\n"
+        f"Test runner: {test_runner}\n"
+        f"Static analyzer: {static_analyzer}\n\n"
+        f"### Components to implement (one source file + one test file each)\n\n"
+        f"{components_block}\n\n"
+        f"### Workflow (strict TDD, per component)\n\n"
+        f"For EACH component above, in order:\n"
+        f"1. RED — write the test file at the listed path. Cover the\n"
+        f"   public API the component's responsibility implies.\n"
+        f"2. GREEN — write the source file at the listed path.\n"
+        f"3. VERIFY — run the per-file test command:\n"
+        f"     {test_cmd_template}\n"
+        f"4. INSPECT — run the static analyzer on the source file:\n"
+        f"     {static_check_template}\n"
+        f"   Fix every finding before moving to the next component.\n"
+        f"5. Up to 3 fix attempts per component, then move on.\n\n"
+        f"All components share the subsystem directory ({src_dir}) — design\n"
+        f"the public API across them as a coherent module, not isolated\n"
+        f"islands. Read the architecture doc (docs/architecture.md) for\n"
+        f"the subsystem's role in the larger system.\n\n"
+        f"Do NOT touch source files outside {src_dir}. Other subsystems are\n"
+        f"being developed in parallel by sibling dispatches.\n"
+    )
+
+
+def _load_stack_contract_block(project_root: Path | None) -> str:
+    """Read ``docs/stack_contract.json`` and render it as a fenced
+    block to prepend to worker prompts. Returns an empty string if
+    the file is missing or malformed (compatible with older projects
+    that never produced one).
+
+    Supports both the new ``subsystems[]`` schema (preferred) and
+    the legacy ``modules[]`` schema (rendered with a deprecation
+    marker so the orchestrator can flag it for re-architecting).
+    """
+    if project_root is None:
+        return ""
+    contract_path = project_root / "docs" / "stack_contract.json"
+    if not contract_path.is_file():
+        return ""
+    try:
+        data = json.loads(contract_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return ""
+    if not isinstance(data, dict):
+        return ""
+    lines = [
+        "=== STACK CONTRACT (architect-defined, FOLLOW EXACTLY — "
+        "do NOT translate to another language/framework) ===",
+    ]
+    for key in _STACK_CONTRACT_KEYS:
+        if key not in data:
+            continue
+        value = data[key]
+        if isinstance(value, list):
+            value = ", ".join(str(v) for v in value)
+        lines.append(f"{key}: {value}")
+    # Subsystem layout — prefer the new two-level schema; fall back
+    # to the legacy flat schema with a clearly-marked deprecation
+    # note so anyone reading the worker prompt sees it should be
+    # re-architected.
+    subsystems = data.get("subsystems")
+    legacy_modules = data.get("modules")
+    if isinstance(subsystems, list) and subsystems:
+        lines.append("subsystems:")
+        lines.append(_render_subsystems_summary(subsystems))
+    elif isinstance(legacy_modules, list) and legacy_modules:
+        lines.append(
+            "subsystems: (LEGACY FLAT 'modules' SCHEMA — should be "
+            "re-architected into nested subsystems[].components[])"
+        )
+        for mod in legacy_modules:
+            if isinstance(mod, dict):
+                name = mod.get("name", "?")
+                src_dir = mod.get("src_dir", "")
+                lines.append(f"  - {name} [{src_dir}]")
+            else:
+                lines.append("  - <invalid module entry>")
+    lines.append("=== END STACK CONTRACT ===")
+    return "\n".join(lines)
 
 
 # -- Context ---------------------------------------------------------------
@@ -426,13 +877,37 @@ def make_dispatch_tools(ctx: ToolContext) -> list[BaseTool]:
                     }
                 )
 
-            # Build the prompt the worker actually sees. Prepend the
-            # project's original user requirement (if the session set
-            # one on ctx) so agents have a stable signal to mirror the
-            # user's natural language when writing docs/*.md. The
-            # already-emitted ``request_msg`` keeps the unprefixed
-            # ``task_description`` in its payload so the UI/log is not
-            # bloated by N copies of the same requirement block.
+            def _on_token_usage(counts: dict[str, int]) -> None:
+                ctx.emit(
+                    {
+                        "type": "token_usage",
+                        "taskId": task_id,
+                        "agent": agent_name,
+                        "timestamp": _now(),
+                        "input_tokens": int(counts.get("input_tokens", 0) or 0),
+                        "output_tokens": int(counts.get("output_tokens", 0) or 0),
+                        "total_tokens": int(counts.get("total_tokens", 0) or 0),
+                    }
+                )
+
+            # Build the prompt the worker actually sees. Two prefixes
+            # are prepended (when available) so workers have stable
+            # context the orchestrator LLM cannot strip:
+            #
+            #   1. ORIGINAL USER REQUIREMENT — the raw user text, used
+            #      by doc-producing agents to mirror its natural
+            #      language in any docs/*.md they write.
+            #   2. STACK CONTRACT — the architect's pinned language /
+            #      framework / test-runner / entry-point choices,
+            #      loaded from docs/stack_contract.json. This stops
+            #      orchestrator dispatches from "translating" the
+            #      stack into a different language (e.g. Node→Python)
+            #      because the worker now has the architect's
+            #      authoritative choices in its prompt.
+            #
+            # The already-emitted ``request_msg`` keeps the
+            # unprefixed ``task_description`` in its payload so the
+            # UI/log is not bloated by N copies of these blocks.
             worker_prompt = task_description
             if ctx.original_requirement:
                 worker_prompt = (
@@ -440,13 +915,17 @@ def make_dispatch_tools(ctx: ToolContext) -> list[BaseTool]:
                     "(preserve this natural language in all docs/*.md) ===\n"
                     f"{ctx.original_requirement}\n"
                     "=== END ORIGINAL REQUIREMENT ===\n\n"
-                    f"{task_description}"
+                    f"{worker_prompt}"
                 )
+            stack_block = _load_stack_contract_block(ctx.project_root)
+            if stack_block:
+                worker_prompt = f"{stack_block}\n\n{worker_prompt}"
 
             # First attempt.
             result = dispatch_rt.handle_message(
                 worker_prompt,
                 on_todos_update=_on_todos_update,
+                on_token_usage=_on_token_usage,
             )
 
             # Context-augmented retry loop. Triggers in two cases, both
@@ -482,6 +961,7 @@ def make_dispatch_tools(ctx: ToolContext) -> list[BaseTool]:
                 result = dispatch_rt.handle_message(
                     retry_prompt,
                     on_todos_update=_on_todos_update,
+                    on_token_usage=_on_token_usage,
                 )
 
             output_len = len(result)
@@ -579,7 +1059,231 @@ def make_dispatch_tools(ctx: ToolContext) -> list[BaseTool]:
             ensure_ascii=False,
         )
 
-    return [dispatch_task, dispatch_tasks_parallel]
+    @tool
+    def dispatch_subsystems(phase: str = "implementation", agent_name: str = "developer") -> str:
+        """Two-stage subsystem fan-out: skeletons first, then per-component
+        TDD in full parallel.
+
+        Stage 1 (sequential within the subsystem, parallel across
+        subsystems): dispatch one *skeleton* task per subsystem. Each
+        worker creates the source files with public API
+        types/signatures/docstrings populated, plus an interface module
+        re-exporting the subsystem's public API — but NO logic and NO
+        tests. This guarantees inter-module contracts are committed to
+        disk before any component is implemented.
+
+        Stage 2 (full fan-out): once every skeleton is on disk, dispatch
+        one *component implementation* task per component across every
+        subsystem. Each dispatch only owns one ``src_dir/<component>``
+        file pair (source + test), so its recursion budget is bounded
+        even for very weak workers — a 24-component architecture
+        becomes 24 small concurrent dispatches instead of one
+        mega-dispatch that runs out of recursion limit at component 9.
+
+        Both stages are throttled by
+        ``max_concurrent_subsystem_dispatches``.
+
+        Args:
+            phase: Phase label ("implementation" /
+                "sprint_execution" / etc.), embedded in every dispatched
+                task description for traceability.
+            agent_name: Worker agent to dispatch to. Defaults to
+                "developer" — change if a future phase needs a
+                different worker (e.g. "qa_engineer").
+        """
+        contract = _load_stack_contract_data(ctx.project_root)
+        if contract is None:
+            return json.dumps({
+                "status": "failed",
+                "error": (
+                    "docs/stack_contract.json missing or unparseable. "
+                    "Dispatch architect first to produce it."
+                ),
+            })
+        subsystems = contract.get("subsystems")
+        if not isinstance(subsystems, list) or not subsystems:
+            return json.dumps({
+                "status": "failed",
+                "error": (
+                    "docs/stack_contract.json has no subsystems[] array. "
+                    "Architect must use the two-level subsystems[].components[] "
+                    "schema (legacy flat modules[] is no longer supported here)."
+                ),
+            })
+
+        max_workers = max(1, ctx.config.safety_limits.max_concurrent_subsystem_dispatches)
+        language = (contract.get("language") or "python").lower()
+        toolchain = _LANGUAGE_TOOLCHAIN.get(language, _LANGUAGE_TOOLCHAIN["python"])
+
+        # Build a per-subsystem plan that bundles its own skeleton +
+        # component dispatches. Cross-subsystem ordering is intentionally
+        # NOT serialized — different subsystems share no files, so a
+        # subsystem that finishes its skeleton early can start its
+        # components while a slower sibling is still scaffolding.
+        subsystem_plans: list[dict[str, Any]] = []
+        for ss in subsystems:
+            if not isinstance(ss, dict):
+                continue
+            sname = ss.get("name", "?")
+            src_dir = ss.get("src_dir", "")
+            interface_path = _interface_module_path(language, sname, src_dir)
+
+            skel_expected: list[str] = []
+            component_items: list[dict[str, Any]] = []
+            for comp in ss.get("components", []) or []:
+                if not isinstance(comp, dict):
+                    continue
+                cf = comp.get("file")
+                if cf:
+                    skel_expected.append(cf)
+                cname = comp.get("name", "?")
+                upper_initial = (cname[:1].upper() + cname[1:]) if cname else "?"
+                tfile = comp.get("test_file") or toolchain["test_path_pattern"].format(
+                    subsystem=sname, component=cname, Component=upper_initial,
+                )
+                component_items.append({
+                    "subsystem": sname,
+                    "component": cname,
+                    "task_description": _build_component_implementation_task(
+                        ss, comp, contract, phase=phase
+                    ),
+                    "step_id": f"phase_{phase}_component_{sname}_{cname}",
+                    "phase": f"{phase}_component",
+                    "expected_artifacts": [p for p in (cf, tfile) if p],
+                })
+            skel_expected.append(interface_path)
+
+            subsystem_plans.append({
+                "subsystem": sname,
+                "skeleton": {
+                    "subsystem": sname,
+                    "task_description": _build_subsystem_skeleton_task(ss, contract, phase=phase),
+                    "step_id": f"phase_{phase}_skeleton_{sname}",
+                    "phase": f"{phase}_skeleton",
+                    "expected_artifacts": skel_expected,
+                },
+                "components": component_items,
+            })
+
+        # Cross-subsystem global throttle. Outer (subsystem) and inner
+        # (component) executors are nested, so a naïve ``max_workers``
+        # on each pool would multiply: cap=2 with 5 subsystems × 2
+        # components could put 4 dispatches in flight. The semaphore
+        # bounds TOTAL in-flight ``dispatch_task`` calls across every
+        # subsystem and every stage, matching the user-visible
+        # ``max_concurrent_subsystem_dispatches`` contract.
+        global_throttle = threading.Semaphore(max_workers)
+
+        def _run_dispatch(item: dict[str, Any]) -> dict[str, Any]:
+            with global_throttle:
+                raw = dispatch_task.invoke({
+                    "agent_name": agent_name,
+                    "task_description": item["task_description"],
+                    "step_id": item["step_id"],
+                    "phase": item["phase"],
+                    "expected_artifacts": item["expected_artifacts"] or None,
+                })
+            try:
+                parsed = json.loads(raw)
+            except Exception:
+                parsed = {"status": "failed", "error": "non-JSON dispatch result"}
+            parsed["subsystem"] = item["subsystem"]
+            if "component" in item:
+                parsed["component"] = item["component"]
+            return parsed
+
+        # Per-subsystem worker: run skeleton first (sequential within
+        # the subsystem), then fan out the subsystem's own components
+        # in parallel. Each subsystem owns its own ThreadPoolExecutor
+        # for the inner component fan-out so a slow subsystem never
+        # blocks a sibling.
+        skeleton_results: list[dict[str, Any]] = []
+        component_results: list[dict[str, Any]] = []
+        results_lock = threading.Lock()
+
+        def _run_subsystem(plan: dict[str, Any]) -> dict[str, Any]:
+            skel_item = plan["skeleton"]
+            try:
+                skel_out = _run_dispatch(skel_item)
+            except Exception as exc:  # pragma: no cover - defensive
+                skel_out = {
+                    "status": "failed",
+                    "subsystem": skel_item["subsystem"],
+                    "error": str(exc),
+                }
+            # Run components even if the skeleton dispatch reported
+            # ``failed`` — the per-component dispatch will surface a
+            # missing-artifact failure via ``expected_artifacts``,
+            # which is more diagnostic than refusing to launch them.
+            inner_results: list[dict[str, Any]] = []
+            comp_items = plan["components"]
+            if comp_items:
+                # Pool just needs enough threads to feed the global
+                # semaphore — the semaphore is the real throttle.
+                inner_workers = max(1, len(comp_items))
+                with concurrent.futures.ThreadPoolExecutor(max_workers=inner_workers) as pool:
+                    futures = {pool.submit(_run_dispatch, item): item for item in comp_items}
+                    for future in concurrent.futures.as_completed(futures):
+                        try:
+                            comp_out = future.result()
+                        except Exception as exc:
+                            item = futures[future]
+                            comp_out = {
+                                "status": "failed",
+                                "subsystem": item["subsystem"],
+                                "component": item["component"],
+                                "error": str(exc),
+                            }
+                        inner_results.append(comp_out)
+            with results_lock:
+                skeleton_results.append(skel_out)
+                component_results.extend(inner_results)
+            return {"skeleton": skel_out, "components": inner_results}
+
+        # Subsystems fan out fully in parallel; the global semaphore
+        # above bounds the total in-flight dispatches across every
+        # subsystem and every stage, so the executor sizes are just
+        # "enough threads to keep the semaphore busy". The actual
+        # concurrency cap is ``max_workers`` (== the semaphore
+        # capacity) regardless of how many subsystems / components
+        # the architect declared.
+        outer_workers = max(1, len(subsystem_plans)) if subsystem_plans else 1
+        with concurrent.futures.ThreadPoolExecutor(max_workers=outer_workers) as outer_pool:
+            outer_futures = [outer_pool.submit(_run_subsystem, plan) for plan in subsystem_plans]
+            for fut in concurrent.futures.as_completed(outer_futures):
+                # Per-subsystem worker already wrote into the shared
+                # result lists; we drain the futures here only to
+                # surface any uncaught exceptions.
+                try:
+                    fut.result()
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.warning("Subsystem worker raised: %s", exc)
+
+        skel_ok = sum(1 for r in skeleton_results if r.get("status") == "completed")
+        skel_fail = sum(1 for r in skeleton_results if r.get("status") == "failed")
+        comp_ok = sum(1 for r in component_results if r.get("status") == "completed")
+        comp_fail = sum(1 for r in component_results if r.get("status") == "failed")
+
+        return json.dumps({
+            "phase": phase,
+            "agent_name": agent_name,
+            "subsystems_dispatched": len(subsystem_plans),
+            "components_dispatched": len(component_results),
+            "max_concurrent": max_workers,
+            "skeleton_completed": skel_ok,
+            "skeleton_failed": skel_fail,
+            "components_completed": comp_ok,
+            "components_failed": comp_fail,
+            # Aggregate roll-up across both stages so callers that just
+            # want pass/fail counts don't have to add the four numbers
+            # themselves.
+            "completed": skel_ok + comp_ok,
+            "failed": skel_fail + comp_fail,
+            "skeleton_results": skeleton_results,
+            "results": component_results,
+        }, ensure_ascii=False)
+
+    return [dispatch_task, dispatch_tasks_parallel, dispatch_subsystems]
 
 
 # -- Shell primitive -------------------------------------------------------
@@ -689,6 +1393,69 @@ def make_shell_tool(ctx: ToolContext) -> BaseTool:
 # -- Workflow state primitive ---------------------------------------------
 
 
+_COMPLETION_MIN_ARTIFACT_BYTES = 64
+
+# Regex hits that indicate the report itself is announcing a partial
+# delivery. PM has historically called ``mark_complete`` after a
+# truncated implementation phase with text like "0/10 ❌ (dispatch
+# cap hit)" — the gate refuses these so the run cannot be falsely
+# closed as completed. Patterns are case-insensitive.
+_COMPLETION_REPORT_REJECT_PATTERNS: tuple[str, ...] = (
+    r"\bdispatch cap hit\b",
+    r"\bnot implemented\b",
+    r"\bcould not be processed\b",
+    r"\bbefore this subsystem\b",
+    r"\b0\s*/\s*\d+\b",
+    r"❌",
+    r"\btruncated\b",
+    r"\bexhausted\b",
+)
+
+
+def _completion_artifact_shortfall(
+    project_root: Path | None,
+) -> list[str]:
+    """Return component source files declared by the architect's stack
+    contract that are missing or trivially small on disk.
+
+    Used by the ``mark_complete`` gate to refuse closing a run while
+    the architect's deliverables aren't fully on disk.
+    """
+    if project_root is None:
+        return []
+    contract_path = project_root / "docs" / "stack_contract.json"
+    if not contract_path.is_file():
+        return []
+    try:
+        data = json.loads(contract_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    if not isinstance(data, dict):
+        return []
+    subsystems = data.get("subsystems")
+    if not isinstance(subsystems, list):
+        return []
+
+    missing: list[str] = []
+    for ss in subsystems:
+        if not isinstance(ss, dict):
+            continue
+        for comp in ss.get("components") or []:
+            if not isinstance(comp, dict):
+                continue
+            cfile = comp.get("file")
+            if not cfile:
+                continue
+            target = (project_root / cfile).resolve()
+            try:
+                size = target.stat().st_size if target.is_file() else 0
+            except OSError:
+                size = 0
+            if size < _COMPLETION_MIN_ARTIFACT_BYTES:
+                missing.append(cfile)
+    return missing
+
+
 def make_completion_tool(ctx: ToolContext) -> BaseTool:
     """Create the ``mark_complete`` primitive — the explicit terminal signal."""
 
@@ -698,6 +1465,18 @@ def make_completion_tool(ctx: ToolContext) -> BaseTool:
 
         After calling this, the orchestrator's continuation loop exits.
         Use ONCE, when all phases are done.
+
+        The runtime gates this call: it is REJECTED when
+
+        - every planned phase has not yet emitted ``phase_complete``,
+        - the architect's stack contract declares component files that
+          are missing or trivially small on disk, OR
+        - the report text contains markers indicating the run was
+          truncated (``"dispatch cap hit"``, ``"0/N"``, ``"❌"``, etc.)
+
+        Rejected calls return ``status: refused`` with the missing
+        artifact list so the orchestrator can dispatch the gaps and
+        retry instead of silently closing a partial run.
 
         Args:
             report: The final delivery report (markdown text).
@@ -720,6 +1499,118 @@ def make_completion_tool(ctx: ToolContext) -> BaseTool:
                     "error": "Workflow is already marked complete.",
                     "existing_report_length": len(ctx.workflow_state.final_report),
                 }
+            )
+
+        # Gate 1: every planned phase must have completed — except the
+        # final one, since mark_complete is called from INSIDE the
+        # final phase (before the orchestrator loop emits its
+        # ``phase_complete`` event). The legal pattern is therefore:
+        # we have a ``phase_start`` for the final index AND every
+        # earlier index has a matching ``phase_complete``.
+        with ctx.event_lock:
+            plan_events = [e for e in ctx.event_log if e.get("type") == "phase_plan"]
+            done_events = [e for e in ctx.event_log if e.get("type") == "phase_complete"]
+            start_events = [e for e in ctx.event_log if e.get("type") == "phase_start"]
+        planned_total = 0
+        if plan_events:
+            try:
+                planned_total = int(plan_events[-1].get("total") or 0)
+            except (TypeError, ValueError):
+                planned_total = 0
+        done_indices: set[int] = set()
+        for ev in done_events:
+            try:
+                done_indices.add(int(ev.get("phase_idx")))
+            except (TypeError, ValueError):
+                continue
+        started_indices: set[int] = set()
+        for ev in start_events:
+            try:
+                started_indices.add(int(ev.get("phase_idx")))
+            except (TypeError, ValueError):
+                continue
+        if planned_total:
+            final_idx = planned_total - 1
+            earlier_required = set(range(final_idx))
+            missing_earlier = sorted(earlier_required - done_indices)
+            in_final_phase = final_idx in started_indices
+            if missing_earlier or not in_final_phase:
+                missing_phases = sorted(earlier_required - done_indices)
+                if not in_final_phase:
+                    missing_phases.append(final_idx)
+                logger.info(
+                    "mark_complete refused: phases_done=%s started_final=%s plan_total=%d",
+                    sorted(done_indices),
+                    in_final_phase,
+                    planned_total,
+                )
+                return json.dumps(
+                    {
+                        "status": "refused",
+                        "error": (
+                            f"Cannot mark complete — {len(done_indices)}/{planned_total} "
+                            f"phases finished and final phase started={in_final_phase}. "
+                            f"Missing phase indices: {missing_phases}. "
+                            "Continue dispatching the remaining phases (main_entry / "
+                            "qa_testing / delivery) before calling mark_complete again."
+                        ),
+                        "phases_completed": sorted(done_indices),
+                        "phases_total": planned_total,
+                        "missing_phase_indices": missing_phases,
+                    },
+                    ensure_ascii=False,
+                )
+
+        # Gate 2: every component file declared by the architect must
+        # exist on disk with non-trivial content. A run that closes
+        # while ``src/gameplay/*.py`` is still empty is not done.
+        missing_files = _completion_artifact_shortfall(ctx.project_root)
+        if missing_files:
+            logger.info(
+                "mark_complete refused: %d declared component files missing/empty",
+                len(missing_files),
+            )
+            return json.dumps(
+                {
+                    "status": "refused",
+                    "error": (
+                        f"Cannot mark complete — {len(missing_files)} component "
+                        "files declared in docs/stack_contract.json are missing or "
+                        "trivially small on disk. Dispatch the responsible subsystem "
+                        "to fill them in, then call mark_complete again."
+                    ),
+                    "missing_artifacts": missing_files[:50],
+                    "missing_artifact_count": len(missing_files),
+                },
+                ensure_ascii=False,
+            )
+
+        # Gate 3: refuse reports that openly admit partial delivery.
+        # PM has historically tried to close runs with text like
+        # "0/10 ❌ (dispatch cap hit before this subsystem was
+        # processed)" — that's a partial delivery, not a delivery.
+        report_lower = (report or "").lower()
+        flagged: list[str] = []
+        for pattern in _COMPLETION_REPORT_REJECT_PATTERNS:
+            if re.search(pattern, report_lower, flags=re.IGNORECASE):
+                flagged.append(pattern)
+        if flagged:
+            logger.info(
+                "mark_complete refused: report contains partial-delivery markers: %s",
+                flagged,
+            )
+            return json.dumps(
+                {
+                    "status": "refused",
+                    "error": (
+                        "Cannot mark complete — the report you supplied describes a "
+                        "partial delivery (matched markers: "
+                        f"{flagged}). Finish the missing work and submit a report "
+                        "that does not flag any subsystem as failed/truncated."
+                    ),
+                    "flagged_markers": flagged,
+                },
+                ensure_ascii=False,
             )
 
         ctx.workflow_state.is_complete = True

--- a/src/aise/runtime/trace_callback.py
+++ b/src/aise/runtime/trace_callback.py
@@ -47,13 +47,22 @@ class TraceLLMCallback(BaseCallbackHandler):
         trace_path: Path | None,
         lock: threading.Lock,
         on_todos_update: Callable[[list[dict[str, Any]]], None] | None = None,
+        on_token_usage: Callable[[dict[str, int]], None] | None = None,
     ) -> None:
         super().__init__()
         self._record = trace_record
         self._path = trace_path
         self._lock = lock
         self._on_todos_update = on_todos_update
+        self._on_token_usage = on_token_usage
         self._pending: dict[UUID, dict[str, Any]] = {}
+        # Aggregate per-dispatch token usage. The callback owns the
+        # running totals so a crash mid-run still leaves an accurate
+        # ``token_usage`` block on the partial trace prefix.
+        self._record.setdefault(
+            "token_usage",
+            {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0, "llm_calls": 0},
+        )
 
     # -- LLM start: capture the full input messages -------------------------
 
@@ -87,6 +96,9 @@ class TraceLLMCallback(BaseCallbackHandler):
 
         duration_ms = int((time.monotonic() - pending["start_time"]) * 1000)
         output = _dump_llm_result(response)
+        call_tokens = _extract_token_counts(response)
+        if any(call_tokens.values()):
+            output["token_usage_normalized"] = call_tokens
 
         entry: dict[str, Any] = {
             "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -95,12 +107,29 @@ class TraceLLMCallback(BaseCallbackHandler):
             "output": output,
         }
 
+        forwarded: dict[str, int] | None = None
         with self._lock:
             calls = self._record.setdefault("llm_calls", [])
             entry["index"] = len(calls) + 1
             calls.append(entry)
             self._record["llm_call_count"] = len(calls)
+            totals = self._record.setdefault(
+                "token_usage",
+                {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0, "llm_calls": 0},
+            )
+            totals["input_tokens"] += call_tokens["input_tokens"]
+            totals["output_tokens"] += call_tokens["output_tokens"]
+            totals["total_tokens"] += call_tokens["total_tokens"]
+            totals["llm_calls"] += 1
+            if any(call_tokens.values()):
+                forwarded = dict(call_tokens)
             _flush(self._path, self._record)
+
+        if forwarded is not None and self._on_token_usage is not None:
+            try:
+                self._on_token_usage(forwarded)
+            except Exception as exc:  # pragma: no cover - never let UI plumbing crash the agent
+                logger.debug("on_token_usage callback failed: %s", exc)
 
     # -- LLM error ----------------------------------------------------------
 
@@ -243,6 +272,58 @@ def _dump_tool_call(tc: Any) -> dict[str, Any]:
             "args": _safe(tc.get("args", {})),
         }
     return {"raw": str(tc)}
+
+
+def _extract_token_counts(result: LLMResult) -> dict[str, int]:
+    """Pull ``input_tokens`` / ``output_tokens`` / ``total_tokens`` from an
+    ``LLMResult``, normalizing across providers.
+
+    OpenAI exposes ``prompt_tokens`` / ``completion_tokens``; Anthropic and
+    LangChain's standardized ``UsageMetadata`` use ``input_tokens`` /
+    ``output_tokens``. We accept both and fall back to summing components
+    when ``total_tokens`` is absent.
+    """
+    counts = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+
+    def _add(usage: Any) -> None:
+        if not isinstance(usage, dict):
+            return
+        prompt = usage.get("input_tokens") if "input_tokens" in usage else usage.get("prompt_tokens")
+        completion = usage.get("output_tokens") if "output_tokens" in usage else usage.get("completion_tokens")
+        total = usage.get("total_tokens")
+        try:
+            counts["input_tokens"] += int(prompt or 0)
+        except (TypeError, ValueError):
+            pass
+        try:
+            counts["output_tokens"] += int(completion or 0)
+        except (TypeError, ValueError):
+            pass
+        try:
+            counts["total_tokens"] += int(total or 0)
+        except (TypeError, ValueError):
+            pass
+
+    llm_output = result.llm_output
+    if isinstance(llm_output, dict):
+        _add(llm_output.get("token_usage"))
+        _add(llm_output.get("usage"))
+
+    if counts["input_tokens"] == 0 and counts["output_tokens"] == 0 and counts["total_tokens"] == 0:
+        for batch in result.generations or []:
+            for gen in batch:
+                msg = getattr(gen, "message", None)
+                if msg is None:
+                    continue
+                _add(getattr(msg, "usage_metadata", None))
+                response_metadata = getattr(msg, "response_metadata", None)
+                if isinstance(response_metadata, dict):
+                    _add(response_metadata.get("token_usage"))
+                    _add(response_metadata.get("usage"))
+
+    if counts["total_tokens"] == 0:
+        counts["total_tokens"] = counts["input_tokens"] + counts["output_tokens"]
+    return counts
 
 
 def _dump_llm_result(result: LLMResult) -> dict[str, Any]:

--- a/src/aise/web/app.py
+++ b/src/aise/web/app.py
@@ -84,6 +84,15 @@ class WorkflowRun:
     # and lets the user walk the retry chain backwards.
     resumed_from_run_id: str = ""
     start_phase_idx: int = 0
+    # LLM token consumption aggregated across every dispatch in this run
+    # (orchestrator + every sub-agent). Populated in real time from
+    # ``token_usage`` events emitted by ``ProjectSession`` /
+    # ``dispatch_task`` so the dashboard can show live cost as a run
+    # progresses, and persisted on completion.
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_tokens: int = 0
+    llm_call_count: int = 0
 
 
 @dataclass
@@ -116,6 +125,11 @@ class WebProjectService:
         )
         self._runs_by_project: dict[str, list[WorkflowRun]] = {}
         self._requirements_by_project: dict[str, list[RequirementEntry]] = {}
+        # Scaffolding-phase LLM token usage per project. Scaffolding
+        # happens once (with possible safety-net repair retries) and
+        # is not tied to a WorkflowRun, so we accumulate it on the
+        # project itself. Keys: ``input``/``output``/``total``/``calls``.
+        self._scaffolding_tokens_by_project: dict[str, dict[str, int]] = {}
         self._lock = RLock()
         self._active_workflow_runs: set[tuple[str, str]] = set()
         self._state_path = self.project_manager._projects_root / "web_state.json"
@@ -369,7 +383,22 @@ class WebProjectService:
         if pm_runtime is None:
             raise RuntimeError("product_manager runtime not found in RuntimeManager")
         thread_id = f"scaffold-{project.project_id}"
-        pm_runtime.handle_message(prompt, thread_id=thread_id)
+
+        def _on_token_usage(counts: dict[str, int]) -> None:
+            with self._lock:
+                bucket = self._scaffolding_tokens_by_project.setdefault(
+                    project.project_id,
+                    {"input": 0, "output": 0, "total": 0, "calls": 0},
+                )
+                try:
+                    bucket["input"] += int(counts.get("input_tokens") or 0)
+                    bucket["output"] += int(counts.get("output_tokens") or 0)
+                    bucket["total"] += int(counts.get("total_tokens") or 0)
+                    bucket["calls"] += 1
+                except (TypeError, ValueError):
+                    pass
+
+        pm_runtime.handle_message(prompt, thread_id=thread_id, on_token_usage=_on_token_usage)
 
     def get_project(self, project_id: str) -> dict[str, Any] | None:
         with self._lock:
@@ -384,7 +413,38 @@ class WebProjectService:
                 "requirements": [
                     self._serialize_requirement(item) for item in self._list_requirement_history(project_id)
                 ],
+                "token_usage": self._project_token_summary(project_id),
             }
+
+    def _project_token_summary(self, project_id: str) -> dict[str, int]:
+        """Total LLM tokens consumed by this project: scaffolding + every run.
+
+        Aggregates the scaffolding bucket (created during project
+        creation) with the per-run totals so the UI can present a
+        single "what did this project cost" number.
+        """
+        scaffold = self._scaffolding_tokens_by_project.get(
+            project_id, {"input": 0, "output": 0, "total": 0, "calls": 0}
+        )
+        input_tokens = int(scaffold.get("input", 0))
+        output_tokens = int(scaffold.get("output", 0))
+        total_tokens = int(scaffold.get("total", 0))
+        llm_calls = int(scaffold.get("calls", 0))
+        for run in self._runs_by_project.get(project_id, []):
+            input_tokens += run.total_input_tokens
+            output_tokens += run.total_output_tokens
+            total_tokens += run.total_tokens
+            llm_calls += run.llm_call_count
+        return {
+            "scaffolding_input_tokens": int(scaffold.get("input", 0)),
+            "scaffolding_output_tokens": int(scaffold.get("output", 0)),
+            "scaffolding_total_tokens": int(scaffold.get("total", 0)),
+            "scaffolding_llm_calls": int(scaffold.get("calls", 0)),
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": total_tokens,
+            "llm_calls": llm_calls,
+        }
 
     def get_run(self, project_id: str, run_id: str) -> dict[str, Any] | None:
         with self._lock:
@@ -409,6 +469,7 @@ class WebProjectService:
                 raise ValueError(f"Project {project_id} not found")
             self._runs_by_project.pop(project_id, None)
             self._requirements_by_project.pop(project_id, None)
+            self._scaffolding_tokens_by_project.pop(project_id, None)
             self._active_workflow_runs = {(pid, rid) for pid, rid in self._active_workflow_runs if pid != project_id}
             self._save_state()
             logger.info("Web project deleted: project_id=%s", project_id)
@@ -651,6 +712,14 @@ class WebProjectService:
                     # final status=completed branch resets them anyway.
                     run.failed_phase_idx = -1
                     run.failed_phase_name = ""
+                elif event_type == "token_usage":
+                    try:
+                        run.total_input_tokens += int(event.get("input_tokens") or 0)
+                        run.total_output_tokens += int(event.get("output_tokens") or 0)
+                        run.total_tokens += int(event.get("total_tokens") or 0)
+                        run.llm_call_count += 1
+                    except (TypeError, ValueError):
+                        pass
 
         # Resolve project root for file output
         project_root = None
@@ -1110,6 +1179,12 @@ class WebProjectService:
                         start_idx_val = int(start_idx_raw)
                     except (TypeError, ValueError):
                         start_idx_val = 0
+                    def _coerce_int(value: Any) -> int:
+                        try:
+                            return max(0, int(value))
+                        except (TypeError, ValueError):
+                            return 0
+
                     self._runs_by_project[project_id].append(
                         WorkflowRun(
                             run_id=str(item.get("run_id", "")),
@@ -1127,6 +1202,10 @@ class WebProjectService:
                             phase_total=phase_total_val,
                             resumed_from_run_id=str(item.get("resumed_from_run_id", "")),
                             start_phase_idx=max(0, start_idx_val),
+                            total_input_tokens=_coerce_int(item.get("total_input_tokens")),
+                            total_output_tokens=_coerce_int(item.get("total_output_tokens")),
+                            total_tokens=_coerce_int(item.get("total_tokens")),
+                            llm_call_count=_coerce_int(item.get("llm_call_count")),
                         )
                     )
 
@@ -1170,6 +1249,21 @@ class WebProjectService:
                 except Exception:
                     pass
 
+        scaffold_tokens = data.get("scaffolding_tokens_by_project", {})
+        if isinstance(scaffold_tokens, dict):
+            for project_id, bucket in scaffold_tokens.items():
+                if not isinstance(bucket, dict):
+                    continue
+                try:
+                    self._scaffolding_tokens_by_project[str(project_id)] = {
+                        "input": int(bucket.get("input") or 0),
+                        "output": int(bucket.get("output") or 0),
+                        "total": int(bucket.get("total") or 0),
+                        "calls": int(bucket.get("calls") or 0),
+                    }
+                except (TypeError, ValueError):
+                    continue
+
         # Persist the reaped statuses so the next restart sees clean state
         # instead of re-reaping the same runs.
         if reaped_any:
@@ -1196,6 +1290,9 @@ class WebProjectService:
                 }
                 for p in self.project_manager.list_projects()
             },
+            "scaffolding_tokens_by_project": {
+                pid: dict(bucket) for pid, bucket in self._scaffolding_tokens_by_project.items()
+            },
         }
         tmp_path = self._state_path.with_suffix(f"{self._state_path.suffix}.{uuid.uuid4().hex}.tmp")
         tmp_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
@@ -1219,6 +1316,10 @@ class WebProjectService:
             "phase_total": run.phase_total,
             "resumed_from_run_id": run.resumed_from_run_id,
             "start_phase_idx": run.start_phase_idx,
+            "total_input_tokens": run.total_input_tokens,
+            "total_output_tokens": run.total_output_tokens,
+            "total_tokens": run.total_tokens,
+            "llm_call_count": run.llm_call_count,
         }
 
     @staticmethod

--- a/src/aise/web/app.py
+++ b/src/aise/web/app.py
@@ -1179,6 +1179,7 @@ class WebProjectService:
                         start_idx_val = int(start_idx_raw)
                     except (TypeError, ValueError):
                         start_idx_val = 0
+
                     def _coerce_int(value: Any) -> int:
                         try:
                             return max(0, int(value))

--- a/src/aise/web/static/app.js
+++ b/src/aise/web/static/app.js
@@ -496,6 +496,7 @@ function setupProjectReact() {
         const [projectInfo, setProjectInfo] = window.React.useState(project.info || {});
         const [requirements, setRequirements] = window.React.useState(Array.isArray(project.requirements) ? project.requirements : []);
         const [runs, setRuns] = window.React.useState(Array.isArray(project.runs) ? project.runs : []);
+        const [tokenUsage, setTokenUsage] = window.React.useState(project.token_usage || null);
         const [text, setText] = window.React.useState("");
         const [submitting, setSubmitting] = window.React.useState(false);
         const [deleting, setDeleting] = window.React.useState(false);
@@ -514,6 +515,7 @@ function setupProjectReact() {
                     ]);
                     if (!active) return;
                     if (projData && projData.info) setProjectInfo(projData.info);
+                    if (projData && projData.token_usage) setTokenUsage(projData.token_usage);
                     setRequirements(Array.isArray(requirementsData.requirements) ? requirementsData.requirements : []);
                     setRuns(Array.isArray(runsData.runs) ? runsData.runs : []);
                     setProjectMissing(false);
@@ -699,6 +701,17 @@ function setupProjectReact() {
                 const hasMoreRequirements = requirements.length > HISTORY_LIMIT;
                 const hasMoreRuns = runs.length > HISTORY_LIMIT;
                 const hasMore = hasMoreRequirements || hasMoreRuns;
+                const tokenSummary = tokenUsage || {
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    total_tokens: 0,
+                    llm_calls: 0,
+                    scaffolding_input_tokens: 0,
+                    scaffolding_output_tokens: 0,
+                    scaffolding_total_tokens: 0,
+                    scaffolding_llm_calls: 0,
+                };
+                const tokenFmt = (n) => Number(n || 0).toLocaleString();
                 return [
                     h(
                         "section",
@@ -726,6 +739,41 @@ function setupProjectReact() {
                             },
                             t("project.action_view_latest_run")
                         ) : null,
+                    ),
+                    h(
+                        "section",
+                        { key: "token-usage", className: "card" },
+                        h("h3", { style: { marginTop: 0 } }, t("project.token_usage_title")),
+                        h("p", { className: "muted", style: { fontSize: "12px" } }, t("project.token_usage_hint")),
+                        h(
+                            "div",
+                            { style: { display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: "12px", marginTop: "8px" } },
+                            h("div", null,
+                                h("div", { className: "muted", style: { fontSize: "12px" } }, t("project.token_usage_input")),
+                                h("div", { style: { fontSize: "1.4rem", fontWeight: 600 } }, tokenFmt(tokenSummary.input_tokens))
+                            ),
+                            h("div", null,
+                                h("div", { className: "muted", style: { fontSize: "12px" } }, t("project.token_usage_output")),
+                                h("div", { style: { fontSize: "1.4rem", fontWeight: 600 } }, tokenFmt(tokenSummary.output_tokens))
+                            ),
+                            h("div", null,
+                                h("div", { className: "muted", style: { fontSize: "12px" } }, t("project.token_usage_total")),
+                                h("div", { style: { fontSize: "1.4rem", fontWeight: 600 } }, tokenFmt(tokenSummary.total_tokens))
+                            ),
+                            h("div", null,
+                                h("div", { className: "muted", style: { fontSize: "12px" } }, t("project.token_usage_calls")),
+                                h("div", { style: { fontSize: "1.4rem", fontWeight: 600 } }, tokenFmt(tokenSummary.llm_calls))
+                            ),
+                        ),
+                        (tokenSummary.scaffolding_llm_calls || tokenSummary.scaffolding_total_tokens) ? h(
+                            "p",
+                            { className: "muted", style: { fontSize: "12px", marginTop: "8px" } },
+                            t("project.token_usage_scaffolding", {
+                                input: tokenFmt(tokenSummary.scaffolding_input_tokens),
+                                output: tokenFmt(tokenSummary.scaffolding_output_tokens),
+                                calls: tokenFmt(tokenSummary.scaffolding_llm_calls),
+                            })
+                        ) : null
                     ),
                     h(
                         "section",
@@ -1175,6 +1223,13 @@ function setupRunReact() {
             "tool_call",
             "language_config",
             "workflow_complete",
+            // ``token_usage`` fires once per LLM round-trip — for a real run
+            // that's hundreds of rows of pure cost telemetry, drowning out
+            // the actual A2A dispatches the user came here to read. The
+            // numbers are already aggregated and rendered in the run-stats
+            // bar (输入 / 输出 / 累计 Token), so the raw events have no
+            // place in the timeline log.
+            "token_usage",
         ]);
         const isVisibleEvent = (e) => !!e && !HIDDEN_LOG_EVENT_TYPES.has(e.type);
         const visibleLog = taskLog.filter(isVisibleEvent);
@@ -1306,6 +1361,9 @@ function setupRunReact() {
                 h("div", { className: "run-stat" }, h("span", { className: "run-stat-value" }, requests.length), h("span", { className: "run-stat-label" }, t("run.stat.dispatches"))),
                 h("div", { className: "run-stat" }, h("span", { className: "run-stat-value" }, completed), h("span", { className: "run-stat-label" }, t("run.stat.completed"))),
                 failed > 0 ? h("div", { className: "run-stat run-stat-error" }, h("span", { className: "run-stat-value" }, failed), h("span", { className: "run-stat-label" }, t("run.stat.failed"))) : null,
+                h("div", { className: "run-stat" }, h("span", { className: "run-stat-value" }, Number(run.total_input_tokens || 0).toLocaleString()), h("span", { className: "run-stat-label" }, t("project.token_usage_input"))),
+                h("div", { className: "run-stat" }, h("span", { className: "run-stat-value" }, Number(run.total_output_tokens || 0).toLocaleString()), h("span", { className: "run-stat-label" }, t("project.token_usage_output"))),
+                h("div", { className: "run-stat" }, h("span", { className: "run-stat-value" }, Number(run.total_tokens || 0).toLocaleString()), h("span", { className: "run-stat-label" }, t("project.token_usage_total"))),
             ),
             // View switcher: "timeline" = current stage-progress + A2A log;
             // "agents" = the agent-interaction graph. Persists only for the

--- a/src/aise/web/static/locales/en/translation.json
+++ b/src/aise/web/static/locales/en/translation.json
@@ -277,7 +277,15 @@
     "scaffolding_failed_title": "Environment preparation failed",
     "scaffolding_failed_hint": "Project initialisation did not complete, so no requirement can be submitted. Error detail:",
     "scaffolding_failed_fallback_error": "No specific error was captured. Check the runtime logs for details.",
-    "scaffolding_failed_guidance": "The recommended recovery is to delete the project and re-create it. If the failure recurs, inspect the product-manager agent logs and the project-root directory permissions."
+    "scaffolding_failed_guidance": "The recommended recovery is to delete the project and re-create it. If the failure recurs, inspect the product-manager agent logs and the project-root directory permissions.",
+    "token_usage_title": "Token usage",
+    "token_usage_hint": "Cumulative LLM input / output tokens for this project — scaffolding plus every workflow run.",
+    "token_usage_input": "Input tokens",
+    "token_usage_output": "Output tokens",
+    "token_usage_total": "Total tokens",
+    "token_usage_calls": "LLM calls",
+    "token_usage_scaffolding": "Scaffolding: in {{input}} / out {{output}} / {{calls}} calls",
+    "token_usage_run_breakdown": "This run: in {{input}} / out {{output}} / {{calls}} calls"
   },
   "monitor": {
     "title": "Agent Monitor",

--- a/src/aise/web/static/locales/zh/translation.json
+++ b/src/aise/web/static/locales/zh/translation.json
@@ -277,7 +277,15 @@
     "scaffolding_failed_title": "环境准备失败",
     "scaffolding_failed_hint": "项目初始化未成功，无法继续下发需求。错误详情：",
     "scaffolding_failed_fallback_error": "未捕获到具体错误信息，请查看运行日志。",
-    "scaffolding_failed_guidance": "建议删除该项目后重新创建；如果问题反复出现，请检查 product-manager 代理日志与项目根目录权限。"
+    "scaffolding_failed_guidance": "建议删除该项目后重新创建；如果问题反复出现，请检查 product-manager 代理日志与项目根目录权限。",
+    "token_usage_title": "Token 消耗",
+    "token_usage_hint": "项目创建至今所有 LLM 调用的输入 / 输出 Token 累计（含环境准备阶段与每次工作流执行）。",
+    "token_usage_input": "输入 Token",
+    "token_usage_output": "输出 Token",
+    "token_usage_total": "累计 Token",
+    "token_usage_calls": "LLM 调用次数",
+    "token_usage_scaffolding": "环境准备阶段：输入 {{input}} / 输出 {{output}} / 调用 {{calls}} 次",
+    "token_usage_run_breakdown": "本次执行：输入 {{input}} / 输出 {{output}} / 调用 {{calls}} 次"
   },
   "monitor": {
     "title": "Agent Monitor",

--- a/tests/test_agents/test_no_language_lock_in.py
+++ b/tests/test_agents/test_no_language_lock_in.py
@@ -37,7 +37,7 @@ _PYTHON_TOKENS = (
     "pyproject.toml",
     "tests/test_<module>.py",
     "src/<module>.py",
-    "find src -type f -name \"*.py\"",
+    'find src -type f -name "*.py"',
     "find src -type f -name '*.py'",
     "pytest --cov",
     "--cov=src",
@@ -87,13 +87,9 @@ def _file_passes(path: Path) -> tuple[bool, str]:
     # File mentions Python — must also mention a non-Python language
     multi_hits = [m for m in _NON_PYTHON_LANGUAGE_MARKERS if m in text]
     if multi_hits:
-        return True, (
-            f"Python tokens present ({len(py_hits)}) but balanced by "
-            f"{len(multi_hits)} non-Python markers"
-        )
+        return True, (f"Python tokens present ({len(py_hits)}) but balanced by {len(multi_hits)} non-Python markers")
     return False, (
-        f"Python-locked: tokens present {py_hits[:3]} but no non-Python "
-        f"language markers found anywhere in the file"
+        f"Python-locked: tokens present {py_hits[:3]} but no non-Python language markers found anywhere in the file"
     )
 
 
@@ -152,10 +148,7 @@ def test_continuation_prompt_uses_multilingual_test_command():
     # test command" anywhere in the body, OR an explicit list of multiple
     # runners.
     has_generic = "full-suite test command" in body or "project's full-suite" in body
-    runners_listed = sum(
-        marker in body
-        for marker in ("pytest", "vitest", "jest", "go test", "cargo test", "mvn test")
-    )
+    runners_listed = sum(marker in body for marker in ("pytest", "vitest", "jest", "go test", "cargo test", "mvn test"))
     assert has_generic or runners_listed >= 3, (
         "continuation prompt must either use generic 'project's test command' "
         "phrasing or list 3+ test runners; found generic="

--- a/tests/test_agents/test_no_language_lock_in.py
+++ b/tests/test_agents/test_no_language_lock_in.py
@@ -1,0 +1,163 @@
+"""Regression tests: agent prompts and orchestrator phase prompts must
+NOT lock the project into a single language (Python by default). Where
+specific commands or file paths are necessary as examples, they must be
+accompanied by examples for at least one non-Python mainstream language
+within a small window of context.
+
+The user feedback that motivated these tests:
+
+  > 当前的部分 agent 中有大量特殊化的提示，如限定于 Python 语言的要求和指导
+  > 模板等，应当尽可能去掉这些特殊化的语言约束。如果确实需要约束，应该包括
+  > 主流语言的示例
+
+Mainstream non-Python languages we accept as "the file is multi-lingual":
+TypeScript / JavaScript, Go, Rust, Java, Kotlin, C# / .NET.
+
+The check works by counting Python-specific tokens (e.g. ``pytest``,
+``ruff``, ``mypy``, ``pyproject.toml``) and Python-specific commands
+(e.g. ``python -m pytest``, ``find ... '*.py'``). For every file
+inspected, we either accept that the Python tokens are absent or
+require that at least one non-Python mainstream-language token is
+present in the same file. This catches "I added a Python example and
+nothing else" regressions.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_PYTHON_TOKENS = (
+    "python -m pytest",
+    "pytest tests/",
+    "ruff check",
+    "mypy ",
+    "pyproject.toml",
+    "tests/test_<module>.py",
+    "src/<module>.py",
+    "find src -type f -name \"*.py\"",
+    "find src -type f -name '*.py'",
+    "pytest --cov",
+    "--cov=src",
+)
+
+_NON_PYTHON_LANGUAGE_MARKERS = (
+    # TypeScript / JavaScript
+    "vitest",
+    "jest",
+    "npx ",
+    "tsc ",
+    "package.json",
+    "tsconfig.json",
+    # Go
+    "go test",
+    "go vet",
+    "go.mod",
+    "gofmt",
+    # Rust
+    "cargo test",
+    "cargo check",
+    "cargo clippy",
+    "Cargo.toml",
+    # Java / Kotlin
+    "mvn test",
+    "gradle ",
+    "pom.xml",
+    "build.gradle",
+    # C# / .NET
+    "dotnet ",
+    # Generic multi-language placeholders explicitly used in our prompts
+    "match the project's stack",
+    "matching your stack",
+    "matching the project's language",
+    "language's idiomatic",
+    "Do NOT default to Python",
+    "do NOT default to Python",
+)
+
+
+def _file_passes(path: Path) -> tuple[bool, str]:
+    """Return (passes, reason). True if no Python lock-in OR multilingual."""
+    text = path.read_text(encoding="utf-8")
+    py_hits = [tok for tok in _PYTHON_TOKENS if tok in text]
+    if not py_hits:
+        return True, "no Python-specific tokens"
+    # File mentions Python — must also mention a non-Python language
+    multi_hits = [m for m in _NON_PYTHON_LANGUAGE_MARKERS if m in text]
+    if multi_hits:
+        return True, (
+            f"Python tokens present ({len(py_hits)}) but balanced by "
+            f"{len(multi_hits)} non-Python markers"
+        )
+    return False, (
+        f"Python-locked: tokens present {py_hits[:3]} but no non-Python "
+        f"language markers found anywhere in the file"
+    )
+
+
+# Files that orchestrate or guide developer work and therefore must NOT
+# be Python-locked. Each is checked independently.
+_AGENT_FILES = [
+    "src/aise/agents/architect.md",
+    "src/aise/agents/developer.md",
+    "src/aise/agents/qa_engineer.md",
+    "src/aise/agents/product_manager.md",
+    "src/aise/agents/code_reviewer.md",
+    "src/aise/agents/project_manager.md",
+    "src/aise/agents/rd_director.md",
+    "src/aise/agents/_runtime_skills/tdd/SKILL.md",
+    "src/aise/agents/_runtime_skills/code_inspection/SKILL.md",
+    "src/aise/runtime/project_session.py",
+]
+
+
+@pytest.mark.parametrize("relpath", _AGENT_FILES)
+def test_agent_prompt_is_not_python_locked(relpath):
+    """Every agent prompt / skill / orchestrator phase prompt that
+    contains Python-specific tokens MUST also contain at least one
+    non-Python mainstream-language marker in the same file.
+
+    This is a regression guard: if a future edit adds a Python-only
+    example without the multi-language counterpart, this test fails
+    immediately.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    path = repo_root / relpath
+    assert path.is_file(), f"missing file: {path}"
+    ok, reason = _file_passes(path)
+    assert ok, f"{relpath}: {reason}"
+
+
+def test_continuation_prompt_uses_multilingual_test_command():
+    """The runtime's continuation prompt previously hard-coded
+    ``execute_shell('python -m pytest tests/...')``. It must now
+    instruct the orchestrator using language-aware phrasing — e.g.
+    "the project's full-suite test command" — with examples spanning
+    multiple mainstream test runners.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    text = (repo_root / "src/aise/runtime/project_session.py").read_text(encoding="utf-8")
+    # Find the _render_continuation_prompt body
+    match = re.search(
+        r"def _render_continuation_prompt\(self\) -> str:\s*\"\"\"(?:[^\"]|\"(?!\"\"))*\"\"\"(.*?)(?=\n    def |\Z)",
+        text,
+        re.DOTALL,
+    )
+    assert match, "could not locate _render_continuation_prompt body"
+    body = match.group(1)
+    # Must NOT contain a bare standalone Python pytest invocation as the
+    # only test-runner instruction. We look for "the project's full-suite
+    # test command" anywhere in the body, OR an explicit list of multiple
+    # runners.
+    has_generic = "full-suite test command" in body or "project's full-suite" in body
+    runners_listed = sum(
+        marker in body
+        for marker in ("pytest", "vitest", "jest", "go test", "cargo test", "mvn test")
+    )
+    assert has_generic or runners_listed >= 3, (
+        "continuation prompt must either use generic 'project's test command' "
+        "phrasing or list 3+ test runners; found generic="
+        f"{has_generic}, runners_listed={runners_listed}"
+    )

--- a/tests/test_runtime/test_agent_runtime.py
+++ b/tests/test_runtime/test_agent_runtime.py
@@ -166,7 +166,7 @@ class TestAgentRuntimeTrace:
         assert "Recursion limit" in record["error"]
         assert record["error_type"] == "RuntimeError"
 
-    def test_default_recursion_limit_is_240(self, agent_md_file, skills_dir, mock_create_deep_agent):
+    def test_default_recursion_limit_is_480(self, agent_md_file, skills_dir, mock_create_deep_agent):
         from langchain_core.messages import AIMessage
 
         _, mock_agent = mock_create_deep_agent
@@ -177,7 +177,7 @@ class TestAgentRuntimeTrace:
         runtime.handle_message("hi")
 
         _, kwargs = mock_agent.invoke.call_args
-        assert kwargs["config"]["recursion_limit"] == 240
+        assert kwargs["config"]["recursion_limit"] == 480
 
 
 class TestAgentRuntimeTodos:

--- a/tests/test_runtime/test_dispatch_subsystems.py
+++ b/tests/test_runtime/test_dispatch_subsystems.py
@@ -97,15 +97,17 @@ def _valid_contract(n_subsystems: int = 4) -> dict:
     subsystems = []
     for i in range(n_subsystems):
         sname = f"sub{i}"
-        subsystems.append({
-            "name": sname,
-            "src_dir": f"src/{sname}/",
-            "responsibilities": f"{sname} responsibilities",
-            "components": [
-                {"name": f"comp_a_{i}", "file": f"src/{sname}/comp_a_{i}.py", "responsibility": "A"},
-                {"name": f"comp_b_{i}", "file": f"src/{sname}/comp_b_{i}.py", "responsibility": "B"},
-            ],
-        })
+        subsystems.append(
+            {
+                "name": sname,
+                "src_dir": f"src/{sname}/",
+                "responsibilities": f"{sname} responsibilities",
+                "components": [
+                    {"name": f"comp_a_{i}", "file": f"src/{sname}/comp_a_{i}.py", "responsibility": "A"},
+                    {"name": f"comp_b_{i}", "file": f"src/{sname}/comp_b_{i}.py", "responsibility": "B"},
+                ],
+            }
+        )
     return {
         "language": "python",
         "test_runner": "pytest",
@@ -147,10 +149,13 @@ class TestDispatchSubsystemsContractRequired:
         # An old-style flat modules[] contract is no longer accepted
         # by dispatch_subsystems — architect must produce the new
         # subsystems[].components[] schema before phase 3 can fan out.
-        _write_contract(tmp_path, {
-            "language": "python",
-            "modules": [{"name": "x", "src_dir": "src/x/"}],
-        })
+        _write_contract(
+            tmp_path,
+            {
+                "language": "python",
+                "modules": [{"name": "x", "src_dir": "src/x/"}],
+            },
+        )
         ctx = _build_ctx(tmp_path)
         tools = build_orchestrator_tools(ctx)
         ds = next(t for t in tools if t.name == "dispatch_subsystems")
@@ -202,8 +207,7 @@ class TestDispatchSubsystemsRunsInParallel:
         # parallel (additional threads from stage 2's component fan-out
         # may push this higher; what we assert is real fan-out).
         assert len(first_start_per_thread) >= 4, (
-            f"expected ≥4 distinct worker threads (one per subsystem skeleton), "
-            f"got {len(first_start_per_thread)}"
+            f"expected ≥4 distinct worker threads (one per subsystem skeleton), got {len(first_start_per_thread)}"
         )
         # The 4 EARLIEST starts must all happen before the first finish —
         # that's the skeleton stage proving real concurrency.
@@ -314,11 +318,8 @@ class TestDispatchSubsystemsRunsInParallel:
 
         sub0_events = [e for e in events if e[0] == "sub0"]
         sub1_events = [e for e in events if e[0] == "sub1"]
-        assert any(
-            _overlaps(a, b) for a in sub0_events for b in sub1_events
-        ), (
-            "no time overlap between sub0 and sub1 dispatches — "
-            "subsystems are not running in parallel"
+        assert any(_overlaps(a, b) for a in sub0_events for b in sub1_events), (
+            "no time overlap between sub0 and sub1 dispatches — subsystems are not running in parallel"
         )
 
     def test_results_aggregate_includes_per_subsystem_status(self, tmp_path):
@@ -382,8 +383,7 @@ class TestMaxConcurrentDispatchesCap:
         assert out["subsystems_dispatched"] == 5
         assert out["components_dispatched"] == 10
         assert peak_in_flight <= 2, (
-            f"peak concurrent dispatches was {peak_in_flight}, "
-            f"exceeded cap of 2 — throttle is broken"
+            f"peak concurrent dispatches was {peak_in_flight}, exceeded cap of 2 — throttle is broken"
         )
         assert peak_in_flight >= 2, (
             f"peak concurrent dispatches was {peak_in_flight}, "
@@ -423,11 +423,14 @@ class TestMaxConcurrentDispatchesCap:
 class TestSubsystemTaskDescriptionDeterministic:
     def test_python_task_includes_component_paths_and_test_command(self):
         contract = {
-            "language": "python", "test_runner": "pytest",
+            "language": "python",
+            "test_runner": "pytest",
             "static_analyzer": ["ruff", "mypy"],
         }
         ss = {
-            "name": "ui", "src_dir": "src/ui/", "responsibilities": "render",
+            "name": "ui",
+            "src_dir": "src/ui/",
+            "responsibilities": "render",
             "components": [
                 {"name": "menu", "file": "src/ui/menu.py", "responsibility": "main menu"},
                 {"name": "hud", "file": "src/ui/hud.py", "responsibility": "in-game HUD"},
@@ -453,11 +456,14 @@ class TestSubsystemTaskDescriptionDeterministic:
 
     def test_typescript_task_uses_vitest_and_ts_paths(self):
         contract = {
-            "language": "typescript", "test_runner": "vitest",
+            "language": "typescript",
+            "test_runner": "vitest",
             "static_analyzer": ["eslint", "tsc --noEmit"],
         }
         ss = {
-            "name": "engine", "src_dir": "src/engine/", "responsibilities": "x",
+            "name": "engine",
+            "src_dir": "src/engine/",
+            "responsibilities": "x",
             "components": [
                 {"name": "loop", "file": "src/engine/loop.ts", "responsibility": "y"},
             ],
@@ -477,7 +483,8 @@ class TestSubsystemTaskDescriptionDeterministic:
         ):
             contract = {"language": lang, "test_runner": cmd, "static_analyzer": []}
             ss = {
-                "name": "x", "src_dir": src_pat.rsplit("/", 1)[0] + "/",
+                "name": "x",
+                "src_dir": src_pat.rsplit("/", 1)[0] + "/",
                 "responsibilities": "x",
                 "components": [
                     {"name": "comp", "file": src_pat, "responsibility": "y"},
@@ -495,7 +502,8 @@ class TestSubsystemTaskDescriptionDeterministic:
         # should still prefer one of the canonical languages.)
         contract = {"language": "haskell"}
         ss = {
-            "name": "x", "src_dir": "src/x/",
+            "name": "x",
+            "src_dir": "src/x/",
             "responsibilities": "x",
             "components": [{"name": "c", "file": "src/x/c.hs", "responsibility": "y"}],
         }
@@ -540,7 +548,9 @@ class TestSubsystemSkeletonTask:
     def test_python_skeleton_lists_components_and_interface(self):
         contract = {"language": "python"}
         ss = {
-            "name": "ui", "src_dir": "src/ui/", "responsibilities": "render",
+            "name": "ui",
+            "src_dir": "src/ui/",
+            "responsibilities": "render",
             "components": [
                 {"name": "menu", "file": "src/ui/menu.py", "responsibility": "main menu"},
                 {"name": "hud", "file": "src/ui/hud.py", "responsibility": "in-game HUD"},
@@ -560,7 +570,8 @@ class TestSubsystemSkeletonTask:
     def test_typescript_skeleton_uses_index_ts(self):
         contract = {"language": "typescript"}
         ss = {
-            "name": "engine", "src_dir": "src/engine/",
+            "name": "engine",
+            "src_dir": "src/engine/",
             "components": [{"name": "loop", "file": "src/engine/loop.ts", "responsibility": "tick"}],
         }
         text = _build_subsystem_skeleton_task(ss, contract, phase="implementation")
@@ -576,7 +587,8 @@ class TestComponentImplementationTask:
 
     def test_component_task_scopes_to_single_pair(self):
         contract = {
-            "language": "python", "test_runner": "pytest",
+            "language": "python",
+            "test_runner": "pytest",
             "static_analyzer": ["ruff", "mypy"],
         }
         ss = {"name": "ui", "src_dir": "src/ui/"}

--- a/tests/test_runtime/test_dispatch_subsystems.py
+++ b/tests/test_runtime/test_dispatch_subsystems.py
@@ -1,0 +1,605 @@
+"""Regression tests for the ``dispatch_subsystems`` primitive — the
+deterministic phase-3 fan-out that bypasses the orchestrator LLM's
+weak multi-tool-call output.
+
+The original symptom: vLLM logs showed ``Running: 1 reqs, Waiting: 0``
+even when the architecture had 4+ subsystems. RCA confirmed the
+weak orchestrator LLM (qwen3.6-35b on local vLLM) could not emit
+multiple ``dispatch_task`` tool_calls in one inference, so the N
+subsystems became N serial dispatches. Fix: build a primitive that
+needs only ONE tool call from the LLM (``dispatch_subsystems(phase=…)``)
+and runs the per-subsystem fan-out deterministically in Python from
+``docs/stack_contract.json``.
+
+This file exercises:
+
+1. The primitive is registered in the orchestrator toolset.
+2. Without ``docs/stack_contract.json`` it returns a ``failed`` result
+   pointing the orchestrator to dispatch architect.
+3. With a valid contract it dispatches one developer per subsystem in
+   parallel — measured via timestamps that overlap, not march
+   serially.
+4. ``max_concurrent_subsystem_dispatches`` actually throttles the
+   ThreadPoolExecutor: with cap=2, no more than 2 dispatches can be
+   in-flight at the same time even when there are 5 subsystems.
+5. Each subsystem's task_description (built by
+   ``_build_subsystem_task_description``) carries the correct
+   per-language toolchain row + components list — so the developer
+   that receives it can do real per-component TDD without the
+   orchestrator having drafted any of it.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from aise.runtime.models import AgentState
+from aise.runtime.runtime_config import RuntimeConfig
+from aise.runtime.tool_primitives import (
+    _LANGUAGE_TOOLCHAIN,
+    ToolContext,
+    WorkflowState,
+    _build_component_implementation_task,
+    _build_subsystem_skeleton_task,
+    _build_subsystem_task_description,
+    _interface_module_path,
+    build_orchestrator_tools,
+)
+
+
+def _build_ctx(
+    root: Path,
+    *,
+    handle_message_side_effect=None,
+    max_concurrent: int | None = None,
+) -> ToolContext:
+    """Build a ToolContext whose ``developer`` runtime is a MagicMock
+    with a controllable ``handle_message`` side effect (for timing
+    tests). The developer dispatch and parallel fan-out logic is real;
+    only the LLM call is mocked out.
+    """
+    fake_rt = MagicMock()
+    fake_rt._state = AgentState.ACTIVE
+    fake_rt.handle_message.side_effect = handle_message_side_effect or (lambda *a, **kw: "ok")
+    fake_rt.definition.role = "developer"
+    fake_rt.definition.metadata = {}
+
+    manager = MagicMock()
+    manager.runtimes = {"developer": fake_rt}
+    manager.get_runtime = lambda n: fake_rt if n == "developer" else None
+
+    cfg = RuntimeConfig()
+    if max_concurrent is not None:
+        cfg.safety_limits.max_concurrent_subsystem_dispatches = max_concurrent
+
+    return ToolContext(
+        manager=manager,
+        project_root=root,
+        config=cfg,
+        workflow_state=WorkflowState(),
+    )
+
+
+def _write_contract(root: Path, payload: dict) -> Path:
+    docs = root / "docs"
+    docs.mkdir(exist_ok=True)
+    p = docs / "stack_contract.json"
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    return p
+
+
+def _valid_contract(n_subsystems: int = 4) -> dict:
+    """Build a contract with N subsystems, each with 2 components."""
+    subsystems = []
+    for i in range(n_subsystems):
+        sname = f"sub{i}"
+        subsystems.append({
+            "name": sname,
+            "src_dir": f"src/{sname}/",
+            "responsibilities": f"{sname} responsibilities",
+            "components": [
+                {"name": f"comp_a_{i}", "file": f"src/{sname}/comp_a_{i}.py", "responsibility": "A"},
+                {"name": f"comp_b_{i}", "file": f"src/{sname}/comp_b_{i}.py", "responsibility": "B"},
+            ],
+        })
+    return {
+        "language": "python",
+        "test_runner": "pytest",
+        "static_analyzer": ["ruff", "mypy"],
+        "subsystems": subsystems,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Primitive registration
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchSubsystemsPrimitiveExists:
+    def test_registered_in_orchestrator_toolset(self, tmp_path):
+        ctx = _build_ctx(tmp_path)
+        tools = build_orchestrator_tools(ctx)
+        names = {t.name for t in tools}
+        assert "dispatch_subsystems" in names
+
+
+# ---------------------------------------------------------------------------
+# 2. Missing-contract behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchSubsystemsContractRequired:
+    def test_missing_contract_returns_failed_with_actionable_error(self, tmp_path):
+        ctx = _build_ctx(tmp_path)  # no docs/stack_contract.json
+        tools = build_orchestrator_tools(ctx)
+        ds = next(t for t in tools if t.name == "dispatch_subsystems")
+        result = json.loads(ds.invoke({"phase": "implementation"}))
+        assert result["status"] == "failed"
+        # Error should point the orchestrator at architect — not
+        # leave it guessing.
+        assert "architect" in result["error"].lower()
+
+    def test_legacy_modules_only_contract_is_rejected(self, tmp_path):
+        # An old-style flat modules[] contract is no longer accepted
+        # by dispatch_subsystems — architect must produce the new
+        # subsystems[].components[] schema before phase 3 can fan out.
+        _write_contract(tmp_path, {
+            "language": "python",
+            "modules": [{"name": "x", "src_dir": "src/x/"}],
+        })
+        ctx = _build_ctx(tmp_path)
+        tools = build_orchestrator_tools(ctx)
+        ds = next(t for t in tools if t.name == "dispatch_subsystems")
+        result = json.loads(ds.invoke({"phase": "implementation"}))
+        assert result["status"] == "failed"
+        assert "subsystems" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# 3. Real parallel fan-out
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchSubsystemsRunsInParallel:
+    def test_skeleton_stage_dispatched_concurrently(self, tmp_path):
+        """4 subsystems with default cap (4 concurrent) should all
+        START their *skeleton* dispatches before any FINISHES.
+
+        We measure stage 1 specifically by sleeping longer than the
+        per-thread overhead. ``dispatch_task`` retries empty /
+        artifact-missing dispatches once with context (see
+        ``_MAX_DISPATCH_RETRIES``), so a worker thread may invoke
+        ``handle_message`` more than once per dispatch — we record
+        the FIRST start time per thread to measure initial fan-out.
+        """
+        _write_contract(tmp_path, _valid_contract(n_subsystems=4))
+
+        first_start_per_thread: dict[int, float] = {}
+        finish_times: list[float] = []
+        lock = threading.Lock()
+
+        def slow_handle(*args, **kwargs):
+            tid = threading.get_ident()
+            t0 = time.monotonic()
+            with lock:
+                first_start_per_thread.setdefault(tid, t0)
+            time.sleep(0.3)
+            t1 = time.monotonic()
+            with lock:
+                finish_times.append(t1)
+            return "ok"
+
+        ctx = _build_ctx(tmp_path, handle_message_side_effect=slow_handle, max_concurrent=4)
+        tools = build_orchestrator_tools(ctx)
+        ds = next(t for t in tools if t.name == "dispatch_subsystems")
+        ds.invoke({"phase": "implementation"})
+
+        # At least 4 distinct worker threads ran the skeleton stage in
+        # parallel (additional threads from stage 2's component fan-out
+        # may push this higher; what we assert is real fan-out).
+        assert len(first_start_per_thread) >= 4, (
+            f"expected ≥4 distinct worker threads (one per subsystem skeleton), "
+            f"got {len(first_start_per_thread)}"
+        )
+        # The 4 EARLIEST starts must all happen before the first finish —
+        # that's the skeleton stage proving real concurrency.
+        starts = sorted(first_start_per_thread.values())[:4]
+        first_finish = min(finish_times)
+        for s in starts:
+            assert s <= first_finish, (
+                f"dispatch started at {s} after the first finish at {first_finish} — "
+                "indicates serial execution, not parallel"
+            )
+
+    def test_per_subsystem_skeleton_before_components(self, tmp_path):
+        """Within EACH subsystem, the skeleton dispatch must finish
+        before that subsystem's component dispatches begin — otherwise
+        a component would race ahead of its own skeleton's interface
+        module. Cross-subsystem ordering is intentionally NOT enforced:
+        a fast subsystem may already be deep into components while a
+        slow sibling is still scaffolding.
+        """
+        _write_contract(tmp_path, _valid_contract(n_subsystems=2))
+
+        # Each dispatch records (subsystem, phase, start, end) by
+        # parsing the prompt — stage-1 prompts include the subsystem
+        # name in "## Subsystem skeleton task: <name>" and stage-2
+        # prompts include "## Component implementation task: <sub>.<comp>".
+        events: list[tuple[str, str, float, float]] = []
+        lock = threading.Lock()
+
+        def phase_aware_handle(prompt, **_kwargs):
+            t0 = time.monotonic()
+            time.sleep(0.05)
+            t1 = time.monotonic()
+            if "Subsystem skeleton task: " in prompt:
+                phase = "skeleton"
+                sub = prompt.split("Subsystem skeleton task: ", 1)[1].split("\n", 1)[0].strip()
+            elif "Component implementation task: " in prompt:
+                phase = "component"
+                token = prompt.split("Component implementation task: ", 1)[1].split("\n", 1)[0].strip()
+                sub = token.split(".", 1)[0]
+            else:
+                phase, sub = "unknown", "?"
+            with lock:
+                events.append((sub, phase, t0, t1))
+            return "ok"
+
+        ctx = _build_ctx(tmp_path, handle_message_side_effect=phase_aware_handle, max_concurrent=4)
+        tools = build_orchestrator_tools(ctx)
+        ds = next(t for t in tools if t.name == "dispatch_subsystems")
+        ds.invoke({"phase": "implementation"})
+
+        # For each subsystem: every skeleton END (incl. retries) must
+        # be ≤ every component START in the SAME subsystem.
+        subsystems_seen = {sub for sub, _, _, _ in events if sub != "?"}
+        assert subsystems_seen == {"sub0", "sub1"}, subsystems_seen
+        for sub in subsystems_seen:
+            skel = [(t0, t1) for s, p, t0, t1 in events if s == sub and p == "skeleton"]
+            comp = [(t0, t1) for s, p, t0, t1 in events if s == sub and p == "component"]
+            assert skel, f"{sub}: no skeleton dispatch observed"
+            assert comp, f"{sub}: no component dispatch observed"
+            last_skel_end = max(t1 for _, t1 in skel)
+            first_comp_start = min(t0 for t0, _ in comp)
+            assert last_skel_end <= first_comp_start, (
+                f"{sub}: skeleton ended at {last_skel_end} but component started at "
+                f"{first_comp_start} — per-subsystem ordering broken"
+            )
+
+    def test_subsystems_overlap_each_other(self, tmp_path):
+        """Subsystems run fully in parallel — a slow subsystem's
+        skeleton must NOT block a sibling subsystem's components.
+        Concretely: at some point during the run, sub0's components
+        and sub1's skeleton (or vice versa) overlap in time.
+        """
+        _write_contract(tmp_path, _valid_contract(n_subsystems=2))
+
+        events: list[tuple[str, str, float, float]] = []
+        lock = threading.Lock()
+
+        def phase_aware_handle(prompt, **_kwargs):
+            t0 = time.monotonic()
+            time.sleep(0.1)
+            t1 = time.monotonic()
+            if "Subsystem skeleton task: " in prompt:
+                phase = "skeleton"
+                sub = prompt.split("Subsystem skeleton task: ", 1)[1].split("\n", 1)[0].strip()
+            elif "Component implementation task: " in prompt:
+                phase = "component"
+                token = prompt.split("Component implementation task: ", 1)[1].split("\n", 1)[0].strip()
+                sub = token.split(".", 1)[0]
+            else:
+                phase, sub = "unknown", "?"
+            with lock:
+                events.append((sub, phase, t0, t1))
+            return "ok"
+
+        ctx = _build_ctx(tmp_path, handle_message_side_effect=phase_aware_handle, max_concurrent=4)
+        tools = build_orchestrator_tools(ctx)
+        ds = next(t for t in tools if t.name == "dispatch_subsystems")
+        ds.invoke({"phase": "implementation"})
+
+        # Find any cross-subsystem time overlap. If subsystems were
+        # globally serialized into "all skeletons → all components",
+        # sub1's skeleton would start AFTER sub0's skeleton finishes,
+        # but sub0's COMPONENTS would only start AFTER all skeletons.
+        # Under the new design, sub0's components can overlap sub1's
+        # skeleton (the slow sibling).
+        def _overlaps(a, b):
+            return a[2] < b[3] and b[2] < a[3]
+
+        sub0_events = [e for e in events if e[0] == "sub0"]
+        sub1_events = [e for e in events if e[0] == "sub1"]
+        assert any(
+            _overlaps(a, b) for a in sub0_events for b in sub1_events
+        ), (
+            "no time overlap between sub0 and sub1 dispatches — "
+            "subsystems are not running in parallel"
+        )
+
+    def test_results_aggregate_includes_per_subsystem_status(self, tmp_path):
+        _write_contract(tmp_path, _valid_contract(n_subsystems=3))
+        ctx = _build_ctx(tmp_path, max_concurrent=4)
+        tools = build_orchestrator_tools(ctx)
+        ds = next(t for t in tools if t.name == "dispatch_subsystems")
+        out = json.loads(ds.invoke({"phase": "implementation"}))
+        # 3 subsystems × 2 components each = 3 skeleton + 6 component
+        # dispatches under the new two-stage flow.
+        assert out["subsystems_dispatched"] == 3
+        assert out["components_dispatched"] == 6
+        assert out["skeleton_completed"] + out["skeleton_failed"] == 3
+        assert out["components_completed"] + out["components_failed"] == 6
+        assert out["completed"] + out["failed"] == 9
+        # Skeleton results map back to subsystems; component results
+        # map to (subsystem, component) pairs so the LLM can pinpoint
+        # which slot fell over.
+        skel_names = {r["subsystem"] for r in out["skeleton_results"]}
+        assert skel_names == {"sub0", "sub1", "sub2"}
+        comp_pairs = {(r["subsystem"], r["component"]) for r in out["results"]}
+        expected_pairs = {(f"sub{i}", f"comp_{ab}_{i}") for i in range(3) for ab in ("a", "b")}
+        assert comp_pairs == expected_pairs
+
+
+# ---------------------------------------------------------------------------
+# 4. Throttling
+# ---------------------------------------------------------------------------
+
+
+class TestMaxConcurrentDispatchesCap:
+    def test_cap_limits_simultaneous_dispatches(self, tmp_path):
+        """With max_concurrent_subsystem_dispatches=2 and 5 subsystems,
+        the in-flight count must NEVER exceed 2 at any sampled
+        moment — even though the full execution still completes all 5.
+        Without the cap a single architect with 24 subsystems would
+        flood the LLM serving layer.
+        """
+        _write_contract(tmp_path, _valid_contract(n_subsystems=5))
+
+        in_flight = 0
+        peak_in_flight = 0
+        lock = threading.Lock()
+
+        def tracked_handle(*args, **kwargs):
+            nonlocal in_flight, peak_in_flight
+            with lock:
+                in_flight += 1
+                peak_in_flight = max(peak_in_flight, in_flight)
+            time.sleep(0.15)
+            with lock:
+                in_flight -= 1
+            return "ok"
+
+        ctx = _build_ctx(tmp_path, handle_message_side_effect=tracked_handle, max_concurrent=2)
+        tools = build_orchestrator_tools(ctx)
+        ds = next(t for t in tools if t.name == "dispatch_subsystems")
+        out = json.loads(ds.invoke({"phase": "implementation"}))
+
+        # 5 skeleton dispatches + 5×2 = 10 component dispatches = 15 total.
+        assert out["subsystems_dispatched"] == 5
+        assert out["components_dispatched"] == 10
+        assert peak_in_flight <= 2, (
+            f"peak concurrent dispatches was {peak_in_flight}, "
+            f"exceeded cap of 2 — throttle is broken"
+        )
+        assert peak_in_flight >= 2, (
+            f"peak concurrent dispatches was {peak_in_flight}, "
+            f"never reached cap of 2 — throttle may be over-restrictive "
+            f"or the test is degenerate"
+        )
+
+    def test_cap_of_one_serializes(self, tmp_path):
+        _write_contract(tmp_path, _valid_contract(n_subsystems=3))
+
+        in_flight = 0
+        peak = 0
+        lock = threading.Lock()
+
+        def tracked_handle(*args, **kwargs):
+            nonlocal in_flight, peak
+            with lock:
+                in_flight += 1
+                peak = max(peak, in_flight)
+            time.sleep(0.05)
+            with lock:
+                in_flight -= 1
+            return "ok"
+
+        ctx = _build_ctx(tmp_path, handle_message_side_effect=tracked_handle, max_concurrent=1)
+        tools = build_orchestrator_tools(ctx)
+        ds = next(t for t in tools if t.name == "dispatch_subsystems")
+        ds.invoke({"phase": "implementation"})
+        assert peak == 1
+
+
+# ---------------------------------------------------------------------------
+# 5. Deterministic per-subsystem task description
+# ---------------------------------------------------------------------------
+
+
+class TestSubsystemTaskDescriptionDeterministic:
+    def test_python_task_includes_component_paths_and_test_command(self):
+        contract = {
+            "language": "python", "test_runner": "pytest",
+            "static_analyzer": ["ruff", "mypy"],
+        }
+        ss = {
+            "name": "ui", "src_dir": "src/ui/", "responsibilities": "render",
+            "components": [
+                {"name": "menu", "file": "src/ui/menu.py", "responsibility": "main menu"},
+                {"name": "hud", "file": "src/ui/hud.py", "responsibility": "in-game HUD"},
+            ],
+        }
+        text = _build_subsystem_task_description(ss, contract, phase="implementation")
+        # Subsystem identity
+        assert "## Subsystem implementation task: ui" in text
+        assert "src/ui/" in text
+        # Each component appears with source + test paths derived
+        # deterministically from the language pattern.
+        assert "src/ui/menu.py" in text
+        assert "src/ui/hud.py" in text
+        assert "tests/ui/test_menu.py" in text
+        assert "tests/ui/test_hud.py" in text
+        # Toolchain commands rendered
+        assert "python -m pytest" in text
+        assert "ruff check" in text
+        assert "mypy" in text
+        # Anti-cross-contamination instruction so parallel sibling
+        # subsystems don't stomp on each other
+        assert "Do NOT touch source files outside src/ui/" in text
+
+    def test_typescript_task_uses_vitest_and_ts_paths(self):
+        contract = {
+            "language": "typescript", "test_runner": "vitest",
+            "static_analyzer": ["eslint", "tsc --noEmit"],
+        }
+        ss = {
+            "name": "engine", "src_dir": "src/engine/", "responsibilities": "x",
+            "components": [
+                {"name": "loop", "file": "src/engine/loop.ts", "responsibility": "y"},
+            ],
+        }
+        text = _build_subsystem_task_description(ss, contract, phase="implementation")
+        assert "src/engine/loop.ts" in text
+        assert "tests/engine/loop.test.ts" in text
+        assert "npx vitest run" in text
+        # No Python defaults leaked in
+        assert "pytest" not in text
+        assert ".py" not in text
+
+    def test_go_and_rust_paths(self):
+        for lang, src_pat, test_pat, cmd in (
+            ("go", "internal/x/comp.go", "internal/x/comp_test.go", "go test"),
+            ("rust", "src/x/comp.rs", "tests/x/comp.rs", "cargo test"),
+        ):
+            contract = {"language": lang, "test_runner": cmd, "static_analyzer": []}
+            ss = {
+                "name": "x", "src_dir": src_pat.rsplit("/", 1)[0] + "/",
+                "responsibilities": "x",
+                "components": [
+                    {"name": "comp", "file": src_pat, "responsibility": "y"},
+                ],
+            }
+            text = _build_subsystem_task_description(ss, contract, phase="implementation")
+            assert src_pat in text
+            assert test_pat in text
+            assert cmd in text
+
+    def test_unknown_language_falls_back_to_python_toolchain(self):
+        # Unknown / future languages don't crash the renderer; they
+        # fall back to the Python row so the developer at least gets
+        # SOME guidance instead of an empty task. (The architect
+        # should still prefer one of the canonical languages.)
+        contract = {"language": "haskell"}
+        ss = {
+            "name": "x", "src_dir": "src/x/",
+            "responsibilities": "x",
+            "components": [{"name": "c", "file": "src/x/c.hs", "responsibility": "y"}],
+        }
+        text = _build_subsystem_task_description(ss, contract, phase="implementation")
+        assert "## Subsystem implementation task: x" in text
+        # Falls back to python toolchain — better than crashing
+        assert "src/x/c.hs" in text
+
+
+# ---------------------------------------------------------------------------
+# 6. Toolchain table coverage
+# ---------------------------------------------------------------------------
+
+
+class TestLanguageToolchainCoverage:
+    def test_mainstream_languages_present(self):
+        for lang in ("python", "typescript", "javascript", "go", "rust", "java"):
+            assert lang in _LANGUAGE_TOOLCHAIN, (
+                f"mainstream language {lang!r} missing from "
+                f"_LANGUAGE_TOOLCHAIN — every Phase-3 fan-out for that "
+                f"language would fall back to Python defaults"
+            )
+
+    def test_each_row_has_required_keys(self):
+        for lang, row in _LANGUAGE_TOOLCHAIN.items():
+            for key in ("test_cmd", "test_path_pattern", "src_path_pattern", "static_check"):
+                assert key in row, f"{lang!r} toolchain missing {key!r}"
+
+
+# ---------------------------------------------------------------------------
+# 7. Two-stage helpers (skeleton + per-component)
+# ---------------------------------------------------------------------------
+
+
+class TestSubsystemSkeletonTask:
+    """Stage-1 skeleton task: scaffolds module files + interface module
+    WITHOUT implementing logic or writing tests. Keeps the dispatch
+    budget per subsystem bounded so the recursion limit doesn't bite
+    even on subsystems with many components.
+    """
+
+    def test_python_skeleton_lists_components_and_interface(self):
+        contract = {"language": "python"}
+        ss = {
+            "name": "ui", "src_dir": "src/ui/", "responsibilities": "render",
+            "components": [
+                {"name": "menu", "file": "src/ui/menu.py", "responsibility": "main menu"},
+                {"name": "hud", "file": "src/ui/hud.py", "responsibility": "in-game HUD"},
+            ],
+        }
+        text = _build_subsystem_skeleton_task(ss, contract, phase="implementation")
+        assert "## Subsystem skeleton task: ui" in text
+        # Each component's file listed for skeleton creation
+        assert "src/ui/menu.py" in text
+        assert "src/ui/hud.py" in text
+        # Interface module is named explicitly so the worker writes it
+        assert "src/ui/__init__.py" in text
+        # Skeleton phase MUST forbid logic/tests so stage 2 owns those
+        assert "NO logic" in text or "no logic" in text.lower()
+        assert "NO tests" in text or "no tests" in text.lower()
+
+    def test_typescript_skeleton_uses_index_ts(self):
+        contract = {"language": "typescript"}
+        ss = {
+            "name": "engine", "src_dir": "src/engine/",
+            "components": [{"name": "loop", "file": "src/engine/loop.ts", "responsibility": "tick"}],
+        }
+        text = _build_subsystem_skeleton_task(ss, contract, phase="implementation")
+        assert "src/engine/index.ts" in text
+        # No Python convention leaked into a TS skeleton
+        assert "__init__.py" not in text
+
+
+class TestComponentImplementationTask:
+    """Stage-2 per-component task: a single component owns one source
+    + one test file, against the skeleton's frozen public API.
+    """
+
+    def test_component_task_scopes_to_single_pair(self):
+        contract = {
+            "language": "python", "test_runner": "pytest",
+            "static_analyzer": ["ruff", "mypy"],
+        }
+        ss = {"name": "ui", "src_dir": "src/ui/"}
+        comp = {"name": "menu", "file": "src/ui/menu.py", "responsibility": "main menu"}
+        text = _build_component_implementation_task(ss, comp, contract, phase="implementation")
+        assert "## Component implementation task: ui.menu" in text
+        assert "src/ui/menu.py" in text
+        assert "tests/ui/test_menu.py" in text
+        assert "src/ui/__init__.py" in text  # interface module reference
+        assert "python -m pytest tests/ui/test_menu.py" in text
+        assert "ruff check src/ui/menu.py" in text
+        # Anti-cross-contamination so siblings don't race
+        assert "DO NOT modify any source file other than" in text
+
+
+class TestInterfaceModulePath:
+    def test_python_default_is_init_py(self):
+        assert _interface_module_path("python", "ui", "src/ui/") == "src/ui/__init__.py"
+
+    def test_typescript_default_is_index_ts(self):
+        assert _interface_module_path("typescript", "engine", "src/engine") == "src/engine/index.ts"
+
+    def test_unknown_language_falls_back_to_init_py(self):
+        # Worker still has a meaningful interface filename; the
+        # architect ought to pick a canonical language anyway.
+        assert _interface_module_path("haskell", "x", "src/x").endswith("__init__.py")

--- a/tests/test_runtime/test_project_session.py
+++ b/tests/test_runtime/test_project_session.py
@@ -177,6 +177,44 @@ class TestProjectSessionTools:
         assert requests, "expected at least one task_request event"
         assert requests[-1]["payload"]["task"] == "Implement module X"
 
+    def test_dispatch_emits_token_usage_events(self, session):
+        """dispatch_task must wire an ``on_token_usage`` callback into
+        the worker's ``handle_message`` and surface each round-trip as
+        a ``token_usage`` event on the orchestrator's event log so the
+        web layer can aggregate per-WorkflowRun totals without parsing
+        trace files at runtime.
+        """
+        tools = session._make_tools()
+        dispatch = next(t for t in tools if t.name == "dispatch_task")
+
+        target = session._manager.get_runtime("developer")
+        original_handle = target.handle_message
+
+        def _emit_two_calls(prompt, **kw):
+            cb = kw.get("on_token_usage")
+            if cb is not None:
+                cb({"input_tokens": 10, "output_tokens": 4, "total_tokens": 14})
+                cb({"input_tokens": 6, "output_tokens": 2, "total_tokens": 8})
+            return original_handle(prompt, **kw)
+
+        target.handle_message = _emit_two_calls
+
+        dispatch.invoke(
+            {
+                "agent_name": "developer",
+                "task_description": "produce something",
+            }
+        )
+
+        token_events = [e for e in session.task_log if e["type"] == "token_usage"]
+        assert len(token_events) == 2
+        assert token_events[0]["agent"] == "developer"
+        assert token_events[0]["input_tokens"] == 10
+        assert token_events[0]["output_tokens"] == 4
+        assert token_events[0]["total_tokens"] == 14
+        # Second call gets summed by upstream consumers (web layer).
+        assert token_events[1]["input_tokens"] == 6
+
     def test_dispatch_without_original_requirement_is_unchanged(self, session):
         """Default (empty) requirement means no prefix — preserves the
         existing contract for unit tests and any caller that invokes
@@ -272,17 +310,37 @@ class TestPhase6DeliveryReport:
     """
 
     def test_phase6_prompt_collects_implementation_metrics(self, session):
+        """Phase-6 reads test results from docs/qa_report.json (the QA
+        engineer's structured output) instead of re-running pytest
+        itself — running pytest twice introduces flakiness that hides
+        QA-flagged failures. Source LOC is still gathered live via
+        ``find`` + ``wc -l`` because QA does not produce that.
+        """
         phases = session._build_phase_prompts("Build a thing")
         delivery = dict(phases).get("delivery", "")
-        # Runs shell commands to count files / LOC / tests / coverage.
-        assert "execute_shell" in delivery or "execute(" in delivery
-        # Source counting via find + wc -l (language-agnostic multi-ext).
+        # Source-LOC commands: still language-agnostic via find + wc -l.
         assert "wc -l" in delivery
         assert "find src" in delivery
-        # Test counting via pytest --collect-only.
-        assert "--collect-only" in delivery or "collect-only" in delivery
-        # Coverage attempted but optional — must mention --cov.
-        assert "--cov" in delivery
+        # Test results: read structured QA report, NOT re-run pytest.
+        assert "qa_report.json" in delivery, (
+            "Phase 6 must read docs/qa_report.json instead of re-running "
+            "pytest (avoids flakiness covering up QA findings)"
+        )
+        # Anti-regression: the prompt must NOT instruct the orchestrator
+        # to run the full test suite or coverage tool. That belongs to
+        # the QA engineer in Phase 5.
+        bad_substrings = (
+            "python -m pytest tests/ --cov",
+            "python -m pytest tests/ -q",
+            "go test ./... 2>&1",
+            "cargo test 2>&1",
+        )
+        for bad in bad_substrings:
+            assert bad not in delivery, (
+                f"Phase 6 prompt re-runs the test suite ({bad!r}) — that "
+                f"causes flaky overrides of QA findings. Read qa_report.json "
+                f"instead."
+            )
 
     def test_phase6_prompt_dispatches_product_manager(self, session):
         phases = session._build_phase_prompts("Build a thing")
@@ -303,12 +361,23 @@ class TestPhase6DeliveryReport:
 
     def test_phase6_prompt_forbids_fabricated_numbers(self, session):
         phases = session._build_phase_prompts("Build a thing")
-        delivery = dict(phases).get("delivery", "")
-        # Explicit anti-fabrication clause — PM must cite real outputs.
-        assert (
-            "do not invent numbers" in delivery.lower()
-            or "do not fabricate" in delivery.lower()
-            or "do not guess" in delivery.lower()
+        # The anti-fabrication / read-qa-verbatim clause may be
+        # word-wrapped across newlines, so collapse whitespace before
+        # matching to make the assertion robust to template formatting.
+        delivery = " ".join(dict(phases).get("delivery", "").split()).lower()
+        # Either the explicit anti-fabrication clause, or the new
+        # design's stronger "read qa_report verbatim" instruction.
+        guards = (
+            "do not invent numbers",
+            "do not fabricate",
+            "do not guess",
+            "cite verbatim",
+            "verbatim",
+        )
+        assert any(g in delivery for g in guards), (
+            "Phase 6 prompt must include an anti-fabrication clause OR a "
+            "read-qa-verbatim instruction so the PM cannot rewrite QA's "
+            "structured findings"
         )
 
     def test_phase6_prompt_ends_with_mark_complete(self, session):
@@ -501,13 +570,42 @@ class TestPhase6DeliveryReport:
         assert "mermaid" in architecture.lower()
 
     def test_phase3_prompt_requires_code_inspection(self, session):
-        """Phase 3 prompt must instruct the developer to run the
-        static analyzer via the ``code_inspection`` skill after tests
-        pass."""
-        phases = session._build_phase_prompts("Build a thing")
-        implementation = dict(phases).get("implementation", "")
-        assert "code_inspection" in implementation
-        assert "ruff" in implementation or "static analyzer" in implementation.lower()
+        """Phase 3's code-inspection requirement is now embedded in
+        the per-subsystem task description that ``dispatch_subsystems``
+        renders deterministically (see
+        ``tool_primitives._build_subsystem_task_description``), not in
+        the orchestrator prompt itself. The orchestrator prompt only
+        has to tell the orchestrator to call ``dispatch_subsystems``
+        once; the rendered worker task is what carries the static-
+        analyzer instruction.
+
+        This test asserts the per-subsystem renderer references the
+        ``static_check`` toolchain row so every developer dispatch
+        gets the static-analysis step.
+        """
+        from aise.runtime.tool_primitives import (
+            _LANGUAGE_TOOLCHAIN,
+            _build_subsystem_task_description,
+        )
+        # Each language row must contain a static_check command — that
+        # is the in-task instruction shown to the developer.
+        for lang, row in _LANGUAGE_TOOLCHAIN.items():
+            assert "static_check" in row, (
+                f"language {lang!r} toolchain missing static_check command"
+            )
+        # Sanity: the rendered task description for one Python
+        # subsystem must mention the analyzer phase explicitly.
+        rendered = _build_subsystem_task_description(
+            subsystem={
+                "name": "core", "src_dir": "src/core/",
+                "responsibilities": "x",
+                "components": [{"name": "engine", "file": "src/core/engine.py", "responsibility": "y"}],
+            },
+            contract={"language": "python", "test_runner": "pytest", "static_analyzer": ["ruff", "mypy"]},
+            phase="implementation",
+        )
+        assert "INSPECT" in rendered
+        assert "static analyzer" in rendered.lower() or "ruff" in rendered
 
     def test_code_inspection_skill_file_exists(self):
         """The ``code_inspection`` skill body must live at the
@@ -586,6 +684,120 @@ class TestProjectSessionPhaseEvents:
         session.run("Fresh run")
         resumes = [e for e in session.task_log if e.get("type") == "phase_resume"]
         assert resumes == []
+
+
+class TestDispatchCapDynamicFloor:
+    """A1: ``ProjectSession`` raises ``max_dispatches`` to a per-run
+    floor derived from the architect's stack contract so the cap
+    auto-scales with the actual architecture.
+
+    Regression for project_7-tower run_3f53c0dcc5: 30 dispatches was
+    fewer than 5 subsystems + 32 components and the gameplay
+    subsystem got truncated. The floor must be Σ(1 + components) +
+    DISPATCH_FLOOR_BUFFER.
+    """
+
+    def _seed_contract(self, project_root, n_subsystems: int, comps_per: int) -> None:
+        import json as _json
+        docs = project_root / "docs"
+        docs.mkdir(parents=True, exist_ok=True)
+        subsystems = []
+        for i in range(n_subsystems):
+            subsystems.append({
+                "name": f"sub{i}",
+                "src_dir": f"src/sub{i}/",
+                "components": [
+                    {"name": f"c{j}", "file": f"src/sub{i}/c{j}.py"} for j in range(comps_per)
+                ],
+            })
+        (docs / "stack_contract.json").write_text(
+            _json.dumps({"language": "python", "subsystems": subsystems}),
+            encoding="utf-8",
+        )
+
+    def test_floor_raises_cap_when_contract_exceeds_default(self, started_manager, tmp_path):
+        from unittest.mock import patch as _patch
+
+        from aise.runtime.runtime_config import DISPATCH_FLOOR_BUFFER, RuntimeConfig
+
+        # Force the default low so the contract clearly forces a raise
+        # regardless of what the global default is set to.
+        rc = RuntimeConfig()
+        rc.safety_limits.max_dispatches = 10
+
+        self._seed_contract(tmp_path, n_subsystems=5, comps_per=10)
+
+        with _patch.object(ProjectSession, "_build_pm_runtime") as mock_build:
+            pm_rt = MagicMock()
+            pm_rt.handle_message.return_value = "ok"
+            mock_build.return_value = pm_rt
+            sess = ProjectSession(
+                started_manager,
+                project_root=tmp_path,
+                runtime_config=rc,
+            )
+            sess._apply_dispatch_floor(reason="unit_test")
+
+        # 5 subsystems × (1 skeleton + 10 components) = 55, plus buffer.
+        expected_floor = 5 * (1 + 10) + DISPATCH_FLOOR_BUFFER
+        assert sess._config.safety_limits.max_dispatches == expected_floor
+
+        events = [e for e in sess.task_log if e.get("type") == "dispatch_cap_raised"]
+        assert events, "expected a dispatch_cap_raised event"
+        assert events[-1]["to"] == expected_floor
+        assert events[-1]["from"] == 10
+
+    def test_floor_does_not_lower_an_already_higher_cap(self, started_manager, tmp_path):
+        from unittest.mock import patch as _patch
+
+        from aise.runtime.runtime_config import RuntimeConfig
+
+        rc = RuntimeConfig()
+        rc.safety_limits.max_dispatches = 1024  # explicit project override
+
+        self._seed_contract(tmp_path, n_subsystems=2, comps_per=2)
+
+        with _patch.object(ProjectSession, "_build_pm_runtime") as mock_build:
+            pm_rt = MagicMock()
+            pm_rt.handle_message.return_value = "ok"
+            mock_build.return_value = pm_rt
+            sess = ProjectSession(
+                started_manager,
+                project_root=tmp_path,
+                runtime_config=rc,
+            )
+            sess._apply_dispatch_floor(reason="unit_test")
+
+        # Floor here is 2*(1+2)+16 = 22 — far below 1024. The override
+        # must NOT be lowered.
+        assert sess._config.safety_limits.max_dispatches == 1024
+        # And no raise event fires when there's nothing to raise.
+        events = [e for e in sess.task_log if e.get("type") == "dispatch_cap_raised"]
+        assert events == []
+
+    def test_floor_noop_when_contract_missing(self, started_manager, tmp_path):
+        """No contract on disk → leave the cap untouched. Architect
+        hasn't run yet; the post-phase hook will re-apply once it does.
+        """
+        from unittest.mock import patch as _patch
+
+        from aise.runtime.runtime_config import RuntimeConfig
+
+        rc = RuntimeConfig()
+        original_cap = rc.safety_limits.max_dispatches
+
+        with _patch.object(ProjectSession, "_build_pm_runtime") as mock_build:
+            pm_rt = MagicMock()
+            pm_rt.handle_message.return_value = "ok"
+            mock_build.return_value = pm_rt
+            sess = ProjectSession(
+                started_manager,
+                project_root=tmp_path,
+                runtime_config=rc,
+            )
+            sess._apply_dispatch_floor(reason="unit_test")
+
+        assert sess._config.safety_limits.max_dispatches == original_cap
 
 
 class TestProjectSessionRun:

--- a/tests/test_runtime/test_project_session.py
+++ b/tests/test_runtime/test_project_session.py
@@ -587,17 +587,17 @@ class TestPhase6DeliveryReport:
             _LANGUAGE_TOOLCHAIN,
             _build_subsystem_task_description,
         )
+
         # Each language row must contain a static_check command — that
         # is the in-task instruction shown to the developer.
         for lang, row in _LANGUAGE_TOOLCHAIN.items():
-            assert "static_check" in row, (
-                f"language {lang!r} toolchain missing static_check command"
-            )
+            assert "static_check" in row, f"language {lang!r} toolchain missing static_check command"
         # Sanity: the rendered task description for one Python
         # subsystem must mention the analyzer phase explicitly.
         rendered = _build_subsystem_task_description(
             subsystem={
-                "name": "core", "src_dir": "src/core/",
+                "name": "core",
+                "src_dir": "src/core/",
                 "responsibilities": "x",
                 "components": [{"name": "engine", "file": "src/core/engine.py", "responsibility": "y"}],
             },
@@ -699,17 +699,18 @@ class TestDispatchCapDynamicFloor:
 
     def _seed_contract(self, project_root, n_subsystems: int, comps_per: int) -> None:
         import json as _json
+
         docs = project_root / "docs"
         docs.mkdir(parents=True, exist_ok=True)
         subsystems = []
         for i in range(n_subsystems):
-            subsystems.append({
-                "name": f"sub{i}",
-                "src_dir": f"src/sub{i}/",
-                "components": [
-                    {"name": f"c{j}", "file": f"src/sub{i}/c{j}.py"} for j in range(comps_per)
-                ],
-            })
+            subsystems.append(
+                {
+                    "name": f"sub{i}",
+                    "src_dir": f"src/sub{i}/",
+                    "components": [{"name": f"c{j}", "file": f"src/sub{i}/c{j}.py"} for j in range(comps_per)],
+                }
+            )
         (docs / "stack_contract.json").write_text(
             _json.dumps({"language": "python", "subsystems": subsystems}),
             encoding="utf-8",

--- a/tests/test_runtime/test_runtime_config.py
+++ b/tests/test_runtime/test_runtime_config.py
@@ -4,6 +4,7 @@ from aise.runtime.models import ProcessCaps
 from aise.runtime.runtime_config import (
     DEFAULT_MAX_CONTINUATIONS,
     DEFAULT_MAX_DISPATCHES,
+    DISPATCH_FLOOR_BUFFER,
     RuntimeConfig,
     SafetyLimits,
     ShellConfig,
@@ -15,6 +16,17 @@ class TestSafetyLimits:
         limits = SafetyLimits()
         assert limits.max_dispatches == DEFAULT_MAX_DISPATCHES
         assert limits.max_continuations == DEFAULT_MAX_CONTINUATIONS
+
+    def test_max_dispatches_default_covers_typical_architecture(self):
+        """The default must accommodate a realistic architecture: 5
+        subsystems / ~32 components → 5 + 32 + ~6 (PM/architect/main/
+        qa/delivery) ≈ 43 dispatches. Anything < 64 retroactively
+        truncates the last subsystem (project_7-tower regression).
+        """
+        assert DEFAULT_MAX_DISPATCHES >= 64
+        # Buffer must leave room for the orchestration phases on top
+        # of pure subsystem fan-out.
+        assert DISPATCH_FLOOR_BUFFER >= 8
 
     def test_overlay_with_no_caps_returns_self(self):
         limits = SafetyLimits()

--- a/tests/test_runtime/test_safety_net.py
+++ b/tests/test_runtime/test_safety_net.py
@@ -311,13 +311,18 @@ class TestRepairFailureEmitsEvent:
 
 class TestScaffoldingExpectations:
     def test_set_matches_pm_scaffolding_contract(self) -> None:
-        """The tuple must describe exactly what ``product_manager.md``
-        promises to produce during SCAFFOLDING TASK: git repo +
-        .gitignore + 7 subdirs. If this drifts, the PM's contract and
-        the safety net's checks fall out of sync."""
+        """The tuple must describe what ``product_manager.md``
+        promises to produce during SCAFFOLDING TASK (git repo +
+        .gitignore + 7 subdirs) PLUS the leftover-file guards that
+        catch carryover from prior runs (project_5 / project_7
+        bequeathed a stale ``package.json`` etc. into freshly
+        scaffolded projects). If either set drifts, the PM's
+        contract and the safety net's checks fall out of sync.
+        """
         specs = scaffolding_expectations()
         descriptions = {a.describe() for a in specs}
-        expected = {
+        # Positive: artifacts that MUST exist post-scaffold.
+        required = {
             "git_repo",
             "file:.gitignore",
             "dir:docs",
@@ -328,7 +333,26 @@ class TestScaffoldingExpectations:
             "dir:artifacts",
             "dir:trace",
         }
-        assert descriptions == expected
+        assert required.issubset(descriptions), (
+            f"missing required scaffolding artifacts: "
+            f"{required - descriptions}"
+        )
+        # Negative: leftover-file guards (must_not_exist). Subset
+        # check — the canonical list may grow over time. The paths
+        # below were the ones observed in real failed runs and so are
+        # the load-bearing minimum.
+        leftover_must_be_guarded = {
+            "must_not_exist:package.json",
+            "must_not_exist:node_modules",
+            "must_not_exist:Cargo.toml",
+            "must_not_exist:go.mod",
+            "must_not_exist:pyproject.toml",
+            "must_not_exist:.coverage",
+        }
+        assert leftover_must_be_guarded.issubset(descriptions), (
+            f"missing leftover-file guards: "
+            f"{leftover_must_be_guarded - descriptions}"
+        )
 
     def test_empty_project_gets_fully_repaired(self, tmp_path: Path) -> None:
         """Integration-style: start from nothing, run the scaffolding

--- a/tests/test_runtime/test_safety_net.py
+++ b/tests/test_runtime/test_safety_net.py
@@ -333,10 +333,7 @@ class TestScaffoldingExpectations:
             "dir:artifacts",
             "dir:trace",
         }
-        assert required.issubset(descriptions), (
-            f"missing required scaffolding artifacts: "
-            f"{required - descriptions}"
-        )
+        assert required.issubset(descriptions), f"missing required scaffolding artifacts: {required - descriptions}"
         # Negative: leftover-file guards (must_not_exist). Subset
         # check — the canonical list may grow over time. The paths
         # below were the ones observed in real failed runs and so are
@@ -350,8 +347,7 @@ class TestScaffoldingExpectations:
             "must_not_exist:.coverage",
         }
         assert leftover_must_be_guarded.issubset(descriptions), (
-            f"missing leftover-file guards: "
-            f"{leftover_must_be_guarded - descriptions}"
+            f"missing leftover-file guards: {leftover_must_be_guarded - descriptions}"
         )
 
     def test_empty_project_gets_fully_repaired(self, tmp_path: Path) -> None:

--- a/tests/test_runtime/test_stack_contract.py
+++ b/tests/test_runtime/test_stack_contract.py
@@ -1,0 +1,320 @@
+"""Regression tests for the architect-defined stack contract that
+gates the rest of the pipeline.
+
+Three guarantees are exercised:
+
+1. ``_load_stack_contract_block`` — the helper that turns
+   ``docs/stack_contract.json`` into a ``=== STACK CONTRACT ===``
+   block prepended to every worker dispatch. Missing / malformed
+   files must return ``""`` (back-compat with old projects). Valid
+   contracts must produce a deterministic, key-ordered block.
+
+2. ``dispatch_task`` — when the project root contains a stack
+   contract, the worker prompt MUST start with both the user
+   requirement block and the contract block (contract first, then
+   requirement, then the orchestrator-drafted task description).
+   Without the project root or contract, the task description must
+   pass through unchanged.
+
+3. ``safety_net`` — the new ``architecture_expectations()`` and
+   ``qa_expectations()`` helpers must list the structured artifacts
+   their phase produces, so a missing contract / report triggers a
+   re-dispatch.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from aise.runtime.models import AgentState
+from aise.runtime.runtime_config import RuntimeConfig
+from aise.runtime.safety_net import (
+    REPAIR_ACTIONS,
+    ExpectedArtifact,
+    _artifact_present,
+    architecture_expectations,
+    qa_expectations,
+    scaffolding_expectations,
+)
+from aise.runtime.tool_primitives import (
+    ToolContext,
+    WorkflowState,
+    _load_stack_contract_block,
+    build_orchestrator_tools,
+)
+
+# ---------------------------------------------------------------------------
+# 1. Contract loader
+# ---------------------------------------------------------------------------
+
+
+class TestLoadStackContractBlock:
+    def test_returns_empty_when_project_root_is_none(self):
+        assert _load_stack_contract_block(None) == ""
+
+    def test_returns_empty_when_file_missing(self, tmp_path):
+        assert _load_stack_contract_block(tmp_path) == ""
+
+    def test_returns_empty_for_malformed_json(self, tmp_path):
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "stack_contract.json").write_text("{not valid")
+        assert _load_stack_contract_block(tmp_path) == ""
+
+    def test_returns_empty_when_top_level_is_not_object(self, tmp_path):
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "stack_contract.json").write_text("[]")
+        assert _load_stack_contract_block(tmp_path) == ""
+
+    def test_renders_known_keys_in_canonical_order(self, tmp_path):
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "stack_contract.json").write_text(json.dumps({
+            # Provide keys in scrambled order to confirm output
+            # follows the canonical _STACK_CONTRACT_KEYS ordering.
+            "ui_kind": "phaser",
+            "language": "typescript",
+            "test_runner": "vitest",
+            "framework_backend": "fastify",
+            "static_analyzer": ["npx tsc --noEmit", "eslint ."],
+            "entry_point": "src/index.ts",
+            "ui_required": True,
+            "framework_frontend": "phaser",
+            "package_manager": "npm",
+            "project_config_file": "package.json",
+            "run_command": "npm run dev",
+            "runtime": "node",
+        }))
+        block = _load_stack_contract_block(tmp_path)
+        # Sentinel header + footer
+        assert "=== STACK CONTRACT" in block
+        assert "=== END STACK CONTRACT ===" in block
+        # Each key appears on its own line — and "language" precedes
+        # "ui_kind" because the canonical order puts language first.
+        lang_idx = block.index("language: typescript")
+        uikind_idx = block.index("ui_kind: phaser")
+        assert lang_idx < uikind_idx, (
+            "block must follow canonical key ordering, not the JSON "
+            "object's serialization order"
+        )
+        # Lists are joined with ", " so the orchestrator sees a single
+        # readable line per field.
+        assert "static_analyzer: npx tsc --noEmit, eslint ." in block
+
+    def test_unknown_keys_are_silently_ignored(self, tmp_path):
+        """A future architect might add extra fields. The loader must
+        not crash or expose them in the prompt — only the canonical
+        keys round-trip."""
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "stack_contract.json").write_text(json.dumps({
+            "language": "go",
+            "novel_field_from_the_future": "should not appear in block",
+        }))
+        block = _load_stack_contract_block(tmp_path)
+        assert "language: go" in block
+        assert "novel_field_from_the_future" not in block
+
+
+# ---------------------------------------------------------------------------
+# 2. dispatch_task injection behaviour
+# ---------------------------------------------------------------------------
+
+
+def _build_ctx(root: Path | None, *, requirement: str = "") -> ToolContext:
+    """Construct a ToolContext with a single mocked-out worker
+    runtime called ``developer`` (returns ``"ok"`` from
+    ``handle_message``)."""
+    fake_rt = MagicMock()
+    fake_rt._state = AgentState.ACTIVE
+    fake_rt.handle_message.return_value = "ok"
+    fake_rt.definition.role = "developer"
+    fake_rt.definition.metadata = {}
+
+    manager = MagicMock()
+    manager.runtimes = {"developer": fake_rt}
+    manager.get_runtime = lambda n: fake_rt if n == "developer" else None
+
+    return ToolContext(
+        manager=manager,
+        project_root=root,
+        config=RuntimeConfig(),
+        workflow_state=WorkflowState(),
+        original_requirement=requirement,
+    )
+
+
+class TestDispatchTaskInjectsContract:
+    def _capture_worker_prompt(self, ctx: ToolContext, task: str) -> str:
+        """Helper: invoke dispatch_task, return the exact prompt the
+        worker's handle_message received."""
+        target = ctx.manager.get_runtime("developer")
+        captured = {}
+        original_handle = target.handle_message
+
+        def _capture(prompt, **kw):
+            captured["prompt"] = prompt
+            return original_handle(prompt, **kw)
+
+        target.handle_message = _capture
+        tools = build_orchestrator_tools(ctx)
+        dispatch = next(t for t in tools if t.name == "dispatch_task")
+        dispatch.invoke({"agent_name": "developer", "task_description": task})
+        return captured["prompt"]
+
+    def test_no_contract_no_requirement_passes_task_through(self):
+        with tempfile.TemporaryDirectory() as d:
+            ctx = _build_ctx(Path(d))
+            prompt = self._capture_worker_prompt(ctx, "raw task")
+            assert prompt == "raw task"
+
+    def test_requirement_only_prefixes_requirement_block(self):
+        with tempfile.TemporaryDirectory() as d:
+            ctx = _build_ctx(Path(d), requirement="创建一个贪吃蛇游戏")
+            prompt = self._capture_worker_prompt(ctx, "Implement X")
+            assert "=== ORIGINAL USER REQUIREMENT" in prompt
+            assert "创建一个贪吃蛇游戏" in prompt
+            assert "Implement X" in prompt
+            # No contract block when the file is absent.
+            assert "=== STACK CONTRACT" not in prompt
+
+    def test_contract_present_prepends_block_before_requirement(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            (root / "docs").mkdir()
+            (root / "docs" / "stack_contract.json").write_text(json.dumps({
+                "language": "typescript",
+                "framework_backend": "fastify",
+                "test_runner": "vitest",
+                "entry_point": "src/index.ts",
+                "run_command": "npm run dev",
+                "ui_required": False,
+                "ui_kind": "",
+            }))
+            ctx = _build_ctx(root, requirement="Build a tower defense game")
+            prompt = self._capture_worker_prompt(ctx, "Implement auth module")
+            # All three blocks present
+            assert "=== STACK CONTRACT" in prompt
+            assert "=== ORIGINAL USER REQUIREMENT" in prompt
+            assert "Implement auth module" in prompt
+            # Order: STACK CONTRACT first, then user requirement, then task
+            stack_idx = prompt.index("=== STACK CONTRACT")
+            req_idx = prompt.index("=== ORIGINAL USER REQUIREMENT")
+            task_idx = prompt.index("Implement auth module")
+            assert stack_idx < req_idx < task_idx, (
+                f"prompt ordering wrong: stack={stack_idx} req={req_idx} task={task_idx}"
+            )
+            # Specific stack values reach the worker
+            assert "language: typescript" in prompt
+            assert "framework_backend: fastify" in prompt
+
+    def test_contract_alone_without_requirement_still_prepends(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            (root / "docs").mkdir()
+            (root / "docs" / "stack_contract.json").write_text(json.dumps({
+                "language": "go",
+                "test_runner": "go test",
+            }))
+            ctx = _build_ctx(root)  # empty requirement
+            prompt = self._capture_worker_prompt(ctx, "do thing")
+            assert "=== STACK CONTRACT" in prompt
+            assert "language: go" in prompt
+            # No ORIGINAL USER REQUIREMENT (nothing to prepend)
+            assert "=== ORIGINAL USER REQUIREMENT" not in prompt
+            assert "do thing" in prompt
+
+
+# ---------------------------------------------------------------------------
+# 3. safety_net expectations
+# ---------------------------------------------------------------------------
+
+
+class TestArchitectureExpectations:
+    def test_lists_architecture_md_and_stack_contract(self):
+        exps = architecture_expectations()
+        paths = {(e.path, e.kind) for e in exps}
+        assert ("docs/architecture.md", "file") in paths
+        # docs/stack_contract.json uses the dedicated ``stack_contract``
+        # validator kind, not generic json_file. The validator enforces
+        # the two-level subsystems[].components[] schema instead of just
+        # checking JSON parseability.
+        assert ("docs/stack_contract.json", "stack_contract") in paths
+
+    def test_qa_expectations_list_qa_report(self):
+        exps = qa_expectations()
+        paths = {(e.path, e.kind) for e in exps}
+        assert ("docs/qa_report.json", "json_file") in paths
+
+
+class TestJsonFileArtifact:
+    def test_missing_file_fails(self, tmp_path):
+        art = ExpectedArtifact(path="docs/x.json", kind="json_file", non_empty=True)
+        assert _artifact_present(tmp_path, art) is False
+
+    def test_invalid_json_fails(self, tmp_path):
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "x.json").write_text("{not json")
+        art = ExpectedArtifact(path="docs/x.json", kind="json_file", non_empty=True)
+        assert _artifact_present(tmp_path, art) is False
+
+    def test_valid_json_passes(self, tmp_path):
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "x.json").write_text(json.dumps({"a": 1}))
+        art = ExpectedArtifact(path="docs/x.json", kind="json_file", non_empty=True)
+        assert _artifact_present(tmp_path, art) is True
+
+
+class TestMustNotExistArtifact:
+    def test_missing_file_passes(self, tmp_path):
+        art = ExpectedArtifact(path="package.json", kind="must_not_exist")
+        assert _artifact_present(tmp_path, art) is True
+
+    def test_present_file_fails(self, tmp_path):
+        (tmp_path / "package.json").write_text("{}")
+        art = ExpectedArtifact(path="package.json", kind="must_not_exist")
+        assert _artifact_present(tmp_path, art) is False
+
+    def test_repair_removes_leftover(self, tmp_path):
+        (tmp_path / "package.json").write_text("{}")
+        REPAIR_ACTIONS["leftover_file"](tmp_path, {"path": "package.json"})
+        assert not (tmp_path / "package.json").exists()
+
+    def test_repair_refuses_path_outside_root(self, tmp_path, caplog):
+        # Should be a no-op; no exception, but file outside root is preserved.
+        sentinel = tmp_path.parent / "should-not-be-deleted"
+        sentinel.write_text("preserve me")
+        try:
+            REPAIR_ACTIONS["leftover_file"](
+                tmp_path, {"path": "../should-not-be-deleted"}
+            )
+            assert sentinel.exists(), (
+                "repair must not delete files outside the project root"
+            )
+        finally:
+            sentinel.unlink(missing_ok=True)
+
+    def test_repair_refuses_absolute_path(self, tmp_path):
+        # Absolute path → no-op, no exception
+        REPAIR_ACTIONS["leftover_file"](tmp_path, {"path": "/etc/passwd"})
+        # If we reach here without raising, the safeguard worked
+
+
+class TestScaffoldingMustNotExist:
+    def test_scaffolding_lists_common_leftover_files(self):
+        exps = scaffolding_expectations()
+        leftover_paths = {e.path for e in exps if e.kind == "must_not_exist"}
+        # Each is a known carryover-pollution risk we observed in
+        # project_5 / project_7 runs.
+        for expected in (
+            "package.json",
+            "node_modules",
+            "Cargo.toml",
+            "go.mod",
+            "pyproject.toml",
+            ".coverage",
+        ):
+            assert expected in leftover_paths, (
+                f"scaffolding_expectations should guard against leftover "
+                f"{expected!r} from prior runs"
+            )

--- a/tests/test_runtime/test_stack_contract.py
+++ b/tests/test_runtime/test_stack_contract.py
@@ -70,22 +70,26 @@ class TestLoadStackContractBlock:
 
     def test_renders_known_keys_in_canonical_order(self, tmp_path):
         (tmp_path / "docs").mkdir()
-        (tmp_path / "docs" / "stack_contract.json").write_text(json.dumps({
-            # Provide keys in scrambled order to confirm output
-            # follows the canonical _STACK_CONTRACT_KEYS ordering.
-            "ui_kind": "phaser",
-            "language": "typescript",
-            "test_runner": "vitest",
-            "framework_backend": "fastify",
-            "static_analyzer": ["npx tsc --noEmit", "eslint ."],
-            "entry_point": "src/index.ts",
-            "ui_required": True,
-            "framework_frontend": "phaser",
-            "package_manager": "npm",
-            "project_config_file": "package.json",
-            "run_command": "npm run dev",
-            "runtime": "node",
-        }))
+        (tmp_path / "docs" / "stack_contract.json").write_text(
+            json.dumps(
+                {
+                    # Provide keys in scrambled order to confirm output
+                    # follows the canonical _STACK_CONTRACT_KEYS ordering.
+                    "ui_kind": "phaser",
+                    "language": "typescript",
+                    "test_runner": "vitest",
+                    "framework_backend": "fastify",
+                    "static_analyzer": ["npx tsc --noEmit", "eslint ."],
+                    "entry_point": "src/index.ts",
+                    "ui_required": True,
+                    "framework_frontend": "phaser",
+                    "package_manager": "npm",
+                    "project_config_file": "package.json",
+                    "run_command": "npm run dev",
+                    "runtime": "node",
+                }
+            )
+        )
         block = _load_stack_contract_block(tmp_path)
         # Sentinel header + footer
         assert "=== STACK CONTRACT" in block
@@ -95,8 +99,7 @@ class TestLoadStackContractBlock:
         lang_idx = block.index("language: typescript")
         uikind_idx = block.index("ui_kind: phaser")
         assert lang_idx < uikind_idx, (
-            "block must follow canonical key ordering, not the JSON "
-            "object's serialization order"
+            "block must follow canonical key ordering, not the JSON object's serialization order"
         )
         # Lists are joined with ", " so the orchestrator sees a single
         # readable line per field.
@@ -107,10 +110,14 @@ class TestLoadStackContractBlock:
         not crash or expose them in the prompt — only the canonical
         keys round-trip."""
         (tmp_path / "docs").mkdir()
-        (tmp_path / "docs" / "stack_contract.json").write_text(json.dumps({
-            "language": "go",
-            "novel_field_from_the_future": "should not appear in block",
-        }))
+        (tmp_path / "docs" / "stack_contract.json").write_text(
+            json.dumps(
+                {
+                    "language": "go",
+                    "novel_field_from_the_future": "should not appear in block",
+                }
+            )
+        )
         block = _load_stack_contract_block(tmp_path)
         assert "language: go" in block
         assert "novel_field_from_the_future" not in block
@@ -182,15 +189,19 @@ class TestDispatchTaskInjectsContract:
         with tempfile.TemporaryDirectory() as d:
             root = Path(d)
             (root / "docs").mkdir()
-            (root / "docs" / "stack_contract.json").write_text(json.dumps({
-                "language": "typescript",
-                "framework_backend": "fastify",
-                "test_runner": "vitest",
-                "entry_point": "src/index.ts",
-                "run_command": "npm run dev",
-                "ui_required": False,
-                "ui_kind": "",
-            }))
+            (root / "docs" / "stack_contract.json").write_text(
+                json.dumps(
+                    {
+                        "language": "typescript",
+                        "framework_backend": "fastify",
+                        "test_runner": "vitest",
+                        "entry_point": "src/index.ts",
+                        "run_command": "npm run dev",
+                        "ui_required": False,
+                        "ui_kind": "",
+                    }
+                )
+            )
             ctx = _build_ctx(root, requirement="Build a tower defense game")
             prompt = self._capture_worker_prompt(ctx, "Implement auth module")
             # All three blocks present
@@ -212,10 +223,14 @@ class TestDispatchTaskInjectsContract:
         with tempfile.TemporaryDirectory() as d:
             root = Path(d)
             (root / "docs").mkdir()
-            (root / "docs" / "stack_contract.json").write_text(json.dumps({
-                "language": "go",
-                "test_runner": "go test",
-            }))
+            (root / "docs" / "stack_contract.json").write_text(
+                json.dumps(
+                    {
+                        "language": "go",
+                        "test_runner": "go test",
+                    }
+                )
+            )
             ctx = _build_ctx(root)  # empty requirement
             prompt = self._capture_worker_prompt(ctx, "do thing")
             assert "=== STACK CONTRACT" in prompt
@@ -285,12 +300,8 @@ class TestMustNotExistArtifact:
         sentinel = tmp_path.parent / "should-not-be-deleted"
         sentinel.write_text("preserve me")
         try:
-            REPAIR_ACTIONS["leftover_file"](
-                tmp_path, {"path": "../should-not-be-deleted"}
-            )
-            assert sentinel.exists(), (
-                "repair must not delete files outside the project root"
-            )
+            REPAIR_ACTIONS["leftover_file"](tmp_path, {"path": "../should-not-be-deleted"})
+            assert sentinel.exists(), "repair must not delete files outside the project root"
         finally:
             sentinel.unlink(missing_ok=True)
 
@@ -315,6 +326,5 @@ class TestScaffoldingMustNotExist:
             ".coverage",
         ):
             assert expected in leftover_paths, (
-                f"scaffolding_expectations should guard against leftover "
-                f"{expected!r} from prior runs"
+                f"scaffolding_expectations should guard against leftover {expected!r} from prior runs"
             )

--- a/tests/test_runtime/test_subsystem_layout.py
+++ b/tests/test_runtime/test_subsystem_layout.py
@@ -60,18 +60,29 @@ def _write_contract(root: Path, payload: dict) -> Path:
 
 class TestLoaderRendersNewSchema:
     def test_subsystems_summary_appears_with_counts(self, tmp_path):
-        _write_contract(tmp_path, {
-            "language": "python",
-            "subsystems": [
-                {"name": "ui", "src_dir": "src/ui/", "components": [
-                    {"name": "menu_ui", "file": "src/ui/menu_ui.py", "responsibility": "x"},
-                    {"name": "hud_ui", "file": "src/ui/hud_ui.py", "responsibility": "x"},
-                ]},
-                {"name": "gameplay", "src_dir": "src/gameplay/", "components": [
-                    {"name": "player", "file": "src/gameplay/player.py", "responsibility": "x"},
-                ]},
-            ],
-        })
+        _write_contract(
+            tmp_path,
+            {
+                "language": "python",
+                "subsystems": [
+                    {
+                        "name": "ui",
+                        "src_dir": "src/ui/",
+                        "components": [
+                            {"name": "menu_ui", "file": "src/ui/menu_ui.py", "responsibility": "x"},
+                            {"name": "hud_ui", "file": "src/ui/hud_ui.py", "responsibility": "x"},
+                        ],
+                    },
+                    {
+                        "name": "gameplay",
+                        "src_dir": "src/gameplay/",
+                        "components": [
+                            {"name": "player", "file": "src/gameplay/player.py", "responsibility": "x"},
+                        ],
+                    },
+                ],
+            },
+        )
         block = _load_stack_contract_block(tmp_path)
         assert "subsystems:" in block
         # Each subsystem appears with its component count
@@ -84,12 +95,15 @@ class TestLoaderRendersNewSchema:
         assert "hud_ui" not in block
 
     def test_zero_component_subsystem_omits_count(self, tmp_path):
-        _write_contract(tmp_path, {
-            "language": "go",
-            "subsystems": [
-                {"name": "stub", "src_dir": "internal/stub/", "components": []},
-            ],
-        })
+        _write_contract(
+            tmp_path,
+            {
+                "language": "go",
+                "subsystems": [
+                    {"name": "stub", "src_dir": "internal/stub/", "components": []},
+                ],
+            },
+        )
         block = _load_stack_contract_block(tmp_path)
         # No "(0 components)" noise; just the path.
         assert "- stub [internal/stub/]" in block
@@ -98,13 +112,16 @@ class TestLoaderRendersNewSchema:
 
 class TestLoaderTolerLegacyFlatModules:
     def test_legacy_modules_render_with_deprecation_marker(self, tmp_path):
-        _write_contract(tmp_path, {
-            "language": "python",
-            "modules": [
-                {"name": "auth", "src_dir": "src/auth/", "responsibilities": "x"},
-                {"name": "player", "src_dir": "src/player/", "responsibilities": "x"},
-            ],
-        })
+        _write_contract(
+            tmp_path,
+            {
+                "language": "python",
+                "modules": [
+                    {"name": "auth", "src_dir": "src/auth/", "responsibilities": "x"},
+                    {"name": "player", "src_dir": "src/player/", "responsibilities": "x"},
+                ],
+            },
+        )
         block = _load_stack_contract_block(tmp_path)
         assert "LEGACY FLAT 'modules' SCHEMA" in block
         assert "- auth [src/auth/]" in block
@@ -113,15 +130,22 @@ class TestLoaderTolerLegacyFlatModules:
     def test_subsystems_takes_precedence_over_legacy_modules(self, tmp_path):
         # If both keys exist (mid-migration), the new schema wins
         # and the legacy-flat marker does NOT appear.
-        _write_contract(tmp_path, {
-            "language": "python",
-            "subsystems": [
-                {"name": "ui", "src_dir": "src/ui/", "components": [
-                    {"name": "x", "file": "src/ui/x.py", "responsibility": "y"},
-                ]},
-            ],
-            "modules": [{"name": "should_be_ignored", "src_dir": "src/x/"}],
-        })
+        _write_contract(
+            tmp_path,
+            {
+                "language": "python",
+                "subsystems": [
+                    {
+                        "name": "ui",
+                        "src_dir": "src/ui/",
+                        "components": [
+                            {"name": "x", "file": "src/ui/x.py", "responsibility": "y"},
+                        ],
+                    },
+                ],
+                "modules": [{"name": "should_be_ignored", "src_dir": "src/x/"}],
+            },
+        )
         block = _load_stack_contract_block(tmp_path)
         assert "LEGACY FLAT" not in block
         assert "should_be_ignored" not in block
@@ -137,15 +161,23 @@ def _valid_payload() -> dict:
     return {
         "language": "python",
         "subsystems": [
-            {"name": "ui", "src_dir": "src/ui/", "responsibilities": "render",
-             "components": [
-                 {"name": "menu_ui", "file": "src/ui/menu_ui.py", "responsibility": "x"},
-                 {"name": "hud_ui", "file": "src/ui/hud_ui.py", "responsibility": "x"},
-             ]},
-            {"name": "gameplay", "src_dir": "src/gameplay/", "responsibilities": "logic",
-             "components": [
-                 {"name": "player", "file": "src/gameplay/player.py", "responsibility": "x"},
-             ]},
+            {
+                "name": "ui",
+                "src_dir": "src/ui/",
+                "responsibilities": "render",
+                "components": [
+                    {"name": "menu_ui", "file": "src/ui/menu_ui.py", "responsibility": "x"},
+                    {"name": "hud_ui", "file": "src/ui/hud_ui.py", "responsibility": "x"},
+                ],
+            },
+            {
+                "name": "gameplay",
+                "src_dir": "src/gameplay/",
+                "responsibilities": "logic",
+                "components": [
+                    {"name": "player", "file": "src/gameplay/player.py", "responsibility": "x"},
+                ],
+            },
         ],
     }
 
@@ -177,10 +209,13 @@ class TestStackContractValidator:
         # back-compat in worker prompts, the *validator* (which gates
         # architect re-dispatch) rejects them — so on a fresh project
         # the architect MUST upgrade.
-        p = _write_contract(tmp_path, {
-            "language": "python",
-            "modules": [{"name": "x", "src_dir": "src/x/"}],
-        })
+        p = _write_contract(
+            tmp_path,
+            {
+                "language": "python",
+                "modules": [{"name": "x", "src_dir": "src/x/"}],
+            },
+        )
         assert _stack_contract_valid(p) is False
 
     def test_rejects_empty_subsystems_array(self, tmp_path):
@@ -221,10 +256,13 @@ class TestStackContractValidator:
         # without being a hard error for genuinely large projects.
         many = {"language": "python", "subsystems": []}
         for i in range(11):
-            many["subsystems"].append({
-                "name": f"s{i}", "src_dir": f"src/s{i}/",
-                "components": [{"name": f"c{i}", "file": f"src/s{i}/c{i}.py", "responsibility": "x"}],
-            })
+            many["subsystems"].append(
+                {
+                    "name": f"s{i}",
+                    "src_dir": f"src/s{i}/",
+                    "components": [{"name": f"c{i}", "file": f"src/s{i}/c{i}.py", "responsibility": "x"}],
+                }
+            )
         p = _write_contract(tmp_path, many)
         with caplog.at_level(logging.WARNING, logger="aise.runtime.safety_net"):
             ok = _stack_contract_valid(p)
@@ -256,8 +294,7 @@ class TestArchitectPromptGuidesTwoLevelLayout:
         text = _read_architect_md()
         # The instruction must explicitly say Components are NOT
         # subsystems — this is the load-bearing anti-flat rule.
-        assert "NOT sources" in text or "not subsystems" in text.lower() or \
-               "NOT a directory" in text
+        assert "NOT sources" in text or "not subsystems" in text.lower() or "NOT a directory" in text
         # Container_Boundary is the source of subsystems
         assert "Container_Boundary" in text
         # Component is the unit of files inside a subsystem
@@ -275,8 +312,8 @@ class TestArchitectPromptGuidesTwoLevelLayout:
 
     def test_schema_has_subsystems_with_components_not_flat_modules(self):
         text = _read_architect_md()
-        assert "\"subsystems\":" in text
-        assert "\"components\":" in text
+        assert '"subsystems":' in text
+        assert '"components":' in text
         # The previous flat top-level "modules" key in the schema
         # has been removed — searching for it as a top-level schema
         # field should not find it. (The token "modules" can still

--- a/tests/test_runtime/test_subsystem_layout.py
+++ b/tests/test_runtime/test_subsystem_layout.py
@@ -1,0 +1,342 @@
+"""Regression tests for the architect's two-level subsystem layout.
+
+The user's original intent: ``src/`` should be split by *subsystem*
+(roughly the C4 ``Container_Boundary`` count, typically 3-7), not by
+*component* (which would produce 20+ flat top-level dirs — the
+project_7-tower failure mode).
+
+Three guarantees are exercised:
+
+1. ``_load_stack_contract_block`` accepts the new
+   ``subsystems[].components[]`` schema and renders it as a concise
+   per-subsystem summary (component count, not enumeration).
+
+2. ``_load_stack_contract_block`` STILL renders the legacy
+   ``modules[]`` schema (back-compat for in-flight projects) but
+   marks it ``LEGACY FLAT 'modules' SCHEMA`` so a downstream
+   reader can flag the architect for re-design.
+
+3. ``_stack_contract_valid`` (new safety_net validator) accepts a
+   well-formed two-level contract, rejects:
+   - top-level not an object,
+   - missing/empty ``subsystems[]``,
+   - subsystem with bad ``name`` / ``src_dir`` / ``components``
+     types,
+   - component whose ``file`` does not live under its parent's
+     ``src_dir`` (the load-bearing check that prevents flat
+     re-layout under a different name).
+   It WARNS (does not fail) when:
+   - subsystem count exceeds the soft cap, or
+   - a subsystem has zero components.
+
+4. ``architect.md`` instructs subsystem ≠ component and provides
+   the two-level worked example. Static check on the prompt file.
+
+5. ``project_session.py`` Phase-3 prompts dispatch developer **per
+   subsystem**, NOT per component.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from aise.runtime.safety_net import _stack_contract_valid
+from aise.runtime.tool_primitives import _load_stack_contract_block
+
+# ---------------------------------------------------------------------------
+# 1. Loader — new schema rendering
+# ---------------------------------------------------------------------------
+
+
+def _write_contract(root: Path, payload: dict) -> Path:
+    docs = root / "docs"
+    docs.mkdir(exist_ok=True)
+    p = docs / "stack_contract.json"
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    return p
+
+
+class TestLoaderRendersNewSchema:
+    def test_subsystems_summary_appears_with_counts(self, tmp_path):
+        _write_contract(tmp_path, {
+            "language": "python",
+            "subsystems": [
+                {"name": "ui", "src_dir": "src/ui/", "components": [
+                    {"name": "menu_ui", "file": "src/ui/menu_ui.py", "responsibility": "x"},
+                    {"name": "hud_ui", "file": "src/ui/hud_ui.py", "responsibility": "x"},
+                ]},
+                {"name": "gameplay", "src_dir": "src/gameplay/", "components": [
+                    {"name": "player", "file": "src/gameplay/player.py", "responsibility": "x"},
+                ]},
+            ],
+        })
+        block = _load_stack_contract_block(tmp_path)
+        assert "subsystems:" in block
+        # Each subsystem appears with its component count
+        assert "- ui [src/ui/] (2 components)" in block
+        # Singular form for n=1
+        assert "- gameplay [src/gameplay/] (1 component)" in block
+        # Block does NOT enumerate every component — keeping worker
+        # prompts compact.
+        assert "menu_ui" not in block
+        assert "hud_ui" not in block
+
+    def test_zero_component_subsystem_omits_count(self, tmp_path):
+        _write_contract(tmp_path, {
+            "language": "go",
+            "subsystems": [
+                {"name": "stub", "src_dir": "internal/stub/", "components": []},
+            ],
+        })
+        block = _load_stack_contract_block(tmp_path)
+        # No "(0 components)" noise; just the path.
+        assert "- stub [internal/stub/]" in block
+        assert "(0 component" not in block
+
+
+class TestLoaderTolerLegacyFlatModules:
+    def test_legacy_modules_render_with_deprecation_marker(self, tmp_path):
+        _write_contract(tmp_path, {
+            "language": "python",
+            "modules": [
+                {"name": "auth", "src_dir": "src/auth/", "responsibilities": "x"},
+                {"name": "player", "src_dir": "src/player/", "responsibilities": "x"},
+            ],
+        })
+        block = _load_stack_contract_block(tmp_path)
+        assert "LEGACY FLAT 'modules' SCHEMA" in block
+        assert "- auth [src/auth/]" in block
+        assert "- player [src/player/]" in block
+
+    def test_subsystems_takes_precedence_over_legacy_modules(self, tmp_path):
+        # If both keys exist (mid-migration), the new schema wins
+        # and the legacy-flat marker does NOT appear.
+        _write_contract(tmp_path, {
+            "language": "python",
+            "subsystems": [
+                {"name": "ui", "src_dir": "src/ui/", "components": [
+                    {"name": "x", "file": "src/ui/x.py", "responsibility": "y"},
+                ]},
+            ],
+            "modules": [{"name": "should_be_ignored", "src_dir": "src/x/"}],
+        })
+        block = _load_stack_contract_block(tmp_path)
+        assert "LEGACY FLAT" not in block
+        assert "should_be_ignored" not in block
+        assert "- ui [src/ui/]" in block
+
+
+# ---------------------------------------------------------------------------
+# 2. Validator — new safety_net kind
+# ---------------------------------------------------------------------------
+
+
+def _valid_payload() -> dict:
+    return {
+        "language": "python",
+        "subsystems": [
+            {"name": "ui", "src_dir": "src/ui/", "responsibilities": "render",
+             "components": [
+                 {"name": "menu_ui", "file": "src/ui/menu_ui.py", "responsibility": "x"},
+                 {"name": "hud_ui", "file": "src/ui/hud_ui.py", "responsibility": "x"},
+             ]},
+            {"name": "gameplay", "src_dir": "src/gameplay/", "responsibilities": "logic",
+             "components": [
+                 {"name": "player", "file": "src/gameplay/player.py", "responsibility": "x"},
+             ]},
+        ],
+    }
+
+
+class TestStackContractValidator:
+    def test_accepts_well_formed_two_level_contract(self, tmp_path):
+        p = _write_contract(tmp_path, _valid_payload())
+        assert _stack_contract_valid(p) is True
+
+    def test_rejects_missing_file(self, tmp_path):
+        assert _stack_contract_valid(tmp_path / "nope.json") is False
+
+    def test_rejects_invalid_json(self, tmp_path):
+        p = tmp_path / "bad.json"
+        p.write_text("{not json")
+        assert _stack_contract_valid(p) is False
+
+    def test_rejects_top_level_array(self, tmp_path):
+        p = tmp_path / "x.json"
+        p.write_text("[]")
+        assert _stack_contract_valid(p) is False
+
+    def test_rejects_missing_subsystems(self, tmp_path):
+        p = _write_contract(tmp_path, {"language": "python"})
+        assert _stack_contract_valid(p) is False
+
+    def test_rejects_legacy_flat_modules_only(self, tmp_path):
+        # Even though the loader tolerates legacy modules[] for
+        # back-compat in worker prompts, the *validator* (which gates
+        # architect re-dispatch) rejects them — so on a fresh project
+        # the architect MUST upgrade.
+        p = _write_contract(tmp_path, {
+            "language": "python",
+            "modules": [{"name": "x", "src_dir": "src/x/"}],
+        })
+        assert _stack_contract_valid(p) is False
+
+    def test_rejects_empty_subsystems_array(self, tmp_path):
+        p = _write_contract(tmp_path, {"subsystems": []})
+        assert _stack_contract_valid(p) is False
+
+    def test_rejects_subsystem_missing_name(self, tmp_path):
+        bad = _valid_payload()
+        del bad["subsystems"][0]["name"]
+        p = _write_contract(tmp_path, bad)
+        assert _stack_contract_valid(p) is False
+
+    def test_rejects_subsystem_missing_src_dir(self, tmp_path):
+        bad = _valid_payload()
+        del bad["subsystems"][0]["src_dir"]
+        p = _write_contract(tmp_path, bad)
+        assert _stack_contract_valid(p) is False
+
+    def test_rejects_components_not_a_list(self, tmp_path):
+        bad = _valid_payload()
+        bad["subsystems"][0]["components"] = "should be list"
+        p = _write_contract(tmp_path, bad)
+        assert _stack_contract_valid(p) is False
+
+    def test_rejects_component_file_outside_subsystem_dir(self, tmp_path):
+        # The load-bearing anti-flat-layout check: a "subsystem"
+        # whose components secretly live at the top level is just
+        # the flat layout under a fancier name.
+        bad = _valid_payload()
+        bad["subsystems"][0]["components"][0]["file"] = "src/menu_ui.py"  # not under src/ui/
+        p = _write_contract(tmp_path, bad)
+        assert _stack_contract_valid(p) is False
+
+    def test_warns_but_passes_on_subsystem_count_above_soft_cap(self, tmp_path, caplog):
+        # 11 subsystems is above the soft cap of 10 — should warn
+        # (logged) but the validator returns True. This catches the
+        # "architect promoted components to subsystems" pattern
+        # without being a hard error for genuinely large projects.
+        many = {"language": "python", "subsystems": []}
+        for i in range(11):
+            many["subsystems"].append({
+                "name": f"s{i}", "src_dir": f"src/s{i}/",
+                "components": [{"name": f"c{i}", "file": f"src/s{i}/c{i}.py", "responsibility": "x"}],
+            })
+        p = _write_contract(tmp_path, many)
+        with caplog.at_level(logging.WARNING, logger="aise.runtime.safety_net"):
+            ok = _stack_contract_valid(p)
+        assert ok is True
+        assert any("exceeds soft cap" in r.message for r in caplog.records)
+
+    def test_warns_but_passes_on_zero_component_subsystem(self, tmp_path, caplog):
+        partial = _valid_payload()
+        partial["subsystems"][1]["components"] = []
+        p = _write_contract(tmp_path, partial)
+        with caplog.at_level(logging.WARNING, logger="aise.runtime.safety_net"):
+            ok = _stack_contract_valid(p)
+        assert ok is True
+        assert any("zero components" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# 3. architect.md guidance — static checks
+# ---------------------------------------------------------------------------
+
+
+def _read_architect_md() -> str:
+    repo_root = Path(__file__).resolve().parents[2]
+    return (repo_root / "src" / "aise" / "agents" / "architect.md").read_text(encoding="utf-8")
+
+
+class TestArchitectPromptGuidesTwoLevelLayout:
+    def test_step1_forbids_promoting_components_to_subsystems(self):
+        text = _read_architect_md()
+        # The instruction must explicitly say Components are NOT
+        # subsystems — this is the load-bearing anti-flat rule.
+        assert "NOT sources" in text or "not subsystems" in text.lower() or \
+               "NOT a directory" in text
+        # Container_Boundary is the source of subsystems
+        assert "Container_Boundary" in text
+        # Component is the unit of files inside a subsystem
+        assert "Component" in text and "INSIDE" in text
+
+    def test_worked_example_shows_two_level_nested_layout(self):
+        text = _read_architect_md()
+        # The example must show src/<subsystem>/<component>.py form,
+        # not src/<component>/__init__.py form.
+        assert "src/ui/" in text
+        assert "src/gameplay/" in text
+        assert "menu_ui.py" in text
+        # And explicitly ban the flat alternative.
+        assert "FORBIDDEN" in text or "❌" in text
+
+    def test_schema_has_subsystems_with_components_not_flat_modules(self):
+        text = _read_architect_md()
+        assert "\"subsystems\":" in text
+        assert "\"components\":" in text
+        # The previous flat top-level "modules" key in the schema
+        # has been removed — searching for it as a top-level schema
+        # field should not find it. (The token "modules" can still
+        # appear in narrative — we check the schema block.)
+        assert "src_dir" in text
+
+
+# ---------------------------------------------------------------------------
+# 4. project_session.py Phase-3 — per-subsystem dispatch
+# ---------------------------------------------------------------------------
+
+
+def _read_project_session() -> str:
+    repo_root = Path(__file__).resolve().parents[2]
+    return (repo_root / "src" / "aise" / "runtime" / "project_session.py").read_text(encoding="utf-8")
+
+
+class TestPhase3DispatchesPerSubsystem:
+    def test_initial_phase3_uses_dispatch_subsystems_primitive(self):
+        text = _read_project_session()
+        # Phase-3 fan-out is now done by the orchestration layer via
+        # the deterministic ``dispatch_subsystems`` primitive — NOT by
+        # the orchestrator LLM drafting a tasks_json batch. This
+        # guarantees worker concurrency even when the orchestrator
+        # LLM is too weak to emit multi-tool-call responses.
+        # The phase prompt is a Python string literal, so the embedded
+        # quotes appear escaped in the source (\"…\"). Accept both
+        # forms.
+        assert (
+            'dispatch_subsystems(phase="implementation")' in text
+            or 'dispatch_subsystems(phase=\\"implementation\\")' in text
+        ), (
+            "Phase-3 implementation prompt must instruct the "
+            "orchestrator to call dispatch_subsystems exactly once, "
+            "not draft tasks_json itself"
+        )
+        # Anti-regression: explicit prohibition against falling back
+        # to dispatch_task / dispatch_tasks_parallel for individual
+        # subsystems / components.
+        assert "Do NOT call dispatch_task or dispatch_tasks_parallel" in text
+
+    def test_sprint_execution_uses_dispatch_subsystems_primitive(self):
+        text = _read_project_session()
+        # Both initial and incremental agile sprints use the same
+        # deterministic fan-out primitive.
+        assert (
+            'dispatch_subsystems(phase="sprint_execution")' in text
+            or 'dispatch_subsystems(phase=\\"sprint_execution\\")' in text
+        )
+
+    def test_dispatch_subsystems_primitive_exists_in_tool_primitives(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        tp_text = (repo_root / "src/aise/runtime/tool_primitives.py").read_text(encoding="utf-8")
+        # The primitive itself
+        assert "def dispatch_subsystems(" in tp_text
+        # The deterministic task-description renderer (architecture
+        # of fix: LLM does not draft tasks_json; Python builds it
+        # from the contract).
+        assert "def _build_subsystem_task_description(" in tp_text
+        # Throttle pulled from runtime config — anti-regression
+        # against an unbounded ThreadPoolExecutor that would saturate
+        # the LLM serving layer with N concurrent dispatches.
+        assert "max_concurrent_subsystem_dispatches" in tp_text

--- a/tests/test_runtime/test_token_usage.py
+++ b/tests/test_runtime/test_token_usage.py
@@ -1,0 +1,206 @@
+"""Tests for LLM token-usage accounting.
+
+Covers three layers:
+
+1. ``_extract_token_counts`` — normalizes provider-specific shapes
+   (OpenAI ``prompt_tokens``/``completion_tokens`` vs Anthropic /
+   LangChain ``input_tokens``/``output_tokens`` vs ``usage_metadata``
+   on the message) into a single ``{input,output,total}`` dict.
+
+2. ``TraceLLMCallback.on_llm_end`` — accumulates per-call counts into
+   ``trace_record["token_usage"]`` and forwards each call to the
+   ``on_token_usage`` callback.
+
+3. ``AgentRuntime.handle_message`` — plumbs ``on_token_usage`` through
+   to the ``TraceLLMCallback`` so callers see live token counts as the
+   LLM round-trips fire.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage
+from langchain_core.outputs import ChatGeneration, LLMResult
+
+from aise.runtime.agent_runtime import AgentRuntime
+from aise.runtime.trace_callback import TraceLLMCallback, _extract_token_counts
+
+SAMPLE_AGENT_MD = """\
+---
+name: TokenTestAgent
+description: Token usage agent
+version: 1.0.0
+---
+
+# System Prompt
+
+You are a test agent.
+"""
+
+
+@pytest.fixture
+def agent_md_file(tmp_path: Path) -> Path:
+    f = tmp_path / "agent.md"
+    f.write_text(SAMPLE_AGENT_MD)
+    return f
+
+
+@pytest.fixture
+def skills_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "skills"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def mock_create_deep_agent():
+    mock_agent = MagicMock()
+    mock_agent.invoke.return_value = {"messages": [AIMessage(content="ok")]}
+    with patch("aise.runtime.agent_runtime.create_deep_agent", return_value=mock_agent) as mock_factory:
+        yield mock_factory, mock_agent
+
+
+def _make_llm_result(usage: dict | None = None, usage_metadata: dict | None = None) -> LLMResult:
+    msg = AIMessage(content="hi")
+    if usage_metadata is not None:
+        msg.usage_metadata = usage_metadata
+    gen = ChatGeneration(message=msg, text="hi")
+    llm_output = {"token_usage": usage} if usage is not None else None
+    return LLMResult(generations=[[gen]], llm_output=llm_output)
+
+
+class TestExtractTokenCounts:
+    def test_openai_shape(self):
+        result = _make_llm_result(
+            usage={"prompt_tokens": 12, "completion_tokens": 5, "total_tokens": 17}
+        )
+        counts = _extract_token_counts(result)
+        assert counts == {"input_tokens": 12, "output_tokens": 5, "total_tokens": 17}
+
+    def test_anthropic_shape(self):
+        result = _make_llm_result(
+            usage={"input_tokens": 30, "output_tokens": 8, "total_tokens": 38}
+        )
+        counts = _extract_token_counts(result)
+        assert counts == {"input_tokens": 30, "output_tokens": 8, "total_tokens": 38}
+
+    def test_falls_back_to_usage_metadata_on_message(self):
+        # No llm_output, but the message carries usage_metadata.
+        result = _make_llm_result(
+            usage=None,
+            usage_metadata={"input_tokens": 4, "output_tokens": 2, "total_tokens": 6},
+        )
+        counts = _extract_token_counts(result)
+        assert counts == {"input_tokens": 4, "output_tokens": 2, "total_tokens": 6}
+
+    def test_total_synthesized_when_missing(self):
+        result = _make_llm_result(usage={"prompt_tokens": 10, "completion_tokens": 3})
+        counts = _extract_token_counts(result)
+        # No total_tokens reported → input+output
+        assert counts == {"input_tokens": 10, "output_tokens": 3, "total_tokens": 13}
+
+    def test_zero_when_unavailable(self):
+        result = _make_llm_result(usage=None)
+        counts = _extract_token_counts(result)
+        assert counts == {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+
+
+class TestTraceLLMCallbackTokenUsage:
+    def _drive(self, callback: TraceLLMCallback, result: LLMResult) -> None:
+        import uuid
+
+        run_id = uuid.uuid4()
+        callback.on_chat_model_start(
+            serialized={},
+            messages=[[]],
+            run_id=run_id,
+        )
+        callback.on_llm_end(result, run_id=run_id)
+
+    def test_accumulates_in_trace_record(self):
+        record: dict = {}
+        cb = TraceLLMCallback(trace_record=record, trace_path=None, lock=threading.Lock())
+        self._drive(cb, _make_llm_result(usage={"input_tokens": 7, "output_tokens": 3, "total_tokens": 10}))
+        self._drive(cb, _make_llm_result(usage={"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}))
+
+        assert record["token_usage"] == {
+            "input_tokens": 8,
+            "output_tokens": 5,
+            "total_tokens": 13,
+            "llm_calls": 2,
+        }
+
+    def test_forwards_to_on_token_usage(self):
+        record: dict = {}
+        captured: list[dict] = []
+        cb = TraceLLMCallback(
+            trace_record=record,
+            trace_path=None,
+            lock=threading.Lock(),
+            on_token_usage=captured.append,
+        )
+        self._drive(cb, _make_llm_result(usage={"prompt_tokens": 9, "completion_tokens": 4, "total_tokens": 13}))
+        self._drive(cb, _make_llm_result(usage={"prompt_tokens": 11, "completion_tokens": 6, "total_tokens": 17}))
+
+        assert captured == [
+            {"input_tokens": 9, "output_tokens": 4, "total_tokens": 13},
+            {"input_tokens": 11, "output_tokens": 6, "total_tokens": 17},
+        ]
+
+    def test_no_callback_fired_when_usage_empty(self):
+        captured: list[dict] = []
+        cb = TraceLLMCallback(
+            trace_record={},
+            trace_path=None,
+            lock=threading.Lock(),
+            on_token_usage=captured.append,
+        )
+        self._drive(cb, _make_llm_result(usage=None))
+        # No usage anywhere → callback must NOT fire (otherwise the
+        # WorkflowRun's llm_call_count would be inflated by no-op rounds).
+        assert captured == []
+
+
+class TestAgentRuntimeHandleMessageTokenUsage:
+    def test_on_token_usage_invoked_for_each_round_trip(
+        self, agent_md_file, skills_dir, mock_create_deep_agent
+    ):
+        _, mock_agent = mock_create_deep_agent
+
+        def _simulate_two_calls(state, config=None):
+            callbacks = (config or {}).get("callbacks") or []
+            for cb in callbacks:
+                self._drive_two_llm_calls(cb)
+            return {"messages": [AIMessage(content="done")]}
+
+        mock_agent.invoke.side_effect = _simulate_two_calls
+
+        runtime = AgentRuntime(
+            agent_md=agent_md_file,
+            skills_dir=skills_dir,
+            model="openai:gpt-4o",
+        )
+        runtime.evoke()
+        captured: list[dict] = []
+        runtime.handle_message("hi", on_token_usage=captured.append)
+
+        assert captured == [
+            {"input_tokens": 5, "output_tokens": 2, "total_tokens": 7},
+            {"input_tokens": 8, "output_tokens": 4, "total_tokens": 12},
+        ]
+
+    @staticmethod
+    def _drive_two_llm_calls(cb: TraceLLMCallback) -> None:
+        import uuid
+
+        for usage in (
+            {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7},
+            {"prompt_tokens": 8, "completion_tokens": 4, "total_tokens": 12},
+        ):
+            run_id = uuid.uuid4()
+            cb.on_chat_model_start(serialized={}, messages=[[]], run_id=run_id)
+            cb.on_llm_end(_make_llm_result(usage=usage), run_id=run_id)

--- a/tests/test_runtime/test_token_usage.py
+++ b/tests/test_runtime/test_token_usage.py
@@ -75,16 +75,12 @@ def _make_llm_result(usage: dict | None = None, usage_metadata: dict | None = No
 
 class TestExtractTokenCounts:
     def test_openai_shape(self):
-        result = _make_llm_result(
-            usage={"prompt_tokens": 12, "completion_tokens": 5, "total_tokens": 17}
-        )
+        result = _make_llm_result(usage={"prompt_tokens": 12, "completion_tokens": 5, "total_tokens": 17})
         counts = _extract_token_counts(result)
         assert counts == {"input_tokens": 12, "output_tokens": 5, "total_tokens": 17}
 
     def test_anthropic_shape(self):
-        result = _make_llm_result(
-            usage={"input_tokens": 30, "output_tokens": 8, "total_tokens": 38}
-        )
+        result = _make_llm_result(usage={"input_tokens": 30, "output_tokens": 8, "total_tokens": 38})
         counts = _extract_token_counts(result)
         assert counts == {"input_tokens": 30, "output_tokens": 8, "total_tokens": 38}
 
@@ -166,9 +162,7 @@ class TestTraceLLMCallbackTokenUsage:
 
 
 class TestAgentRuntimeHandleMessageTokenUsage:
-    def test_on_token_usage_invoked_for_each_round_trip(
-        self, agent_md_file, skills_dir, mock_create_deep_agent
-    ):
+    def test_on_token_usage_invoked_for_each_round_trip(self, agent_md_file, skills_dir, mock_create_deep_agent):
         _, mock_agent = mock_create_deep_agent
 
         def _simulate_two_calls(state, config=None):

--- a/tests/test_runtime/test_tool_primitives.py
+++ b/tests/test_runtime/test_tool_primitives.py
@@ -333,6 +333,151 @@ class TestCompletionTool:
         completes = [e for e in ctx.event_log if e.get("type") == "workflow_complete"]
         assert len(completes) == 1
 
+    # -- A3 Gates: phase completion + artifact + report markers ---------
+
+    def test_mark_complete_refused_when_phases_incomplete(self, ctx):
+        """If a ``phase_plan`` was emitted, mark_complete must refuse
+        until every earlier phase has a matching ``phase_complete``
+        AND the final phase has at least started.
+
+        Regression for project_7-tower run_3f53c0dcc5 (2026-04-26): PM
+        hit the dispatch cap during implementation (phase 2) and
+        called mark_complete with a report that openly admitted
+        gameplay was 0/10. The run was wrongly stamped completed.
+        Under the gate, calling mark_complete while still inside
+        phase 2 (with phases 3/4/5 not even started) is refused.
+        """
+        ctx.event_log.append({"type": "phase_plan", "total": 6, "phases": ["p"] * 6})
+        # Phases 0,1,2 finished, but 3 (main_entry) hasn't started yet.
+        for idx in (0, 1, 2):
+            ctx.event_log.append({"type": "phase_start", "phase_idx": idx})
+            ctx.event_log.append({"type": "phase_complete", "phase_idx": idx})
+        tool = make_completion_tool(ctx)
+        result = json.loads(tool.invoke({"report": "tried our best"}))
+        assert result["status"] == "refused"
+        assert result["phases_completed"] == [0, 1, 2]
+        # Final-phase index 5 must appear in the missing list because
+        # it never started.
+        assert 5 in result["missing_phase_indices"]
+        # State must remain untouched so the orchestrator loop can
+        # continue dispatching the remaining phases.
+        assert ctx.workflow_state.is_complete is False
+        assert ctx.workflow_state.final_report == ""
+        assert not any(e.get("type") == "workflow_complete" for e in ctx.event_log)
+
+    def test_mark_complete_accepted_during_final_phase(self, ctx):
+        """The legitimate case: every earlier phase finished AND the
+        final phase has started. mark_complete is called from inside
+        the final phase's PM dispatch, BEFORE its ``phase_complete``
+        is emitted by the orchestrator loop, so the gate must allow it.
+        """
+        ctx.event_log.append({"type": "phase_plan", "total": 6, "phases": ["p"] * 6})
+        for idx in range(5):
+            ctx.event_log.append({"type": "phase_start", "phase_idx": idx})
+            ctx.event_log.append({"type": "phase_complete", "phase_idx": idx})
+        # Final phase started; its phase_complete will fire AFTER the
+        # PM dispatch returns.
+        ctx.event_log.append({"type": "phase_start", "phase_idx": 5})
+        tool = make_completion_tool(ctx)
+        result = json.loads(tool.invoke({"report": "Delivered all phases."}))
+        assert result["status"] == "acknowledged"
+        assert ctx.workflow_state.is_complete is True
+
+    def test_mark_complete_refused_when_artifacts_missing(self, tmp_path, fake_manager):
+        """If the architect's stack contract declares component files
+        that are missing or trivially small on disk, mark_complete must
+        refuse and surface the missing list so the orchestrator can
+        dispatch the gap.
+        """
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        # Two declared components; ONLY the first exists with real
+        # content. The second must show up in the missing list.
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "ok.py").write_text("# real source code, > 64 bytes\n" * 4, encoding="utf-8")
+        (docs / "stack_contract.json").write_text(
+            json.dumps({
+                "language": "python",
+                "subsystems": [
+                    {
+                        "name": "core",
+                        "components": [
+                            {"name": "ok", "file": "src/ok.py"},
+                            {"name": "missing", "file": "src/missing.py"},
+                        ],
+                    }
+                ],
+            }),
+            encoding="utf-8",
+        )
+        ctx = ToolContext(
+            manager=fake_manager,
+            project_root=tmp_path,
+            config=RuntimeConfig(),
+            workflow_state=WorkflowState(),
+        )
+        tool = make_completion_tool(ctx)
+        result = json.loads(tool.invoke({"report": "delivered."}))
+        assert result["status"] == "refused"
+        assert "src/missing.py" in result["missing_artifacts"]
+        assert "src/ok.py" not in result["missing_artifacts"]
+        assert result["missing_artifact_count"] == 1
+        assert ctx.workflow_state.is_complete is False
+
+    def test_mark_complete_refused_when_report_admits_partial_delivery(self, ctx):
+        """Reject reports that contain partial-delivery markers — they
+        encode a failed run, not a delivery.
+        """
+        tool = make_completion_tool(ctx)
+        bad_report = (
+            "Phase 3 implementation complete.\n\n"
+            "| gameplay | 0/10 ❌ (dispatch cap hit before this subsystem was processed) |\n"
+        )
+        result = json.loads(tool.invoke({"report": bad_report}))
+        assert result["status"] == "refused"
+        # At least one of the patterns we care about should fire.
+        assert any(
+            pat in result["flagged_markers"]
+            for pat in (r"\bdispatch cap hit\b", r"\b0\s*/\s*\d+\b", r"❌")
+        )
+        assert ctx.workflow_state.is_complete is False
+
+    def test_mark_complete_acknowledges_clean_report(self, tmp_path, fake_manager):
+        """Sanity-check: when phases are complete, every artifact is on
+        disk, and the report has no partial-delivery markers, the
+        completion tool acknowledges and stores the report.
+        """
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "ok.py").write_text("# real source code, > 64 bytes\n" * 4, encoding="utf-8")
+        (docs / "stack_contract.json").write_text(
+            json.dumps({
+                "language": "python",
+                "subsystems": [
+                    {"name": "core", "components": [{"name": "ok", "file": "src/ok.py"}]}
+                ],
+            }),
+            encoding="utf-8",
+        )
+        ctx = ToolContext(
+            manager=fake_manager,
+            project_root=tmp_path,
+            config=RuntimeConfig(),
+            workflow_state=WorkflowState(),
+        )
+        ctx.event_log.append({"type": "phase_plan", "total": 2, "phases": ["a", "b"]})
+        ctx.event_log.append({"type": "phase_start", "phase_idx": 0})
+        ctx.event_log.append({"type": "phase_complete", "phase_idx": 0})
+        ctx.event_log.append({"type": "phase_start", "phase_idx": 1})
+        # Final phase started; mark_complete is invoked from inside it,
+        # before its phase_complete fires.
+        tool = make_completion_tool(ctx)
+        result = json.loads(tool.invoke({"report": "Delivered cleanly across all phases."}))
+        assert result["status"] == "acknowledged"
+        assert ctx.workflow_state.is_complete is True
+        assert ctx.workflow_state.final_report == "Delivered cleanly across all phases."
+
 
 class TestDispatchTaskCompletionGuard:
     """Once ``mark_complete`` has fired, further dispatches must be refused.
@@ -584,6 +729,11 @@ class TestBuildOrchestratorTools:
             "list_agents",
             "dispatch_task",
             "dispatch_tasks_parallel",
+            # NEW: deterministic phase-3 fan-out that reads
+            # docs/stack_contract.json and dispatches one developer
+            # per subsystem in parallel — bypasses the orchestrator
+            # LLM's tool-call-batching weakness.
+            "dispatch_subsystems",
             "execute_shell",
             "mark_complete",
         }

--- a/tests/test_runtime/test_tool_primitives.py
+++ b/tests/test_runtime/test_tool_primitives.py
@@ -396,18 +396,20 @@ class TestCompletionTool:
         (tmp_path / "src").mkdir()
         (tmp_path / "src" / "ok.py").write_text("# real source code, > 64 bytes\n" * 4, encoding="utf-8")
         (docs / "stack_contract.json").write_text(
-            json.dumps({
-                "language": "python",
-                "subsystems": [
-                    {
-                        "name": "core",
-                        "components": [
-                            {"name": "ok", "file": "src/ok.py"},
-                            {"name": "missing", "file": "src/missing.py"},
-                        ],
-                    }
-                ],
-            }),
+            json.dumps(
+                {
+                    "language": "python",
+                    "subsystems": [
+                        {
+                            "name": "core",
+                            "components": [
+                                {"name": "ok", "file": "src/ok.py"},
+                                {"name": "missing", "file": "src/missing.py"},
+                            ],
+                        }
+                    ],
+                }
+            ),
             encoding="utf-8",
         )
         ctx = ToolContext(
@@ -436,10 +438,7 @@ class TestCompletionTool:
         result = json.loads(tool.invoke({"report": bad_report}))
         assert result["status"] == "refused"
         # At least one of the patterns we care about should fire.
-        assert any(
-            pat in result["flagged_markers"]
-            for pat in (r"\bdispatch cap hit\b", r"\b0\s*/\s*\d+\b", r"❌")
-        )
+        assert any(pat in result["flagged_markers"] for pat in (r"\bdispatch cap hit\b", r"\b0\s*/\s*\d+\b", r"❌"))
         assert ctx.workflow_state.is_complete is False
 
     def test_mark_complete_acknowledges_clean_report(self, tmp_path, fake_manager):
@@ -452,12 +451,12 @@ class TestCompletionTool:
         (tmp_path / "src").mkdir()
         (tmp_path / "src" / "ok.py").write_text("# real source code, > 64 bytes\n" * 4, encoding="utf-8")
         (docs / "stack_contract.json").write_text(
-            json.dumps({
-                "language": "python",
-                "subsystems": [
-                    {"name": "core", "components": [{"name": "ok", "file": "src/ok.py"}]}
-                ],
-            }),
+            json.dumps(
+                {
+                    "language": "python",
+                    "subsystems": [{"name": "core", "components": [{"name": "ok", "file": "src/ok.py"}]}],
+                }
+            ),
             encoding="utf-8",
         )
         ctx = ToolContext(

--- a/tests/test_web/test_app.py
+++ b/tests/test_web/test_app.py
@@ -1277,9 +1277,21 @@ class TestProjectTokenUsage:
         run_obj = service._find_run(project_id, run_id)
         assert run_obj is not None
         events = [
-            {"type": "token_usage", "agent": "developer", "input_tokens": 100, "output_tokens": 30, "total_tokens": 130},
+            {
+                "type": "token_usage",
+                "agent": "developer",
+                "input_tokens": 100,
+                "output_tokens": 30,
+                "total_tokens": 130,
+            },
             {"type": "token_usage", "agent": "developer", "input_tokens": 40, "output_tokens": 12, "total_tokens": 52},
-            {"type": "token_usage", "agent": "project_manager", "input_tokens": 7, "output_tokens": 5, "total_tokens": 12},
+            {
+                "type": "token_usage",
+                "agent": "project_manager",
+                "input_tokens": 7,
+                "output_tokens": 5,
+                "total_tokens": 12,
+            },
             # Non-token event must NOT bump the counters.
             {"type": "stage_update", "stage": "implementation"},
         ]
@@ -1325,9 +1337,7 @@ class TestProjectTokenUsage:
                 "total": 70,
                 "calls": 2,
             }
-            for run_idx, (input_t, output_t, total_t, calls) in enumerate(
-                [(100, 40, 140, 3), (60, 25, 85, 2)]
-            ):
+            for run_idx, (input_t, output_t, total_t, calls) in enumerate([(100, 40, 140, 3), (60, 25, 85, 2)]):
                 service._runs_by_project.setdefault(project_id, []).append(
                     web_app_module.WorkflowRun(
                         run_id=f"run_{run_idx}",

--- a/tests/test_web/test_app.py
+++ b/tests/test_web/test_app.py
@@ -1244,3 +1244,176 @@ class TestAnalyticsI18n:
         for key in self.REQUIRED_KEYS:
             value = _get(key)
             assert isinstance(value, str) and value.strip(), f"missing/empty {lang}/{key}"
+
+
+class TestProjectTokenUsage:
+    """Per-WorkflowRun + per-project LLM token accounting.
+
+    The web layer aggregates token_usage events emitted by the
+    orchestrator session (``token_usage`` event type) onto the
+    matching ``WorkflowRun`` in real time, plus a project-level
+    scaffolding bucket populated by ``_dispatch_scaffolding_to_pm``.
+    """
+
+    def test_run_aggregates_token_usage_events(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        service = WebProjectService()
+        _stub_scaffolding(service)
+        project_id = service.create_project("TokenAggRun", "local")
+        _wait_for_scaffolding(service, project_id)
+
+        run_id = "run_token_001"
+        with service._lock:
+            service._runs_by_project.setdefault(project_id, []).append(
+                web_app_module.WorkflowRun(
+                    run_id=run_id,
+                    requirement_text="Aggregate tokens",
+                    started_at=datetime.now(timezone.utc),
+                    status="running",
+                )
+            )
+
+        # Drive the same callback the live ProjectSession would call.
+        run_obj = service._find_run(project_id, run_id)
+        assert run_obj is not None
+        events = [
+            {"type": "token_usage", "agent": "developer", "input_tokens": 100, "output_tokens": 30, "total_tokens": 130},
+            {"type": "token_usage", "agent": "developer", "input_tokens": 40, "output_tokens": 12, "total_tokens": 52},
+            {"type": "token_usage", "agent": "project_manager", "input_tokens": 7, "output_tokens": 5, "total_tokens": 12},
+            # Non-token event must NOT bump the counters.
+            {"type": "stage_update", "stage": "implementation"},
+        ]
+        for event in events:
+            with service._lock:
+                run = service._find_run(project_id, run_id)
+                run.task_log.append(event)
+                if event["type"] == "token_usage":
+                    run.total_input_tokens += int(event.get("input_tokens") or 0)
+                    run.total_output_tokens += int(event.get("output_tokens") or 0)
+                    run.total_tokens += int(event.get("total_tokens") or 0)
+                    run.llm_call_count += 1
+
+        run = service._find_run(project_id, run_id)
+        assert run.total_input_tokens == 147
+        assert run.total_output_tokens == 47
+        assert run.total_tokens == 194
+        assert run.llm_call_count == 3
+
+        # Persistence round-trip: serialize, restore, verify the
+        # accumulated counts survive a process restart.
+        service._save_state()
+        service2 = WebProjectService()
+        restored = service2._find_run(project_id, run_id)
+        assert restored is not None
+        assert restored.total_input_tokens == 147
+        assert restored.total_output_tokens == 47
+        assert restored.total_tokens == 194
+        assert restored.llm_call_count == 3
+
+    def test_project_token_summary_combines_scaffolding_and_runs(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        service = WebProjectService()
+        _stub_scaffolding(service)
+        project_id = service.create_project("TokenSummary", "local")
+        _wait_for_scaffolding(service, project_id)
+
+        # Simulate scaffolding + two runs each having recorded tokens.
+        with service._lock:
+            service._scaffolding_tokens_by_project[project_id] = {
+                "input": 50,
+                "output": 20,
+                "total": 70,
+                "calls": 2,
+            }
+            for run_idx, (input_t, output_t, total_t, calls) in enumerate(
+                [(100, 40, 140, 3), (60, 25, 85, 2)]
+            ):
+                service._runs_by_project.setdefault(project_id, []).append(
+                    web_app_module.WorkflowRun(
+                        run_id=f"run_{run_idx}",
+                        requirement_text=f"req {run_idx}",
+                        started_at=datetime.now(timezone.utc),
+                        status="completed",
+                        total_input_tokens=input_t,
+                        total_output_tokens=output_t,
+                        total_tokens=total_t,
+                        llm_call_count=calls,
+                    )
+                )
+
+        summary = service._project_token_summary(project_id)
+        assert summary["scaffolding_input_tokens"] == 50
+        assert summary["scaffolding_output_tokens"] == 20
+        assert summary["scaffolding_total_tokens"] == 70
+        assert summary["scaffolding_llm_calls"] == 2
+        assert summary["input_tokens"] == 50 + 100 + 60
+        assert summary["output_tokens"] == 20 + 40 + 25
+        assert summary["total_tokens"] == 70 + 140 + 85
+        assert summary["llm_calls"] == 2 + 3 + 2
+
+        # ``get_project`` exposes the same summary on the API surface.
+        payload = service.get_project(project_id)
+        assert payload is not None
+        assert payload["token_usage"] == summary
+
+    def test_scaffolding_tokens_persisted_across_restarts(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        service = WebProjectService()
+        _stub_scaffolding(service)
+        project_id = service.create_project("TokenScaffoldPersist", "local")
+        _wait_for_scaffolding(service, project_id)
+
+        with service._lock:
+            service._scaffolding_tokens_by_project[project_id] = {
+                "input": 11,
+                "output": 4,
+                "total": 15,
+                "calls": 1,
+            }
+            service._save_state()
+
+        service2 = WebProjectService()
+        restored = service2._scaffolding_tokens_by_project.get(project_id)
+        assert restored == {"input": 11, "output": 4, "total": 15, "calls": 1}
+
+    def test_dispatch_scaffolding_records_tokens_via_callback(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        service = WebProjectService()
+
+        # Replace get_runtime("product_manager") with a stub whose
+        # handle_message synthesizes a single token_usage callback hit.
+        captured_kwargs: dict = {}
+
+        class _StubPM:
+            def handle_message(self, prompt, **kwargs):
+                captured_kwargs.update(kwargs)
+                cb = kwargs.get("on_token_usage")
+                if cb is not None:
+                    cb({"input_tokens": 21, "output_tokens": 9, "total_tokens": 30})
+                return "ok"
+
+        def _get_runtime(name):
+            assert name == "product_manager"
+            return _StubPM()
+
+        monkeypatch.setattr(service._runtime_manager, "get_runtime", _get_runtime)
+
+        # Simulate creation: call the dispatch directly on a fake project.
+        from aise.core.project import Project, ProjectStatus
+
+        config = service.project_manager.create_default_project_config("TokenDispatch")
+        project = Project(
+            project_id="tok_dispatch_pid",
+            config=config,
+            project_root=str(tmp_path / "project"),
+        )
+        project.status = ProjectStatus.SCAFFOLDING
+        Path(project.project_root).mkdir(parents=True, exist_ok=True)
+
+        service._dispatch_scaffolding_to_pm(project, "scaffold this")
+
+        bucket = service._scaffolding_tokens_by_project.get(project.project_id)
+        assert bucket == {"input": 21, "output": 9, "total": 30, "calls": 1}
+        # The runtime ALSO got the on_token_usage kwarg — proves the
+        # plumbing wires up to the AgentRuntime, not just the test stub.
+        assert "on_token_usage" in captured_kwargs


### PR DESCRIPTION
## Summary

This PR bundles two bodies of work touching the same dispatch / runtime path:

### A. Subsystem-aware orchestration (already in flight)
- Tightened agent prompts (`architect` / `developer` / `product_manager` / `qa_engineer` + the `code_inspection` / `tdd` skills) around stack-contract-driven subsystems and language-agnostic delivery.
- `safety_net` invariant catalog + tests for stack-contract-aware scaffolding.
- New `test_subsystem_layout` / `test_stack_contract` / `test_no_language_lock_in` guards that pin the `subsystems[].components[]` schema.

### B. Runtime improvements landed this session

**LLM token accounting**
- `TraceLLMCallback` extracts and accumulates per-call usage across OpenAI / Anthropic / `usage_metadata` shapes; forwards every call via a new `on_token_usage` callback that `AgentRuntime.handle_message`, `ProjectSession._invoke_pm`, and `dispatch_task` plumb so each LLM round-trip emits a `token_usage` event.
- `WorkflowRun` gains `total_input_tokens` / `total_output_tokens` / `total_tokens` / `llm_call_count`; scaffolding-phase tokens are tracked at the project level (`_scaffolding_tokens_by_project`) and persisted across restarts.
- UI: per-project Token-Usage card on the project page, per-run input/output/total stats on the run page, locale strings for both languages. The A2A timeline filters `token_usage` events to keep the log readable.

**Recursion + concurrency caps**
- Worker + orchestrator `recursion_limit` raised 240 → 480.
- `dispatch_subsystems` refactored into a per-subsystem worker: subsystems run fully in parallel; each subsystem internally runs **skeleton (signatures + interface module) → components (TDD, one-per-component fan-out)**. A global `Semaphore` caps total in-flight dispatches across both stages so nested executors can't multiply the cap. New helpers: `_build_subsystem_skeleton_task`, `_build_component_implementation_task`, `_interface_module_path`.
- `max_concurrent_subsystem_dispatches` default 4 → 16.

**Dispatch-budget auto-scale (A1)**
- `max_dispatches` default 30 → 128.
- `ProjectSession._apply_dispatch_floor` reads `docs/stack_contract.json` and lifts the cap to `Σ(1 + components) + DISPATCH_FLOOR_BUFFER` whenever the architect's contract demands more than the current cap. Re-applied after every phase so a contract produced mid-run lifts the cap before implementation. Fires a `dispatch_cap_raised` event for observability.

**`mark_complete` quality gate (A3)**
- Refuses to close a run when:
  1. Earlier phases haven't finished, or the final phase hasn't started.
  2. Any component file declared in `stack_contract.json` is missing or trivially small on disk.
  3. The report contains partial-delivery markers (`dispatch cap hit`, `0/N`, `❌`, `truncated`, `exhausted`, `not implemented`).
- Refusal returns diagnostic detail (missing artifacts list, missing phase indices, flagged markers) so the orchestrator can dispatch the gap and retry instead of silently stamping a partial run as completed.

## Test plan
- [x] `python -m ruff check src/ tests/` — passes.
- [x] `python -m pytest tests/` — **1208 passed, 53 skipped** (full suite, ~11.5min).
- [ ] Smoke-test a fresh project creation in the web UI and verify the Token-Usage card populates and the A2A timeline no longer shows `token_usage` rows.
- [ ] Run a project whose stack contract declares ≥ 50 components and confirm the dispatch cap auto-raises (`dispatch_cap_raised` event emitted; new cap printed in the log).
- [ ] Trigger a forced premature `mark_complete` (e.g. via a test prompt) and confirm the run stays in progress instead of closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)