### PR TITLE
docs(agents+process): align with dispatch_subsystems

### DIFF
--- a/src/aise/agents/architect.md
+++ b/src/aise/agents/architect.md
@@ -119,13 +119,16 @@ own — if you don't lay down the skeleton, nobody will.
   - Soft cap: aim for ≤ 10 subsystems for typical projects. If you
     exceed it, you are likely flat-listing components again.
 
-  This file is read by `dispatch_task` to prepend a `STACK
-  CONTRACT` block to every worker prompt; by qa_engineer to drive
-  UI Validation; by Phase 6 to interpret QA's metrics. **If you
-  skip this file or produce a flat-list schema, the entire
-  downstream pipeline falls back to language-detection-by-LLM,
-  which is what produced project_7-tower's three-stacks-coexist
-  AND 24-flat-directories failure modes.**
+  This file is read directly by `dispatch_subsystems` to fan
+  phase-3 out into one skeleton task + one task per component
+  (using the `subsystems[].components[]` tree as the unit of
+  parallelism); by qa_engineer to drive UI Validation; by
+  Phase 6 to interpret QA's metrics. **If you skip this file or
+  produce a flat-list schema, `dispatch_subsystems` returns a
+  failure result and the entire downstream pipeline falls back
+  to language-detection-by-LLM, which is what produced
+  project_7-tower's three-stacks-coexist AND 24-flat-directories
+  failure modes.**
 
 - **Subsystem directories — MANDATORY (one directory per *subsystem*,
   NOT one directory per component).** A "subsystem" is the unit of

--- a/src/aise/agents/project_manager.md
+++ b/src/aise/agents/project_manager.md
@@ -17,6 +17,7 @@ allowed_tools:
   - get_process
   - list_agents
   - dispatch_task
+  - dispatch_subsystems
   - dispatch_tasks_parallel
   - execute_shell
   - mark_complete
@@ -41,8 +42,9 @@ Your job is to compose these primitives in the order described by the process yo
 | `list_processes()` | Discover available process definitions |
 | `get_process(file)` | Read a process definition (phases, steps, deliverables, verification commands) |
 | `list_agents()` | Discover available agents and their cards |
-| `dispatch_task(agent_name, task_description, step_id, phase)` | Send work to an agent |
-| `dispatch_tasks_parallel(tasks_json)` | Send independent tasks concurrently |
+| `dispatch_task(agent_name, task_description, step_id, phase)` | Send work to an agent (sequential, one dispatch). Use for PM/architect/QA phases and for any single-shot worker call. |
+| `dispatch_subsystems(phase, agent_name)` | Deterministic two-stage fan-out for the implementation phase: reads `docs/stack_contract.json`, dispatches one skeleton task per subsystem, then one component task per `components[]` entry, throttled by `safety_limits.max_concurrent_subsystem_dispatches`. **The orchestrator emits a SINGLE call** — the runtime handles every per-subsystem and per-component dispatch internally. |
+| `dispatch_tasks_parallel(tasks_json)` | Legacy fallback. Send independent tasks concurrently when `dispatch_subsystems` cannot be used (e.g. ad-hoc parallelism that does not derive from the architecture). Do NOT use this to manually fan implementation out per module — use `dispatch_subsystems` instead. |
 | `execute_shell(command, cwd, timeout)` | Run an allowlisted command (e.g. the verification_command from a process step) |
 | `mark_complete(report)` | Signal that the workflow is finished and provide the final delivery report |
 | `write_file(path, content)` | Write your own outputs (plans, reports) — paths constrained by your output_layout |
@@ -61,24 +63,42 @@ Your job is to compose these primitives in the order described by the process yo
    - If the verification command fails AND the step declares `on_failure: retry_with_output` with `max_retries > 0`, dispatch the same agent again with the captured stdout/stderr attached as feedback. Retry up to `max_retries` times.
    - Steps within the same phase that have no inter-dependency may be run in parallel via `dispatch_tasks_parallel`.
 
