### PR TITLE
fix(schema): allow event_loop_owner=null in stack_contract.schema.json

### DIFF
--- a/src/aise/schemas/stack_contract.schema.json
+++ b/src/aise/schemas/stack_contract.schema.json
@@ -42,7 +42,12 @@
       "type": "array",
       "items": { "$ref": "#/definitions/lifecycle_init" }
     },
-    "event_loop_owner": { "$ref": "#/definitions/lifecycle_init" }
+    "event_loop_owner": {
+      "oneOf": [
+        { "$ref": "#/definitions/lifecycle_init" },
+        { "type": "null" }
+      ]
+    }
   },
   "additionalProperties": true,
 

--- a/tests/test_runtime/test_predicates.py
+++ b/tests/test_runtime/test_predicates.py
@@ -209,6 +209,69 @@ class TestSchemaPredicate:
         )
         assert not r.passed and "invalid JSON" in r.detail
 
+    def test_event_loop_owner_null_is_valid(self, tmp_path: Path):
+        # Flutter / Bottle-style entry points hand the loop to an external
+        # library (`runApp(app)`, `app.run()`), so architect.md tells the
+        # producer to set event_loop_owner=null. Schema must accept it —
+        # the magic_tower 2026-05-04 e2e halted at architecture because
+        # this branch was missing from the schema even though architect.md
+        # and safety_net/stack_contract.py both treat null as valid.
+        contract = {
+            "language": "dart",
+            "framework_backend": "",
+            "framework_frontend": "flutter",
+            "package_manager": "pub",
+            "test_runner": "flutter test",
+            "entry_point": "lib/main.dart",
+            "run_command": "flutter run",
+            "subsystems": [
+                {
+                    "name": "ui",
+                    "src_dir": "lib/ui",
+                    "components": [{"name": "main_menu", "file": "lib/ui/main_menu.dart"}],
+                }
+            ],
+            "event_loop_owner": None,
+        }
+        (tmp_path / "stack_contract.json").write_text(json.dumps(contract), encoding="utf-8")
+        r = evaluate_predicate(
+            _pred("schema", "schemas/stack_contract.schema.json"),
+            _ctx(tmp_path, "stack_contract.json"),
+        )
+        assert r.passed, r.detail
+
+    def test_event_loop_owner_object_still_valid(self, tmp_path: Path):
+        # Pygame / Qt-with-custom-loop projects fill in a real lifecycle_init
+        # object — the existing branch must keep working after we widen the
+        # schema to accept null.
+        contract = {
+            "language": "python",
+            "framework_backend": "pygame",
+            "package_manager": "pip",
+            "test_runner": "pytest",
+            "entry_point": "src/main.py",
+            "run_command": "python -m src.main",
+            "subsystems": [
+                {
+                    "name": "core",
+                    "src_dir": "src/core",
+                    "components": [{"name": "game", "file": "src/core/game.py"}],
+                }
+            ],
+            "event_loop_owner": {
+                "attr": "dispatcher",
+                "method": "initialize",
+                "class": "EventDispatcher",
+                "module": "src/core/game.py",
+            },
+        }
+        (tmp_path / "stack_contract.json").write_text(json.dumps(contract), encoding="utf-8")
+        r = evaluate_predicate(
+            _pred("schema", "schemas/stack_contract.schema.json"),
+            _ctx(tmp_path, "stack_contract.json"),
+        )
+        assert r.passed, r.detail
+
 
 # -- language_supported ---------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Widen `event_loop_owner` in `stack_contract.schema.json` to `oneOf [lifecycle_init, null]`. The architect prompt and the safety-net validator already treat `null` as the correct value for projects whose main loop is owned by an external library (`runApp(app)` in Flutter, `app.run()` in Bottle), but the JSON schema was object-only — three contracts disagreed.
- Add two regression tests covering both branches (Flutter `null` and pygame-style object).

## Root cause

A real waterfall_v2 e2e of a Flutter "magic tower" requirement halted at `architecture` with `producer_acceptance_gate_exhausted`. The AUTO_GATE schema check rejected the architect's output:

```
$.event_loop_owner: expected type 'object', got NoneType
```

Three places already say `null` is valid:
- `src/aise/agents/architect.md:163-166` — "Set `event_loop_owner: null` ONLY when the framework's main loop is fully owned by an external library"
- `src/aise/safety_net/stack_contract.py:305` — "event_loop_owner must be an object or null"
- `src/aise/agents/_runtime_skills/entry_point_wiring/SKILL.md:189`

`stack_contract.schema.json:45` was the only outlier. Architect kept retrying with the correct (per-prompt) `null` → schema kept rejecting → 3 retries → halt.

## Test plan

- [x] `pytest tests/test_runtime/test_predicates.py::TestSchemaPredicate -v` (5 passed including 2 new)
- [x] Full local suite: `pytest --tb=short -q --ignore=tests/test_packaging --ignore=tests/test_whatsapp` → 1288 passed / 52 skipped
- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` clean
- [ ] CI Build / Lint / Test 3.11 / Test 3.12 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)