-   **CRITICAL — Per-Module Dispatch for Implementation:**
-   When the process step says "dispatch once per module", you MUST:
-   1. Read `docs/architecture.md` YOURSELF to identify all modules and their dependencies
-   2. Group modules into layers by dependency:
-      - **Layer 1**: Base modules with NO dependencies on other project modules
-      - **Layer 2**: Modules that depend on Layer 1
-      - **Layer 3**: Integration/engine modules that depend on Layer 1+2
-   3. Dispatch each layer using `dispatch_tasks_parallel` — all modules in the
-      same layer run CONCURRENTLY:
-      ```
-      dispatch_tasks_parallel(tasks_json='[
-        {"agent_name": "developer", "task_description": "Implement module A. Arch spec: ...", "step_id": "impl_a", "phase": "implementation"},
-        {"agent_name": "developer", "task_description": "Implement module B. Arch spec: ...", "step_id": "impl_b", "phase": "implementation"}
-      ]')
-      ```
-   4. After each layer completes, run the verification command, then dispatch the next layer
-   5. For EACH module, include the architecture spec DIRECTLY in the task description
-      so the developer does NOT need to read architecture.md
+   **CRITICAL — Implementation Fan-Out Is Runtime-Driven:**
+   When the process step says "dispatch once per module" / "fan
+   out the implementation phase", you MUST issue exactly ONE tool
+   call:
+
+   ```
+   dispatch_subsystems(phase="implementation")
+   ```
+
+   `dispatch_subsystems` reads `docs/stack_contract.json` (which
+   the architect produced in Phase 2), groups files into the
+   subsystems[].components[] tree, and dispatches in two stages:
+
+   1. **Skeleton stage** — one task per subsystem to lay down
+      public API signatures + barrel files (no logic, no tests).
+      Skeletons across subsystems run in parallel.
+   2. **Component stage** — one task per component (source +
+      test pair). All components across all subsystems are
+      eligible to run in parallel as soon as their parent
+      subsystem's skeleton completes.
+
+   Both stages are throttled by
+   `safety_limits.max_concurrent_subsystem_dispatches`. You do
+   NOT need to read `docs/architecture.md`, group modules into
+   dependency layers, or hand-build a `tasks_json` payload — the
+   runtime owns that decision because empirically the
+   orchestrator LLM cannot reliably emit N parallel tool_calls
+   in one inference, which serialised the old
+   `dispatch_tasks_parallel` flow.
+
+   When `dispatch_subsystems` returns, run the
+   `verification_command` from the process step on its result
+   and proceed to the next phase. Do NOT re-issue
+   `dispatch_subsystems` for the same phase — the primitive is
+   idempotent only at the level of "produce the missing files",
+   not at the level of "rerun the entire fan-out".
 
 5. **Finish.** When every step in every phase is complete, write the final delivery report to `docs/delivery_report.md` and call `mark_complete(report=...)` with the same content. The session ends as soon as `mark_complete` is acknowledged.
 
@@ -87,7 +107,7 @@ Your job is to compose these primitives in the order described by the process yo
 - Read each agent's card (description + skills) before assigning work — do NOT assume role-name conventions.
 - Keep `dispatch_task` task descriptions concise: describe WHAT to produce and WHERE to write it, not how. Each agent already knows its own output_layout.
 - On a failed task: retry once with clarifying instructions, then move on with what you have.
-- Total dispatches should stay under the runtime safety cap (default 12 — the runtime will refuse new dispatches beyond it).
+- Total dispatches must stay under the runtime safety cap (`safety_limits.max_dispatches`, default `DEFAULT_MAX_DISPATCHES = 128`; auto-scaled per project to `Σ(1 + len(components)) + DISPATCH_FLOOR_BUFFER` so a typical 5-subsystem / 32-component project gets ~50–60 dispatches of headroom). The runtime refuses new dispatches once the cap is reached. Each `dispatch_subsystems` invocation counts every per-subsystem and per-component child dispatch against this budget.
 - Always end the session by calling `mark_complete`. If you do not, the runtime will continue prompting you until the cap is hit.
 - Do NOT use the `task` tool (subagent). Use `dispatch_task` to send work to agents instead.
 - Do NOT write or edit source code yourself. Dispatch developer to write code.

--- a/src/aise/processes/waterfall.process.md
+++ b/src/aise/processes/waterfall.process.md
@@ -5,7 +5,15 @@ work_type: structured_development
 keywords: waterfall, sequential, design-first, documentation, milestone
 summary: A linear and sequential approach to software development where each phase must be completed before the next begins. Default choice for most structured projects.
 caps:
-  max_dispatches: 30
+  # ``max_dispatches`` is the upper bound; the runtime auto-scales
+  # the *floor* per project as
+  # ``Σ(1 + len(components)) + DISPATCH_FLOOR_BUFFER``
+  # (see ``src/aise/runtime/runtime_config.py`` and
+  # ``ProjectSession._auto_scale_dispatch_floor``), so a 5-subsystem /
+  # 32-component project gets ~50–60 dispatches of headroom, well
+  # under this 128 cap. Bumping this higher only matters for very
+  # large projects (≥ 8 subsystems with deep component trees).
+  max_dispatches: 128
   max_continuations: 15
 terminal_step: deliver_report
 required_phases:
@@ -42,24 +50,35 @@ required_phases:
 - deliverables: docs/architecture.md
 
 ### phase_3_implementation: Implementation
-#### step_implement_modules: Per-Module TDD Implementation
+#### step_implement_modules: Subsystem Fan-Out Implementation
 - agents: developer
 - description: |
-    IMPORTANT: The orchestrator must dispatch the developer ONCE PER MODULE,
-    not once for all modules. Read docs/architecture.md to identify the list
-    of modules, then for each module:
-      1. dispatch_task(developer, "Implement module <name>: write tests/test_<name>.py then src/<name>.py.
-         This module depends on: <list imports from other modules if any>.")
-      2. After the dispatch returns, run the verification_command
-      3. If verification fails, re-dispatch with the pytest output
-      4. Move to the next module only after the current one passes
+    The orchestrator MUST issue exactly ONE tool call here:
 
-    Dispatch ORDER matters: implement base/data modules first (no dependencies),
-    then modules that depend on them. Include dependency info in each task description
-    so the developer knows what to import.
+      dispatch_subsystems(phase="implementation")
 
-    Each dispatch should produce exactly 2 files: one test file and one source file.
-    This keeps each agent invocation small and focused.
+    The runtime reads docs/stack_contract.json (produced by the
+    architect in phase 2) and fans out in two stages:
+
+      Stage 1 — skeleton: one dispatch per subsystem, producing
+      public API signatures + barrel files (no logic, no tests).
+      Skeletons across subsystems run in parallel, throttled by
+      safety_limits.max_concurrent_subsystem_dispatches.
+
+      Stage 2 — components: one dispatch per
+      subsystems[].components[] entry, each producing exactly the
+      (source, test) file pair declared in the contract. Components
+      across the entire project are eligible to run in parallel as
+      soon as their parent subsystem's skeleton completes.
+
+    Do NOT call dispatch_task or dispatch_tasks_parallel for
+    per-module implementation here — the runtime owns the fan-out
+    decision because the orchestrator LLM cannot reliably emit N
+    parallel tool_calls in one inference, which serialised the old
+    flow into N sequential ReAct cycles.
+
+    On return, the verification_command runs once over the whole
+    src/ + tests/ tree.
 - deliverables: src/, tests/
 - verification_command: python -m pytest tests/ -q --tb=short
 - on_failure: retry_with_output
@@ -68,14 +87,22 @@ required_phases:
 #### step_integrate_main: Main Entry Point
 - agents: developer
 - description: |
-    After all modules are implemented, dispatch the developer ONE MORE TIME to write
-    the main entry point that wires all modules together:
-      dispatch_task(developer, "Write src/main.py — the main entry point that imports
-      and initializes all modules (<list the implemented modules>), and provides a
-      runnable application. Also write tests/test_main.py to verify the integration.")
+    After dispatch_subsystems completes, dispatch the developer
+    once more to wire the runnable entry point:
 
-    This step ensures the system is runnable as a whole, not just isolated modules.
-- deliverables: src/main.py, tests/test_main.py
+      dispatch_task(developer, "Write the main entry file declared
+      at docs/stack_contract.json#/entry_point — import and
+      initialise every subsystem from src/, and provide a runnable
+      application using the framework recorded in
+      stack_contract.json#/framework_backend (or framework_frontend
+      for UI projects). Also add the integration test that boots
+      the entry point end-to-end.")
+
+    This is a single dispatch_task — the entry point is one file
+    pair, not a fan-out. The runtime exercises the chosen stack at
+    boot time, which is what guarantees the framework choice is
+    real and not just declared in prose.
+- deliverables: src/main.<ext>, tests/test_main.<ext>
 - verification_command: python -m pytest tests/ -q --tb=short
 - on_failure: retry_with_output
 - max_retries: 2


### PR DESCRIPTION
## Summary

PR #129 introduced the deterministic phase-3 fan-out primitive
`dispatch_subsystems` but left several pieces of guidance still pointing
at the previous LLM-driven `dispatch_tasks_parallel` flow. This PR
brings the docs in line with the runtime — no code changes.

- **`agents/architect.md`**: `stack_contract.json` is now consumed by
  `dispatch_subsystems` (skeleton + per-component fan-out), not by
  `dispatch_task` wrapping a STACK CONTRACT prompt prefix. Update the
  reader-of-record description.
- **`agents/project_manager.md`**: add `dispatch_subsystems` to
  `allowed_tools`; rewrite the "per-module dispatch" section so the
  orchestrator emits exactly ONE `dispatch_subsystems(phase="implementation")`
  call instead of hand-building dependency layers + `tasks_json`. Update
  the safety cap line to reference `DEFAULT_MAX_DISPATCHES = 128` and the
  per-project auto-scaled floor (`Σ(1 + len(components)) + DISPATCH_FLOOR_BUFFER`).
- **`processes/waterfall.process.md`**: bump `caps.max_dispatches` from
  30 → 128 and document the auto-scale floor; rewrite
  `step_implement_modules` as a single `dispatch_subsystems(phase="implementation")`
  call with a comment on why the LLM is no longer in the fan-out loop;
  rewrite `step_integrate_main` to dispatch the entry-point file pair as
  a single `dispatch_task` keyed by `stack_contract.json#/entry_point`.

## Test plan

- [x] `ruff check src/ tests/`
- [x] `ruff format --check src/ tests/`
- [x] `pytest tests/` — full suite passes (1117 passed / 50 skipped locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)