### PR TITLE
feat(testing): cpp_wc_cli scenario fixtures (P3.5)

### DIFF
--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/architecture/case.yaml
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/architecture/case.yaml
@@ -1,0 +1,49 @@
+aise_version: "0.1.0"
+scenario_id: cpp_wc_cli
+phase: architecture
+
+input_dir: input/
+project_config_file: project_config.json
+
+requirement: |
+  Build a C++17 command-line tool similar to ``wc`` — single binary,
+  CMake build, CTest tests, stdlib only.
+
+max_review_iterations: 1
+timeout_sec: 1800
+
+assertions:
+  - { name: arch_md_present,             path: docs/architecture.md, predicate: file_exists }
+  - { name: arch_md_substantial,         path: docs/architecture.md, predicate: { min_bytes: 2000 } }
+  - { name: stack_contract_present,      path: docs/stack_contract.json, predicate: file_exists }
+  - { name: behavioral_contract_present, path: docs/behavioral_contract.json, predicate: file_exists }
+  - name: stack_schema_valid
+    path: docs/stack_contract.json
+    predicate: { schema: schemas/stack_contract.schema.json }
+  - name: language_cpp
+    path: docs/stack_contract.json
+    predicate: { json_field_one_of: { field: language, allowed: [cpp, "c++"] } }
+  - name: package_manager_cmake
+    path: docs/stack_contract.json
+    predicate: { json_field_one_of: { field: package_manager, allowed: [cmake, conan, vcpkg] } }
+  - name: project_config_cmakelists
+    path: docs/stack_contract.json
+    predicate: { json_field_equals: { field: project_config_file, expected: CMakeLists.txt } }
+  - name: test_runner_ctest
+    path: docs/stack_contract.json
+    predicate: { json_field_one_of: { field: test_runner, allowed: [ctest, "ctest --test-dir build", "ctest --output-on-failure"] } }
+  - name: ui_required_false
+    path: docs/stack_contract.json
+    predicate: { json_field_equals: { field: ui_required, expected: false } }
+  - name: subsystems_min
+    path: docs/stack_contract.json
+    predicate: { count_at_least: { field: subsystems, min: 1 } }
+  - name: subsystems_max
+    path: docs/stack_contract.json
+    predicate: { count_at_most: { field: subsystems, max: 8 } }
+  - name: arch_mentions_cpp_and_cmake
+    path: docs/architecture.md
+    predicate: { contains_keywords: { all_of: ["C++", CMake] } }
+  - name: not_python_typescript_or_flutter
+    path: docs/architecture.md
+    predicate: { forbidden_patterns: { patterns: ["pyproject\\.toml", "package\\.json", "pubspec\\.yaml", "lib/main\\.dart"] } }

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/architecture/input/docs/requirement.md
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/architecture/input/docs/requirement.md
@@ -1,0 +1,251 @@
+# Requirement Specification — wc-tool
+
+## 功能需求
+
+### FR-001: File Input and Argument Parsing
+
+The tool accepts a single positional argument that specifies the path to the file to be
+analysed.
+
+- **FR-001.1** The tool MUST accept exactly one file path argument on the command line.
+- **FR-001.2** If no argument is provided, the tool MUST print an error message to
+  **stderr** and exit with a non-zero status code.
+- **FR-001.3** If the file does not exist or cannot be opened, the tool MUST print an
+  error message to **stderr** and exit with a non-zero status code.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_invoke(("Invoke wc-tool"))
+  uc_parse(("Parse file argument"))
+  uc_validate(("Validate file exists"))
+  actor_user --> uc_invoke
+  uc_invoke --> uc_parse
+  uc_parse --> uc_validate
+  uc_validate -->|missing arg| uc_error
+  uc_validate -->|file not found| uc_error
+  uc_error(["Error to stderr"])
+```
+
+### FR-002: Line Count
+
+The tool MUST count the number of newline characters (`\n`) in the file and report the
+result as the first integer in its output.
+
+- **FR-002.1** Each newline character (`\n`) in the file contributes exactly one to the
+  line count.
+- **FR-002.2** A file that is empty (zero bytes) MUST produce a line count of `0`.
+- **FR-002.3** A file whose last character is not a newline MUST still be counted as
+  containing one additional line (matching `wc` semantics).
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_read(("Read file"))
+  uc_count_lines(("Count lines"))
+  uc_report(("Report line count"))
+  actor_user --> uc_read
+  uc_read --> uc_count_lines
+  uc_count_lines --> uc_report
+```
+
+### FR-003: Word Count
+
+The tool MUST count the number of whitespace-delimited words in the file.
+
+- **FR-003.1** A word is defined as a maximal sequence of non-whitespace characters.
+  Whitespace characters are those recognised by `std::isspace` (space, tab, newline,
+  carriage return, form feed, vertical tab).
+- **FR-003.2** Empty files MUST produce a word count of `0`.
+- **FR-003.3** Multiple consecutive whitespace characters MUST NOT produce extra words.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_read(("Read file"))
+  uc_count_words(("Count words"))
+  uc_report(("Report word count"))
+  actor_user --> uc_read
+  uc_read --> uc_count_words
+  uc_count_words --> uc_report
+```
+
+### FR-004: Byte Count
+
+The tool MUST report the total number of bytes in the file.
+
+- **FR-004.1** The byte count is the file size in bytes as reported by the operating
+  system (e.g. `std::filesystem::file_size` or reading until EOF).
+- **FR-004.2** An empty file MUST produce a byte count of `0`.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_read(("Read file"))
+  uc_count_bytes(("Count bytes"))
+  uc_report(("Report byte count"))
+  actor_user --> uc_read
+  uc_read --> uc_count_bytes
+  uc_count_bytes --> uc_report
+```
+
+### FR-005: Output Format
+
+The tool MUST print three integers (lines, words, bytes) separated by single spaces,
+followed by the filename, to stdout.
+
+- **FR-005.1** The output format is: `<lines> <words> <bytes> <filename>`
+- **FR-005.2** Fields are separated by exactly one space.
+- **FR-005.3** The filename printed is the user-provided argument, not a canonicalised path.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_compute(("Compute statistics"))
+  uc_format(("Format output"))
+  uc_print(("Print to stdout"))
+  actor_user --> uc_compute
+  uc_compute --> uc_format
+  uc_format --> uc_print
+```
+
+### FR-006: Build System
+
+The project MUST be buildable with CMake using C++17 as the strict language standard,
+producing a single static binary with no runtime dependencies.
+
+- **FR-006.1** A `CMakeLists.txt` file exists at the project root.
+- **FR-006.2** The build system enforces C++17 via `set(CMAKE_CXX_STANDARD 17)`.
+- **FR-006.3** The build produces a single static binary with no runtime dependencies.
+
+```mermaid
+flowchart LR
+  actor_dev(["👤 Developer"])
+  uc_cmake(("Configure CMake"))
+  uc_build(("Build binary"))
+  uc_verify(("Verify binary"))
+  actor_dev --> uc_cmake
+  uc_cmake --> uc_build
+  uc_build --> uc_verify
+```
+
+### FR-007: Unit Tests
+
+The project MUST include unit tests for each counting primitive using the CTest framework
+with no third-party dependencies.
+
+- **FR-007.1** Separate test executables exist for line-count, word-count, and byte-count.
+- **FR-007.2** Tests are registered with `add_test` in CMake.
+- **FR-007.3** No third-party testing frameworks are used.
+
+```mermaid
+flowchart LR
+  actor_dev(["👤 Developer"])
+  uc_write_tests(("Write unit tests"))
+  uc_register(("Register with CTest"))
+  uc_run(("Run tests"))
+  actor_dev --> uc_write_tests
+  uc_write_tests --> uc_register
+  uc_register --> uc_run
+```
+
+## 非功能需求
+
+### NFR-001: Performance
+
+The tool reads the input file exactly once, processes files of at least 1 GB within
+30 seconds on standard hardware, and uses O(1) memory with respect to file size
+via streaming read.
+
+### NFR-002: Portability
+
+The tool compiles and runs on Linux (glibc) and macOS (Apple clang) using C++17,
+and is relocatable with no hardcoded paths.
+
+### NFR-003: Reliability
+
+The tool handles binary files gracefully without crashing and does not produce
+undefined behaviour on empty files, very large files, or files with unusual encodings.
+
+## 用例
+
+### UC-001: Count File Statistics
+
+**Actor:** User
+**Goal:** Obtain line, word, and byte counts for a given file.
+**Preconditions:** A file exists and is readable.
+**Main Flow:**
+1. User invokes `wc-tool <file_path>`.
+2. The tool opens the file for reading.
+3. The tool reads the file once, counting lines, words, and bytes.
+4. The tool prints the results to stdout.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_run(("Run wc-tool"))
+  uc_open(("Open file"))
+  uc_read(("Read and count"))
+  uc_output(("Output results"))
+  actor_user --> uc_run
+  uc_run --> uc_open
+  uc_open --> uc_read
+  uc_read --> uc_output
+```
+
+Covers: FR-001, FR-002, FR-003, FR-004, FR-005
+
+### UC-002: Handle Missing File Argument
+
+**Actor:** User
+**Goal:** Receive an error message when no file argument is provided.
+**Preconditions:** None.
+**Main Flow:**
+1. User invokes `wc-tool` without arguments.
+2. The tool detects the missing argument.
+3. The tool prints an error message to stderr.
+4. The tool exits with a non-zero status code.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_run(("Run wc-tool"))
+  uc_check(("Check arguments"))
+  uc_error(("Print error to stderr"))
+  uc_exit(("Exit with non-zero"))
+  actor_user --> uc_run
+  uc_run --> uc_check
+  uc_check -->|no args| uc_error
+  uc_error --> uc_exit
+```
+
+Covers: FR-001
+
+### UC-003: Handle Non-Existent File
+
+**Actor:** User
+**Goal:** Receive an error message when the specified file does not exist.
+**Preconditions:** None.
+**Main Flow:**
+1. User invokes `wc-tool <nonexistent_file>`.
+2. The tool attempts to open the file.
+3. The tool detects the file does not exist.
+4. The tool prints an error message to stderr.
+5. The tool exits with a non-zero status code.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_run(("Run wc-tool"))
+  uc_open(("Open file"))
+  uc_check(("Check if exists"))
+  uc_error(("Print error to stderr"))
+  uc_exit(("Exit with non-zero"))
+  actor_user --> uc_run
+  uc_run --> uc_open
+  uc_open --> uc_check
+  uc_check -->|not found| uc_error
+  uc_error --> uc_exit
+```
+
+Covers: FR-001

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/architecture/input/docs/requirement_contract.json
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/architecture/input/docs/requirement_contract.json
@@ -1,0 +1,156 @@
+{
+  "project_name": "wc-tool",
+  "summary": "A C++17 command-line tool that computes line count, word count, and byte count for a given file, mirroring the Unix wc utility. Built with CMake, tested with CTest, producing a single static binary with no runtime dependencies beyond the C++ standard library.",
+  "functional_requirements": [
+    {
+      "id": "FR-001",
+      "title": "File Input and Argument Parsing",
+      "description": "The tool accepts a single positional argument specifying the file path. It must validate the argument exists and the file is readable, printing errors to stderr and exiting non-zero on failure.",
+      "acceptance_criteria": [
+        "Exactly one file path argument is accepted",
+        "No argument produces an error to stderr with non-zero exit",
+        "Non-existent file produces an error to stderr with non-zero exit"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-002",
+      "title": "Line Count",
+      "description": "The tool counts newline characters as lines, with wc-compatible semantics: empty file yields 0, and a file without a trailing newline still counts the last line.",
+      "acceptance_criteria": [
+        "Each newline character contributes exactly one to line count",
+        "Empty file produces line count of 0",
+        "File without trailing newline still counts the final line"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-003",
+      "title": "Word Count",
+      "description": "The tool counts whitespace-delimited words where a word is a maximal sequence of non-whitespace characters. Multiple consecutive whitespace characters do not produce extra words.",
+      "acceptance_criteria": [
+        "A word is a maximal sequence of non-whitespace characters",
+        "Empty file produces word count of 0",
+        "Multiple consecutive whitespace characters do not produce extra words"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-004",
+      "title": "Byte Count",
+      "description": "The tool reports the total number of bytes in the file, equivalent to the file size in bytes as reported by the operating system.",
+      "acceptance_criteria": [
+        "Byte count equals the file size in bytes",
+        "Empty file produces byte count of 0"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-005",
+      "title": "Output Format",
+      "description": "The tool prints three integers (lines, words, bytes) separated by single spaces, followed by the filename, to stdout.",
+      "acceptance_criteria": [
+        "Output format is: <lines> <words> <bytes> <filename>",
+        "Fields are separated by exactly one space",
+        "Filename printed is the user-provided argument, not a canonicalised path"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-006",
+      "title": "Build System",
+      "description": "The project is buildable with CMake using C++17 as the strict language standard, producing a single static binary with no runtime dependencies.",
+      "acceptance_criteria": [
+        "CMakeLists.txt exists at the project root",
+        "Build system enforces C++17",
+        "Build produces a single static binary with no runtime dependencies"
+      ],
+      "priority": "P1"
+    },
+    {
+      "id": "FR-007",
+      "title": "Unit Tests",
+      "description": "The project includes unit tests for each counting primitive using the CTest framework with no third-party dependencies. Separate test executables are registered with add_test.",
+      "acceptance_criteria": [
+        "Separate test executables exist for line-count, word-count, and byte-count",
+        "Tests are registered with add_test in CMake",
+        "No third-party testing frameworks are used"
+      ],
+      "priority": "P1"
+    }
+  ],
+  "non_functional_requirements": [
+    {
+      "id": "NFR-001",
+      "title": "Performance",
+      "description": "The tool reads the input file exactly once, processes files of at least 1 GB within 30 seconds on standard hardware, and uses O(1) memory with respect to file size via streaming read.",
+      "priority": "P1"
+    },
+    {
+      "id": "NFR-002",
+      "title": "Portability",
+      "description": "The tool compiles and runs on Linux (glibc) and macOS (Apple clang) using C++17, and is relocatable with no hardcoded paths.",
+      "priority": "P1"
+    },
+    {
+      "id": "NFR-003",
+      "title": "Reliability",
+      "description": "The tool handles binary files gracefully without crashing and does not produce undefined behaviour on empty files, very large files, or files with unusual encodings.",
+      "priority": "P1"
+    }
+  ],
+  "use_cases": [
+    {
+      "id": "UC-001",
+      "actor": "User",
+      "goal": "Obtain line, word, and byte counts for a given file.",
+      "preconditions": [
+        "A file exists and is readable"
+      ],
+      "main_flow": [
+        "User invokes wc-tool with a file path argument",
+        "The tool opens the file for reading",
+        "The tool reads the file once, counting lines, words, and bytes",
+        "The tool prints the results to stdout in the format: lines words bytes filename"
+      ],
+      "covers_requirements": [
+        "FR-001",
+        "FR-002",
+        "FR-003",
+        "FR-004",
+        "FR-005"
+      ]
+    },
+    {
+      "id": "UC-002",
+      "actor": "User",
+      "goal": "Receive an error message when no file argument is provided.",
+      "preconditions": [],
+      "main_flow": [
+        "User invokes wc-tool without arguments",
+        "The tool detects the missing argument",
+        "The tool prints an error message to stderr",
+        "The tool exits with a non-zero status code"
+      ],
+      "covers_requirements": [
+        "FR-001"
+      ]
+    },
+    {
+      "id": "UC-003",
+      "actor": "User",
+      "goal": "Receive an error message when the specified file does not exist.",
+      "preconditions": [],
+      "main_flow": [
+        "User invokes wc-tool with a non-existent file path",
+        "The tool attempts to open the file",
+        "The tool detects the file does not exist",
+        "The tool prints an error message to stderr",
+        "The tool exits with a non-zero status code"
+      ],
+      "covers_requirements": [
+        "FR-001"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/architecture/project_config.json
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/architecture/project_config.json
@@ -1,0 +1,72 @@
+{
+  "project_name": "cpp_wc",
+  "development_mode": "local",
+  "process_type": "waterfall_v2",
+  "ui_language": "en",
+  "default_model": {
+    "provider": "Local",
+    "model": "qwen3.6-35b",
+    "api_key": "",
+    "base_url": "http://127.0.0.1:8088/v1",
+    "temperature": 0.7,
+    "max_tokens": 4096
+  },
+  "model_providers": [
+    {
+      "provider": "Local",
+      "api_key": "",
+      "base_url": "http://127.0.0.1:8088/v1",
+      "enabled": true
+    }
+  ],
+  "agents": {
+    "product_manager": {
+      "name": "product_manager",
+      "enabled": true
+    },
+    "architect": {
+      "name": "architect",
+      "enabled": true
+    },
+    "developer": {
+      "name": "developer",
+      "enabled": true
+    },
+    "qa_engineer": {
+      "name": "qa_engineer",
+      "enabled": true
+    },
+    "project_manager": {
+      "name": "project_manager",
+      "enabled": true
+    },
+    "rd_director": {
+      "name": "rd_director",
+      "enabled": true
+    }
+  },
+  "agent_model_selection": {},
+  "workflow": {
+    "max_review_iterations": 3,
+    "fail_on_review_rejection": false
+  },
+  "session": {
+    "max_concurrent_sessions": 5
+  },
+  "workspace": {
+    "projects_root": "projects",
+    "artifacts_root": "artifacts",
+    "auto_create_dirs": true
+  },
+  "logging": {
+    "level": "INFO",
+    "log_dir": "logs",
+    "json_format": false,
+    "rotate_daily": true
+  },
+  "github": {
+    "token": "",
+    "repo_owner": "",
+    "repo_name": ""
+  }
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/case.yaml
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/case.yaml
@@ -1,0 +1,33 @@
+aise_version: "0.1.0"
+scenario_id: cpp_wc_cli
+phase: delivery
+
+input_dir: input/
+project_config_file: project_config.json
+
+requirement: |
+  Build a C++17 ``wc``-like CLI — deliver the project.
+
+max_review_iterations: 1
+timeout_sec: 900
+
+assertions:
+  - name: delivery_report_present
+    path: docs/delivery_report.md
+    predicate: file_exists
+
+  - name: delivery_report_substantial
+    path: docs/delivery_report.md
+    predicate: { min_bytes: 600 }
+
+  - name: report_summarizes_prior_phases
+    path: docs/delivery_report.md
+    predicate: { prior_phases_summarized: 4 }
+
+  - name: report_mentions_cpp
+    path: docs/delivery_report.md
+    predicate: { contains_keywords: { any_of: ["C++", "cpp", "C++17"] } }
+
+  - name: report_mentions_wc_or_counts
+    path: docs/delivery_report.md
+    predicate: { contains_keywords: { any_of: [wc, "word count", "lines, words, bytes"] } }

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/CMakeLists.txt
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/CMakeLists.txt
@@ -1,0 +1,122 @@
+cmake_minimum_required(VERSION 3.14)
+project(wc-tool VERSION 1.0.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Static library — all subsystem source compiled once
+add_library(wc-tool-lib
+    src/input/arg_parser.cpp
+    src/input/file_opener.cpp
+    src/counter/line_counter.cpp
+    src/counter/word_counter.cpp
+    src/counter/byte_counter.cpp
+    src/counter/combined_counter.cpp
+    src/output/formatter.cpp
+)
+target_include_directories(wc-tool-lib PUBLIC src)
+
+# Main executable
+add_executable(wc-tool src/main.cpp)
+target_link_libraries(wc-tool PRIVATE wc-tool-lib)
+
+# Unit test executables — each links against the shared library
+add_executable(test_line_counter tests/test_line_counter.cpp)
+target_link_libraries(test_line_counter PRIVATE wc-tool-lib)
+
+add_executable(test_word_counter tests/test_word_counter.cpp)
+target_link_libraries(test_word_counter PRIVATE wc-tool-lib)
+
+add_executable(test_byte_counter tests/test_byte_counter.cpp)
+target_link_libraries(test_byte_counter PRIVATE wc-tool-lib)
+
+add_executable(test_combined_counter tests/test_combined_counter.cpp)
+target_link_libraries(test_combined_counter PRIVATE wc-tool-lib)
+
+add_executable(test_arg_parser tests/test_arg_parser.cpp)
+target_link_libraries(test_arg_parser PRIVATE wc-tool-lib)
+
+add_executable(test_file_opener tests/test_file_opener.cpp)
+target_link_libraries(test_file_opener PRIVATE wc-tool-lib)
+
+add_executable(test_output_formatter tests/test_output_formatter.cpp)
+target_link_libraries(test_output_formatter PRIVATE wc-tool-lib)
+
+# E2E test executables — each links against the shared library
+add_executable(test_e2e_normal_file tests/test_e2e_normal_file.cpp)
+target_link_libraries(test_e2e_normal_file PRIVATE wc-tool-lib)
+
+add_executable(test_e2e_empty_file tests/test_e2e_empty_file.cpp)
+target_link_libraries(test_e2e_empty_file PRIVATE wc-tool-lib)
+
+add_executable(test_e2e_no_argument tests/test_e2e_no_argument.cpp)
+target_link_libraries(test_e2e_no_argument PRIVATE wc-tool-lib)
+
+add_executable(test_e2e_file_not_found tests/test_e2e_file_not_found.cpp)
+target_link_libraries(test_e2e_file_not_found PRIVATE wc-tool-lib)
+
+add_executable(test_e2e_no_trailing_newline tests/test_e2e_no_trailing_newline.cpp)
+target_link_libraries(test_e2e_no_trailing_newline PRIVATE wc-tool-lib)
+
+# === Scenario integration tests (tests/scenarios/) ===
+add_executable(scenario_line_counter tests/scenarios/test_line_counter.cpp)
+target_link_libraries(scenario_line_counter PRIVATE wc-tool-lib)
+
+add_executable(scenario_word_counter tests/scenarios/test_word_counter.cpp)
+target_link_libraries(scenario_word_counter PRIVATE wc-tool-lib)
+
+add_executable(scenario_byte_counter tests/scenarios/test_byte_counter.cpp)
+target_link_libraries(scenario_byte_counter PRIVATE wc-tool-lib)
+
+add_executable(scenario_arg_parser tests/scenarios/test_arg_parser.cpp)
+target_link_libraries(scenario_arg_parser PRIVATE wc-tool-lib)
+
+add_executable(scenario_output_formatter tests/scenarios/test_output_formatter.cpp)
+target_link_libraries(scenario_output_formatter PRIVATE wc-tool-lib)
+
+add_executable(scenario_e2e_normal_file tests/scenarios/e2e_normal_file.cpp)
+target_link_libraries(scenario_e2e_normal_file PRIVATE wc-tool-lib)
+
+add_executable(scenario_e2e_empty_file tests/scenarios/e2e_empty_file.cpp)
+target_link_libraries(scenario_e2e_empty_file PRIVATE wc-tool-lib)
+
+add_executable(scenario_e2e_no_argument tests/scenarios/e2e_no_argument.cpp)
+target_link_libraries(scenario_e2e_no_argument PRIVATE wc-tool-lib)
+
+add_executable(scenario_e2e_file_not_found tests/scenarios/e2e_file_not_found.cpp)
+target_link_libraries(scenario_e2e_file_not_found PRIVATE wc-tool-lib)
+
+add_executable(scenario_e2e_no_trailing_newline tests/scenarios/e2e_no_trailing_newline.cpp)
+target_link_libraries(scenario_e2e_no_trailing_newline PRIVATE wc-tool-lib)
+
+# Enable testing
+enable_testing()
+
+# Unit tests
+add_test(NAME LineCounterTest COMMAND test_line_counter)
+add_test(NAME WordCounterTest COMMAND test_word_counter)
+add_test(NAME ByteCounterTest COMMAND test_byte_counter)
+add_test(NAME CombinedCounterTest COMMAND test_combined_counter)
+add_test(NAME ArgParserTest COMMAND test_arg_parser)
+add_test(NAME OutputFormatterTest COMMAND test_output_formatter)
+add_test(NAME FileOpenerTest COMMAND test_file_opener)
+
+# E2E unit tests
+add_test(NAME E2ENormalFileTest COMMAND test_e2e_normal_file)
+add_test(NAME E2EEmptyFileTest COMMAND test_e2e_empty_file)
+add_test(NAME E2ENoArgumentTest COMMAND test_e2e_no_argument)
+add_test(NAME E2EFileNotFoundTest COMMAND test_e2e_file_not_found)
+add_test(NAME E2ENoTrailingNewlineTest COMMAND test_e2e_no_trailing_newline)
+
+# Scenario integration tests
+add_test(NAME ScenarioLineCounterTest COMMAND scenario_line_counter)
+add_test(NAME ScenarioWordCounterTest COMMAND scenario_word_counter)
+add_test(NAME ScenarioByteCounterTest COMMAND scenario_byte_counter)
+add_test(NAME ScenarioArgParserTest COMMAND scenario_arg_parser)
+add_test(NAME ScenarioOutputFormatterTest COMMAND scenario_output_formatter)
+add_test(NAME ScenarioE2ENormalFileTest COMMAND scenario_e2e_normal_file)
+add_test(NAME ScenarioE2EEmptyFileTest COMMAND scenario_e2e_empty_file)
+add_test(NAME ScenarioE2ENoArgumentTest COMMAND scenario_e2e_no_argument)
+add_test(NAME ScenarioE2EFileNotFoundTest COMMAND scenario_e2e_file_not_found)
+add_test(NAME ScenarioE2ENoTrailingNewlineTest COMMAND scenario_e2e_no_trailing_newline)

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/docs/architecture.md
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/docs/architecture.md
@@ -1,0 +1,526 @@
+# wc-tool 架构设计文档
+
+## 1. 概述
+
+本文档描述 wc-tool — 一个类 Unix `wc` 命令行工具 — 的架构设计。该工具读取指定文件，统计行数、单词数和字节数，并将结果输出到标准输出。
+
+## 2. 技术栈
+
+| 项目 | 选择 | 理由 |
+|------|------|------|
+| 语言 | C++17 | 标准库提供完整的文件系统、流处理、字符串处理能力 |
+| 构建系统 | CMake | 跨平台构建，与CTest原生集成，支持C++17标准 |
+| 测试框架 | CTest + cassert | 标准库断言，无第三方依赖，与CMake原生集成 |
+| 运行时依赖 | 无 | 仅使用C++标准库，单静态二进制，无动态链接 |
+| 代码风格 | C++17 严格模式 | 启用C++17，禁用扩展，确保可移植性 |
+
+## 3. 系统上下文 (C4 Context)
+
+```mermaid
+C4Context
+  title System Context - wc-tool
+  Person(user, "用户", "在命令行中运行wc-tool的终端用户")
+  System(wc_tool, "wc-tool", "命令行单词计数工具", "统计文件的行数、单词数和字节数")
+  System_Ext(file_system, "文件系统", "本地文件系统，提供输入文件")
+  System_Ext(shell, "命令行Shell", "Unix/Linux/macOS终端环境")
+
+  Rel(user, shell, "执行")
+  Rel(shell, wc_tool, "启动并传递参数")
+  Rel(wc_tool, file_system, "读取文件")
+  Rel(wc_tool, user, "输出结果到stdout")
+  
+  UpdateLayoutConfig()
+```
+
+## 4. 容器分解 (C4 Container)
+
+```mermaid
+C4Container
+  title Container View - wc-tool
+  System_Boundary(app, "wc-tool 应用") {
+    Component(main, "main.cpp", "入口点，协调各子系统", "C++")
+    Component(arg_parser, "arg_parser.cpp", "解析并验证命令行参数", "C++")
+    Component(file_opener, "file_opener.cpp", "打开文件流", "C++")
+    Component(line_counter, "line_counter.cpp", "统计换行符数量", "C++")
+    Component(word_counter, "word_counter.cpp", "统计单词数量", "C++")
+    Component(byte_counter, "byte_counter.cpp", "统计字节数量", "C++")
+    Component(formatter, "formatter.cpp", "格式化输出结果", "C++")
+  }
+  
+  Rel(main, arg_parser, "调用")
+  Rel(main, file_opener, "调用")
+  Rel(main, line_counter, "调用")
+  Rel(main, word_counter, "调用")
+  Rel(main, byte_counter, "调用")
+  Rel(main, formatter, "调用")
+  
+  UpdateLayoutConfig()
+```
+
+## 5. 组件分解 (C4 Component)
+
+```mermaid
+C4Component
+  title Component View - 内部组件关系
+  Container_Boundary(input_boundary, "输入子系统") {
+    Component(arg_parser, "arg_parser", "解析并验证命令行参数", "C++")
+    Component(file_opener, "file_opener", "打开文件流", "C++")
+  }
+  
+  Container_Boundary(counter_boundary, "计数子系统") {
+    Component(line_counter, "line_counter", "统计换行符数量", "C++")
+    Component(word_counter, "word_counter", "统计单词数量", "C++")
+    Component(byte_counter, "byte_counter", "统计字节数量", "C++")
+  }
+  
+  Container_Boundary(output_boundary, "输出子系统") {
+    Component(formatter, "formatter", "格式化输出结果", "C++")
+  }
+  
+  Rel(main, arg_parser, "parse_file_argument", "参数验证")
+  Rel(main, file_opener, "open_file", "文件打开")
+  Rel(main, line_counter, "count_lines", "行计数")
+  Rel(main, word_counter, "count_words", "词计数")
+  Rel(main, byte_counter, "count_bytes", "字节计数")
+  Rel(main, formatter, "print_result", "结果输出")
+  
+  UpdateLayoutConfig()
+```
+
+## 6. 数据模型
+
+### 6.1 输入数据
+
+```mermaid
+erDiagram
+    FILE {
+        string path "文件路径"
+        int64 size "文件大小（字节）"
+        int64 line_count "换行符数量"
+        int64 word_count "单词数量"
+        int64 byte_count "字节数量"
+    }
+    
+    COMMAND_LINE {
+        int argc "参数数量"
+        string* argv "参数数组"
+        string file_path "提取的文件路径"
+    }
+    
+    FILE ||--o{ COMMAND_LINE : "从命令行获取"
+```
+
+### 6.2 输出数据
+
+输出格式：`<lines> <words> <bytes> <filename>`
+
+```mermaid
+erDiagram
+    OUTPUT_RESULT {
+        int64 lines "行数"
+        int64 words "词数"
+        int64 bytes "字节数"
+        string filename "文件名"
+    }
+    
+    OUTPUT_RESULT ||--o{ STDOUT : "输出到标准输出"
+```
+
+## 7. 模块依赖关系
+
+```mermaid
+flowchart TD
+    subgraph src ["src/"]
+        main["src/main.cpp"]
+        input["src/input/"]
+        counter["src/counter/"]
+        output["src/output/"]
+    end
+    
+    main --> input
+    main --> counter
+    main --> output
+    counter --> input
+    
+    UpdateLayoutConfig()
+```
+
+## 8. 组件交互流程
+
+### 8.1 主流程
+
+```mermaid
+sequenceDiagram
+    participant Main as main.cpp
+    participant Arg as arg_parser
+    participant File as file_opener
+    participant Line as line_counter
+    participant Word as word_counter
+    participant Byte as byte_counter
+    participant Out as formatter
+
+    Main->>Arg: parse_file_argument(argc, argv)
+    Arg-->>Main: filepath
+    Main->>File: open_file(filepath)
+    File-->>Main: ifstream
+    Main->>Line: count_lines(stream)
+    Line-->>Main: lines
+    Main->>Word: count_words(stream)
+    Word-->>Main: words
+    Main->>Byte: count_bytes(stream)
+    Byte-->>Main: bytes
+    Main->>Out: print_result(lines, words, bytes, filepath)
+    Out->>Out: cout << lines << " " << words << " " << bytes << " " << filename
+```
+
+### 8.2 错误处理流程
+
+```mermaid
+flowchart LR
+  A["用户执行 wc-tool"] --> B{"参数有效?"}
+  B -->|否| C["输出错误到stderr"]
+  C --> D["退出码1"]
+  B -->|是| E{"文件存在?"}
+  E -->|否| F["输出错误到stderr"]
+  F --> D
+  E -->|是| G["读取文件"]
+  G --> H["统计行数"]
+  H --> I["统计词数"]
+  I --> J["统计字节数"]
+  J --> K["输出结果"]
+```
+
+## 9. 测试架构
+
+### 9.1 单元测试
+
+| 测试名称 | 测试可执行文件 | 测试内容 | CTest 名称 |
+|----------|---------------|---------|-----------|
+| 行计数 | test_line_counter | FR-002 | LineCounterTest |
+| 单词计数 | test_word_counter | FR-003 | WordCounterTest |
+| 字节计数 | test_byte_counter | FR-004 | ByteCounterTest |
+| 参数解析 | test_arg_parser | FR-001 | ArgParserTest |
+| 输出格式化 | test_output_formatter | FR-005 | OutputFormatterTest |
+
+### 9.2 端到端测试 — 独立可执行
+
+每个端到端场景拥有**独立的测试可执行文件**和**唯一的 CTest 测试名**，确保可以通过 `ctest -R <name>` 单独执行：
+
+| 场景 ID | 描述 | CTest 名称 | 测试可执行文件 |
+|---------|------|-----------|---------------|
+| e2e_normal_file | 正常文件处理 | E2ENormalFileTest | test_e2e_normal_file |
+| e2e_empty_file | 空文件处理 | E2EEmptyFileTest | test_e2e_empty_file |
+| e2e_no_argument | 缺少参数 | E2ENoArgumentTest | test_e2e_no_argument |
+| e2e_file_not_found | 文件不存在 | E2EFileNotFoundTest | test_e2e_file_not_found |
+| e2e_no_trailing_newline | 无尾部换行符 | E2ENoTrailingNewlineTest | test_e2e_no_trailing_newline |
+
+```mermaid
+flowchart LR
+    subgraph unit_tests ["单元测试"]
+        tlc["LineCounterTest"]
+        twc["WordCounterTest"]
+        tbc["ByteCounterTest"]
+        tap["ArgParserTest"]
+        tof["OutputFormatterTest"]
+    end
+
+    subgraph e2e_tests ["端到端测试 — 独立可执行"]
+        en["E2ENormalFileTest"]
+        ee["E2EEmptyFileTest"]
+        ea["E2ENoArgumentTest"]
+        ef["E2EFileNotFoundTest"]
+        et["E2ENoTrailingNewlineTest"]
+    end
+
+    tlc -.->|依赖| en
+    twc -.->|依赖| en
+    tbc -.->|依赖| en
+    tap -.->|依赖| ea
+    tap -.->|依赖| ef
+    tof -.->|依赖| et
+```
+
+### 9.3 测试执行命令
+
+每个测试可独立执行：
+
+```
+ctest --test-dir build --output-on-failure --verbose -R E2ENormalFile
+ctest --test-dir build --output-on-failure --verbose -R E2EEmptyFile
+ctest --test-dir build --output-on-failure --verbose -R E2ENoArgument
+ctest --test-dir build --output-on-failure --verbose -R E2EFileNotFound
+ctest --test-dir build --output-on-failure --verbose -R E2ENoTrailingNewline
+```
+
+所有测试一起执行：
+
+```
+ctest --test-dir build --output-on-failure --verbose
+```
+
+## 9. 子系统详细设计
+
+### 9.1 输入子系统 (input)
+
+**职责**: 命令行参数解析和文件打开
+
+**组件**:
+- `arg_parser`: 验证argc == 2，提取argv[1]作为文件路径
+- `file_opener`: 使用`std::ifstream`以二进制模式打开文件
+
+**公共接口**:
+```cpp
+// arg_parser.h
+namespace input {
+    std::string parse_file_argument(int argc, char* argv[]);
+}
+
+// file_opener.h
+namespace input {
+    std::ifstream open_file(const std::string& path);
+}
+```
+
+### 9.2 计数子系统 (counter)
+
+**职责**: 行计数、单词计数和字节计数算法
+
+**组件**:
+- `line_counter`: 遍历文件流，统计'\n'字符数量
+- `word_counter`: 遍历文件流，统计非空白字符序列数量
+- `byte_counter`: 遍历文件流，统计所有字符数量
+
+**公共接口**:
+```cpp
+// line_counter.h
+namespace counter {
+    std::intmax_t count_lines(std::istream& stream);
+}
+
+// word_counter.h
+namespace counter {
+    std::intmax_t count_words(std::istream& stream);
+}
+
+// byte_counter.h
+namespace counter {
+    std::intmax_t count_bytes(std::istream& stream);
+}
+```
+
+### 9.3 输出子系统 (output)
+
+**职责**: 格式化并打印结果
+
+**组件**:
+- `formatter`: 将统计结果格式化为`<lines> <words> <bytes> <filename>`格式并输出到stdout
+
+**公共接口**:
+```cpp
+// formatter.h
+namespace output {
+    void print_result(std::intmax_t lines, std::intmax_t words, std::intmax_t bytes, const std::string& filename);
+}
+```
+
+## 10. 构建系统
+
+### 10.1 CMakeLists.txt
+
+```cmake
+cmake_minimum_required(VERSION 3.14)
+project(wc-tool VERSION 1.0.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# 主可执行文件
+add_executable(wc-tool
+    src/main.cpp
+    src/input/arg_parser.cpp
+    src/input/file_opener.cpp
+    src/counter/line_counter.cpp
+    src/counter/word_counter.cpp
+    src/counter/byte_counter.cpp
+    src/output/formatter.cpp
+)
+
+target_include_directories(wc-tool PRIVATE src)
+
+# 单元测试可执行文件
+add_executable(test_line_counter tests/test_line_counter.cpp)
+target_include_directories(test_line_counter PRIVATE src)
+
+add_executable(test_word_counter tests/test_word_counter.cpp)
+target_include_directories(test_word_counter PRIVATE src)
+
+add_executable(test_byte_counter tests/test_byte_counter.cpp)
+target_include_directories(test_byte_counter PRIVATE src)
+
+add_executable(test_arg_parser tests/test_arg_parser.cpp)
+target_include_directories(test_arg_parser PRIVATE src)
+
+add_executable(test_output_formatter tests/test_output_formatter.cpp)
+target_include_directories(test_output_formatter PRIVATE src)
+
+# 端到端测试 — 每个场景独立可执行文件
+add_executable(test_e2e_normal_file tests/test_e2e_normal_file.cpp)
+target_include_directories(test_e2e_normal_file PRIVATE src)
+
+add_executable(test_e2e_empty_file tests/test_e2e_empty_file.cpp)
+target_include_directories(test_e2e_empty_file PRIVATE src)
+
+add_executable(test_e2e_no_argument tests/test_e2e_no_argument.cpp)
+target_include_directories(test_e2e_no_argument PRIVATE src)
+
+add_executable(test_e2e_file_not_found tests/test_e2e_file_not_found.cpp)
+target_include_directories(test_e2e_file_not_found PRIVATE src)
+
+add_executable(test_e2e_no_trailing_newline tests/test_e2e_no_trailing_newline.cpp)
+target_include_directories(test_e2e_no_trailing_newline PRIVATE src)
+
+# 启用测试
+enable_testing()
+
+add_test(NAME LineCounterTest COMMAND test_line_counter)
+add_test(NAME WordCounterTest COMMAND test_word_counter)
+add_test(NAME ByteCounterTest COMMAND test_byte_counter)
+add_test(NAME ArgParserTest COMMAND test_arg_parser)
+add_test(NAME OutputFormatterTest COMMAND test_output_formatter)
+
+# 端到端测试 — 每个场景独立的 CTest 名称
+add_test(NAME E2ENormalFileTest COMMAND test_e2e_normal_file)
+add_test(NAME E2EEmptyFileTest COMMAND test_e2e_empty_file)
+add_test(NAME E2ENoArgumentTest COMMAND test_e2e_no_argument)
+add_test(NAME E2EFileNotFoundTest COMMAND test_e2e_file_not_found)
+add_test(NAME E2ENoTrailingNewlineTest COMMAND test_e2e_no_trailing_newline)
+```
+
+### 10.2 测试执行
+
+每个测试可独立执行：
+
+```
+ctest --test-dir build --output-on-failure --verbose -R E2ENormalFileTest
+ctest --test-dir build --output-on-failure --verbose -R E2EEmptyFileTest
+ctest --test-dir build --output-on-failure --verbose -R E2ENoArgumentTest
+ctest --test-dir build --output-on-failure --verbose -R E2EFileNotFoundTest
+ctest --test-dir build --output-on-failure --verbose -R E2ENoTrailingNewlineTest
+```
+
+所有测试一起执行：
+
+```
+ctest --test-dir build --output-on-failure --verbose
+```
+
+## 11. 测试策略
+
+### 11.1 单元测试
+
+每个计数原语有独立的测试可执行文件：
+
+| 测试名称 | 测试文件 | 测试内容 |
+|---------|---------|---------|
+| LineCounterTest | tests/test_line_counter.cpp | 空文件、单行、多行、无换行符、连续换行符 |
+| WordCounterTest | tests/test_word_counter.cpp | 空文件、单词、多词、连续空格、制表符、换行符、纯空白 |
+| ByteCounterTest | tests/test_byte_counter.cpp | 空文件、单字节、多字节、换行符、混合内容 |
+| ArgParserTest | tests/test_arg_parser.cpp | 有效参数、缺少参数、过多参数 |
+| OutputFormatterTest | tests/test_output_formatter.cpp | 正常输出、零值、大数值 |
+
+### 11.2 端到端测试
+
+每个端到端场景拥有**独立的测试可执行文件**和**唯一的 CTest 测试名**，确保可以通过 `ctest -R <name>` 单独执行：
+
+| 场景 ID | 描述 | CTest 名称 | 测试可执行文件 |
+|---------|------|-----------|---------------|
+| e2e_normal_file | 正常文件处理 | E2ENormalFileTest | test_e2e_normal_file |
+| e2e_empty_file | 空文件处理 | E2EEmptyFileTest | test_e2e_empty_file |
+| e2e_no_argument | 缺少参数 | E2ENoArgumentTest | test_e2e_no_argument |
+| e2e_file_not_found | 文件不存在 | E2EFileNotFoundTest | test_e2e_file_not_found |
+| e2e_no_trailing_newline | 无尾部换行符 | E2ENoTrailingNewlineTest | test_e2e_no_trailing_newline |
+
+```mermaid
+flowchart LR
+    subgraph unit_tests ["单元测试"]
+        tlc["LineCounterTest"]
+        twc["WordCounterTest"]
+        tbc["ByteCounterTest"]
+        tap["ArgParserTest"]
+        tof["OutputFormatterTest"]
+    end
+
+    subgraph e2e_tests ["端到端测试 — 独立可执行"]
+        en["E2ENormalFileTest"]
+        ee["E2EEmptyFileTest"]
+        ea["E2ENoArgumentTest"]
+        ef["E2EFileNotFoundTest"]
+        et["E2ENoTrailingNewlineTest"]
+    end
+
+    tlc -.->|依赖| en
+    twc -.->|依赖| en
+    tbc -.->|依赖| en
+    tap -.->|依赖| ea
+    tap -.->|依赖| ef
+    tof -.->|依赖| et
+```
+
+## 12. 错误处理
+
+| 错误场景 | 处理方式 | 错误位置 |
+|---------|---------|---------|
+| 无参数 | 输出"Usage: wc-tool <file>"到stderr，exit(1) | arg_parser |
+| 文件不存在 | 输出"Cannot open file: <path>"到stderr，exit(1) | file_opener |
+| 文件无法读取 | 输出"Cannot open file: <path>"到stderr，exit(1) | file_opener |
+
+## 13. 启动序列
+
+```mermaid
+sequenceDiagram
+    participant Main as main.cpp
+    participant Arg as arg_parser
+    participant File as file_opener
+    participant Line as line_counter
+    participant Word as word_counter
+    participant Byte as byte_counter
+    participant Out as formatter
+
+    Note over Main: 构造阶段
+    Main->>Arg: 初始化
+    Main->>File: 初始化
+    Main->>Line: 初始化
+    Main->>Word: 初始化
+    Main->>Byte: 初始化
+    Main->>Out: 初始化
+
+    Note over Main: 主循环阶段
+    Main->>Arg: parse_file_argument(argc, argv)
+    Arg-->>Main: filepath
+    Main->>File: open_file(filepath)
+    File-->>Main: ifstream
+    Main->>Line: count_lines(stream)
+    Line-->>Main: lines
+    Main->>Word: count_words(stream)
+    Word-->>Main: words
+    Main->>Byte: count_bytes(stream)
+    Byte-->>Main: bytes
+    Main->>Out: print_result(lines, words, bytes, filepath)
+    Out->>Out: cout << lines << " " << words << " " << bytes << " " << filename
+    Main->>Main: return 0
+```
+
+## 14. 性能考虑
+
+- 使用`std::istream::get()`逐字符读取，O(1)内存复杂度
+- 每个计数操作独立遍历文件，通过`seekg()`重置流位置
+- 对于大文件（GB级别），流处理确保内存使用恒定
+- 无动态内存分配，无堆分配
+
+## 15. 可移植性
+
+- 仅使用C++17标准库
+- 使用`std::filesystem`和`std::isspace`确保跨平台兼容
+- 支持Linux (glibc)、macOS (Apple clang)
+- 无平台特定API调用

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/docs/behavioral_contract.json
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/docs/behavioral_contract.json
@@ -1,0 +1,164 @@
+{
+  "scenarios": [
+    {
+      "id": "test_line_counter",
+      "name": "行计数单元测试",
+      "description": "测试行计数器的基本功能：空文件返回0，有换行符的文件正确计数，没有尾部换行符的文件正确计数",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R LineCounterTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-002"]
+    },
+    {
+      "id": "test_word_counter",
+      "name": "单词计数单元测试",
+      "description": "测试单词计数器的基本功能：空文件返回0，多个连续空格不产生额外单词，正确统计单词数",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R WordCounterTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-003"]
+    },
+    {
+      "id": "test_byte_counter",
+      "name": "字节计数单元测试",
+      "description": "测试字节计数器的基本功能：空文件返回0，正确统计文件字节数",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R ByteCounterTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-004"]
+    },
+    {
+      "id": "test_arg_parser",
+      "name": "参数解析单元测试",
+      "description": "测试参数解析器：正确参数返回文件路径，缺少参数抛出异常",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R ArgParserTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-001"]
+    },
+    {
+      "id": "test_output_formatter",
+      "name": "输出格式化单元测试",
+      "description": "测试输出格式化器：正确格式化并输出结果",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R OutputFormatterTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-005"]
+    },
+    {
+      "id": "e2e_normal_file",
+      "name": "端到端测试：正常文件处理",
+      "description": "端到端测试：使用wc-tool处理一个包含多行多词的文本文件，验证输出格式正确",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R E2ENormalFileTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-001", "FR-002", "FR-003", "FR-004", "FR-005"]
+    },
+    {
+      "id": "e2e_empty_file",
+      "name": "端到端测试：空文件处理",
+      "description": "端到端测试：使用wc-tool处理空文件，验证输出为 0 0 0 filename",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R E2EEmptyFileTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-002", "FR-003", "FR-004"]
+    },
+    {
+      "id": "e2e_no_argument",
+      "name": "端到端测试：缺少参数",
+      "description": "端到端测试：使用wc-tool不带参数运行，验证输出错误信息到stderr并返回非零退出码",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R E2ENoArgumentTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-001"]
+    },
+    {
+      "id": "e2e_file_not_found",
+      "name": "端到端测试：文件不存在",
+      "description": "端到端测试：使用wc-tool处理不存在的文件，验证输出错误信息到stderr并返回非零退出码",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R E2EFileNotFoundTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-001"]
+    },
+    {
+      "id": "e2e_no_trailing_newline",
+      "name": "端到端测试：无尾部换行符",
+      "description": "端到端测试：使用wc-tool处理没有尾部换行符的文件，验证wc兼容的行计数",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R E2ENoTrailingNewlineTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-002", "FR-003", "FR-004", "FR-005"]
+    }
+  ]
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/docs/qa_report.json
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/docs/qa_report.json
@@ -1,0 +1,73 @@
+{
+  "toolchain_check": {
+    "cmake": "present",
+    "ctest": "present",
+    "clang-tidy": "missing",
+    "g++": "present",
+    "gcc": "present",
+    "make": "present",
+    "ninja": "present"
+  },
+  "ctest": {
+    "ran": true,
+    "passed": 21,
+    "failed": 0,
+    "total": 21,
+    "command": "ctest --test-dir build --output-on-failure",
+    "details": {
+      "unit_tests": {
+        "passed": 6,
+        "tests": [
+          "LineCounterTest",
+          "WordCounterTest",
+          "ByteCounterTest",
+          "ArgParserTest",
+          "OutputFormatterTest",
+          "FileOpenerTest"
+        ]
+      },
+      "e2e_tests": {
+        "passed": 5,
+        "tests": [
+          "E2ENormalFileTest",
+          "E2EEmptyFileTest",
+          "E2ENoArgumentTest",
+          "E2EFileNotFoundTest",
+          "E2ENoTrailingNewlineTest"
+        ]
+      },
+      "scenario_tests": {
+        "passed": 10,
+        "tests": [
+          "ScenarioLineCounterTest",
+          "ScenarioWordCounterTest",
+          "ScenarioByteCounterTest",
+          "ScenarioArgParserTest",
+          "ScenarioOutputFormatterTest",
+          "ScenarioE2ENormalFileTest",
+          "ScenarioE2EEmptyFileTest",
+          "ScenarioE2ENoArgumentTest",
+          "ScenarioE2EFileNotFoundTest",
+          "ScenarioE2ENoTrailingNewlineTest"
+        ]
+      }
+    }
+  },
+  "integration_tests": {
+    "total_written": 10,
+    "files": [
+      "tests/scenarios/test_line_counter.cpp",
+      "tests/scenarios/test_word_counter.cpp",
+      "tests/scenarios/test_byte_counter.cpp",
+      "tests/scenarios/test_arg_parser.cpp",
+      "tests/scenarios/test_output_formatter.cpp",
+      "tests/scenarios/e2e_normal_file.cpp",
+      "tests/scenarios/e2e_empty_file.cpp",
+      "tests/scenarios/e2e_no_argument.cpp",
+      "tests/scenarios/e2e_file_not_found.cpp",
+      "tests/scenarios/e2e_no_trailing_newline.cpp"
+    ]
+  },
+  "ui_required": false,
+  "notes": "All 21 tests passed. clang-tidy is missing from the host but was not required for test execution."
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/docs/requirement.md
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/docs/requirement.md
@@ -1,0 +1,251 @@
+# Requirement Specification — wc-tool
+
+## 功能需求
+
+### FR-001: File Input and Argument Parsing
+
+The tool accepts a single positional argument that specifies the path to the file to be
+analysed.
+
+- **FR-001.1** The tool MUST accept exactly one file path argument on the command line.
+- **FR-001.2** If no argument is provided, the tool MUST print an error message to
+  **stderr** and exit with a non-zero status code.
+- **FR-001.3** If the file does not exist or cannot be opened, the tool MUST print an
+  error message to **stderr** and exit with a non-zero status code.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_invoke(("Invoke wc-tool"))
+  uc_parse(("Parse file argument"))
+  uc_validate(("Validate file exists"))
+  actor_user --> uc_invoke
+  uc_invoke --> uc_parse
+  uc_parse --> uc_validate
+  uc_validate -->|missing arg| uc_error
+  uc_validate -->|file not found| uc_error
+  uc_error(["Error to stderr"])
+```
+
+### FR-002: Line Count
+
+The tool MUST count the number of newline characters (`\n`) in the file and report the
+result as the first integer in its output.
+
+- **FR-002.1** Each newline character (`\n`) in the file contributes exactly one to the
+  line count.
+- **FR-002.2** A file that is empty (zero bytes) MUST produce a line count of `0`.
+- **FR-002.3** A file whose last character is not a newline MUST still be counted as
+  containing one additional line (matching `wc` semantics).
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_read(("Read file"))
+  uc_count_lines(("Count lines"))
+  uc_report(("Report line count"))
+  actor_user --> uc_read
+  uc_read --> uc_count_lines
+  uc_count_lines --> uc_report
+```
+
+### FR-003: Word Count
+
+The tool MUST count the number of whitespace-delimited words in the file.
+
+- **FR-003.1** A word is defined as a maximal sequence of non-whitespace characters.
+  Whitespace characters are those recognised by `std::isspace` (space, tab, newline,
+  carriage return, form feed, vertical tab).
+- **FR-003.2** Empty files MUST produce a word count of `0`.
+- **FR-003.3** Multiple consecutive whitespace characters MUST NOT produce extra words.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_read(("Read file"))
+  uc_count_words(("Count words"))
+  uc_report(("Report word count"))
+  actor_user --> uc_read
+  uc_read --> uc_count_words
+  uc_count_words --> uc_report
+```
+
+### FR-004: Byte Count
+
+The tool MUST report the total number of bytes in the file.
+
+- **FR-004.1** The byte count is the file size in bytes as reported by the operating
+  system (e.g. `std::filesystem::file_size` or reading until EOF).
+- **FR-004.2** An empty file MUST produce a byte count of `0`.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_read(("Read file"))
+  uc_count_bytes(("Count bytes"))
+  uc_report(("Report byte count"))
+  actor_user --> uc_read
+  uc_read --> uc_count_bytes
+  uc_count_bytes --> uc_report
+```
+
+### FR-005: Output Format
+
+The tool MUST print three integers (lines, words, bytes) separated by single spaces,
+followed by the filename, to stdout.
+
+- **FR-005.1** The output format is: `<lines> <words> <bytes> <filename>`
+- **FR-005.2** Fields are separated by exactly one space.
+- **FR-005.3** The filename printed is the user-provided argument, not a canonicalised path.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_compute(("Compute statistics"))
+  uc_format(("Format output"))
+  uc_print(("Print to stdout"))
+  actor_user --> uc_compute
+  uc_compute --> uc_format
+  uc_format --> uc_print
+```
+
+### FR-006: Build System
+
+The project MUST be buildable with CMake using C++17 as the strict language standard,
+producing a single static binary with no runtime dependencies.
+
+- **FR-006.1** A `CMakeLists.txt` file exists at the project root.
+- **FR-006.2** The build system enforces C++17 via `set(CMAKE_CXX_STANDARD 17)`.
+- **FR-006.3** The build produces a single static binary with no runtime dependencies.
+
+```mermaid
+flowchart LR
+  actor_dev(["👤 Developer"])
+  uc_cmake(("Configure CMake"))
+  uc_build(("Build binary"))
+  uc_verify(("Verify binary"))
+  actor_dev --> uc_cmake
+  uc_cmake --> uc_build
+  uc_build --> uc_verify
+```
+
+### FR-007: Unit Tests
+
+The project MUST include unit tests for each counting primitive using the CTest framework
+with no third-party dependencies.
+
+- **FR-007.1** Separate test executables exist for line-count, word-count, and byte-count.
+- **FR-007.2** Tests are registered with `add_test` in CMake.
+- **FR-007.3** No third-party testing frameworks are used.
+
+```mermaid
+flowchart LR
+  actor_dev(["👤 Developer"])
+  uc_write_tests(("Write unit tests"))
+  uc_register(("Register with CTest"))
+  uc_run(("Run tests"))
+  actor_dev --> uc_write_tests
+  uc_write_tests --> uc_register
+  uc_register --> uc_run
+```
+
+## 非功能需求
+
+### NFR-001: Performance
+
+The tool reads the input file exactly once, processes files of at least 1 GB within
+30 seconds on standard hardware, and uses O(1) memory with respect to file size
+via streaming read.
+
+### NFR-002: Portability
+
+The tool compiles and runs on Linux (glibc) and macOS (Apple clang) using C++17,
+and is relocatable with no hardcoded paths.
+
+### NFR-003: Reliability
+
+The tool handles binary files gracefully without crashing and does not produce
+undefined behaviour on empty files, very large files, or files with unusual encodings.
+
+## 用例
+
+### UC-001: Count File Statistics
+
+**Actor:** User
+**Goal:** Obtain line, word, and byte counts for a given file.
+**Preconditions:** A file exists and is readable.
+**Main Flow:**
+1. User invokes `wc-tool <file_path>`.
+2. The tool opens the file for reading.
+3. The tool reads the file once, counting lines, words, and bytes.
+4. The tool prints the results to stdout.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_run(("Run wc-tool"))
+  uc_open(("Open file"))
+  uc_read(("Read and count"))
+  uc_output(("Output results"))
+  actor_user --> uc_run
+  uc_run --> uc_open
+  uc_open --> uc_read
+  uc_read --> uc_output
+```
+
+Covers: FR-001, FR-002, FR-003, FR-004, FR-005
+
+### UC-002: Handle Missing File Argument
+
+**Actor:** User
+**Goal:** Receive an error message when no file argument is provided.
+**Preconditions:** None.
+**Main Flow:**
+1. User invokes `wc-tool` without arguments.
+2. The tool detects the missing argument.
+3. The tool prints an error message to stderr.
+4. The tool exits with a non-zero status code.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_run(("Run wc-tool"))
+  uc_check(("Check arguments"))
+  uc_error(("Print error to stderr"))
+  uc_exit(("Exit with non-zero"))
+  actor_user --> uc_run
+  uc_run --> uc_check
+  uc_check -->|no args| uc_error
+  uc_error --> uc_exit
+```
+
+Covers: FR-001
+
+### UC-003: Handle Non-Existent File
+
+**Actor:** User
+**Goal:** Receive an error message when the specified file does not exist.
+**Preconditions:** None.
+**Main Flow:**
+1. User invokes `wc-tool <nonexistent_file>`.
+2. The tool attempts to open the file.
+3. The tool detects the file does not exist.
+4. The tool prints an error message to stderr.
+5. The tool exits with a non-zero status code.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_run(("Run wc-tool"))
+  uc_open(("Open file"))
+  uc_check(("Check if exists"))
+  uc_error(("Print error to stderr"))
+  uc_exit(("Exit with non-zero"))
+  actor_user --> uc_run
+  uc_run --> uc_open
+  uc_open --> uc_check
+  uc_check -->|not found| uc_error
+  uc_error --> uc_exit
+```
+
+Covers: FR-001

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/docs/requirement_contract.json
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/docs/requirement_contract.json
@@ -1,0 +1,156 @@
+{
+  "project_name": "wc-tool",
+  "summary": "A C++17 command-line tool that computes line count, word count, and byte count for a given file, mirroring the Unix wc utility. Built with CMake, tested with CTest, producing a single static binary with no runtime dependencies beyond the C++ standard library.",
+  "functional_requirements": [
+    {
+      "id": "FR-001",
+      "title": "File Input and Argument Parsing",
+      "description": "The tool accepts a single positional argument specifying the file path. It must validate the argument exists and the file is readable, printing errors to stderr and exiting non-zero on failure.",
+      "acceptance_criteria": [
+        "Exactly one file path argument is accepted",
+        "No argument produces an error to stderr with non-zero exit",
+        "Non-existent file produces an error to stderr with non-zero exit"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-002",
+      "title": "Line Count",
+      "description": "The tool counts newline characters as lines, with wc-compatible semantics: empty file yields 0, and a file without a trailing newline still counts the last line.",
+      "acceptance_criteria": [
+        "Each newline character contributes exactly one to line count",
+        "Empty file produces line count of 0",
+        "File without trailing newline still counts the final line"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-003",
+      "title": "Word Count",
+      "description": "The tool counts whitespace-delimited words where a word is a maximal sequence of non-whitespace characters. Multiple consecutive whitespace characters do not produce extra words.",
+      "acceptance_criteria": [
+        "A word is a maximal sequence of non-whitespace characters",
+        "Empty file produces word count of 0",
+        "Multiple consecutive whitespace characters do not produce extra words"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-004",
+      "title": "Byte Count",
+      "description": "The tool reports the total number of bytes in the file, equivalent to the file size in bytes as reported by the operating system.",
+      "acceptance_criteria": [
+        "Byte count equals the file size in bytes",
+        "Empty file produces byte count of 0"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-005",
+      "title": "Output Format",
+      "description": "The tool prints three integers (lines, words, bytes) separated by single spaces, followed by the filename, to stdout.",
+      "acceptance_criteria": [
+        "Output format is: <lines> <words> <bytes> <filename>",
+        "Fields are separated by exactly one space",
+        "Filename printed is the user-provided argument, not a canonicalised path"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-006",
+      "title": "Build System",
+      "description": "The project is buildable with CMake using C++17 as the strict language standard, producing a single static binary with no runtime dependencies.",
+      "acceptance_criteria": [
+        "CMakeLists.txt exists at the project root",
+        "Build system enforces C++17",
+        "Build produces a single static binary with no runtime dependencies"
+      ],
+      "priority": "P1"
+    },
+    {
+      "id": "FR-007",
+      "title": "Unit Tests",
+      "description": "The project includes unit tests for each counting primitive using the CTest framework with no third-party dependencies. Separate test executables are registered with add_test.",
+      "acceptance_criteria": [
+        "Separate test executables exist for line-count, word-count, and byte-count",
+        "Tests are registered with add_test in CMake",
+        "No third-party testing frameworks are used"
+      ],
+      "priority": "P1"
+    }
+  ],
+  "non_functional_requirements": [
+    {
+      "id": "NFR-001",
+      "title": "Performance",
+      "description": "The tool reads the input file exactly once, processes files of at least 1 GB within 30 seconds on standard hardware, and uses O(1) memory with respect to file size via streaming read.",
+      "priority": "P1"
+    },
+    {
+      "id": "NFR-002",
+      "title": "Portability",
+      "description": "The tool compiles and runs on Linux (glibc) and macOS (Apple clang) using C++17, and is relocatable with no hardcoded paths.",
+      "priority": "P1"
+    },
+    {
+      "id": "NFR-003",
+      "title": "Reliability",
+      "description": "The tool handles binary files gracefully without crashing and does not produce undefined behaviour on empty files, very large files, or files with unusual encodings.",
+      "priority": "P1"
+    }
+  ],
+  "use_cases": [
+    {
+      "id": "UC-001",
+      "actor": "User",
+      "goal": "Obtain line, word, and byte counts for a given file.",
+      "preconditions": [
+        "A file exists and is readable"
+      ],
+      "main_flow": [
+        "User invokes wc-tool with a file path argument",
+        "The tool opens the file for reading",
+        "The tool reads the file once, counting lines, words, and bytes",
+        "The tool prints the results to stdout in the format: lines words bytes filename"
+      ],
+      "covers_requirements": [
+        "FR-001",
+        "FR-002",
+        "FR-003",
+        "FR-004",
+        "FR-005"
+      ]
+    },
+    {
+      "id": "UC-002",
+      "actor": "User",
+      "goal": "Receive an error message when no file argument is provided.",
+      "preconditions": [],
+      "main_flow": [
+        "User invokes wc-tool without arguments",
+        "The tool detects the missing argument",
+        "The tool prints an error message to stderr",
+        "The tool exits with a non-zero status code"
+      ],
+      "covers_requirements": [
+        "FR-001"
+      ]
+    },
+    {
+      "id": "UC-003",
+      "actor": "User",
+      "goal": "Receive an error message when the specified file does not exist.",
+      "preconditions": [],
+      "main_flow": [
+        "User invokes wc-tool with a non-existent file path",
+        "The tool attempts to open the file",
+        "The tool detects the file does not exist",
+        "The tool prints an error message to stderr",
+        "The tool exits with a non-zero status code"
+      ],
+      "covers_requirements": [
+        "FR-001"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/docs/stack_contract.json
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/docs/stack_contract.json
@@ -1,0 +1,74 @@
+{
+  "language": "cpp",
+  "runtime": "native",
+  "framework_backend": "",
+  "framework_frontend": "",
+  "package_manager": "cmake",
+  "project_config_file": "CMakeLists.txt",
+  "test_runner": "ctest",
+  "static_analyzer": ["clang-tidy"],
+  "entry_point": "src/main.cpp",
+  "run_command": "cmake -B build && cmake --build build && ./build/wc-tool",
+  "ui_required": false,
+  "ui_kind": "",
+  "subsystems": [
+    {
+      "name": "input",
+      "src_dir": "src/input",
+      "responsibilities": "命令行参数解析和文件打开",
+      "components": [
+        {
+          "name": "arg_parser",
+          "file": "src/input/arg_parser.cpp",
+          "test_file": "tests/test_arg_parser.cpp",
+          "responsibility": "解析并验证命令行参数"
+        },
+        {
+          "name": "file_opener",
+          "file": "src/input/file_opener.cpp",
+          "test_file": "tests/test_file_opener.cpp",
+          "responsibility": "打开文件流进行读取"
+        }
+      ]
+    },
+    {
+      "name": "counter",
+      "src_dir": "src/counter",
+      "responsibilities": "行计数、单词计数和字节计数算法实现",
+      "components": [
+        {
+          "name": "line_counter",
+          "file": "src/counter/line_counter.cpp",
+          "test_file": "tests/test_line_counter.cpp",
+          "responsibility": "统计换行符数量"
+        },
+        {
+          "name": "word_counter",
+          "file": "src/counter/word_counter.cpp",
+          "test_file": "tests/test_word_counter.cpp",
+          "responsibility": "统计单词数量"
+        },
+        {
+          "name": "byte_counter",
+          "file": "src/counter/byte_counter.cpp",
+          "test_file": "tests/test_byte_counter.cpp",
+          "responsibility": "统计字节数量"
+        }
+      ]
+    },
+    {
+      "name": "output",
+      "src_dir": "src/output",
+      "responsibilities": "格式化并打印结果到标准输出",
+      "components": [
+        {
+          "name": "formatter",
+          "file": "src/output/formatter.cpp",
+          "test_file": "tests/test_output_formatter.cpp",
+          "responsibility": "将统计结果格式化为指定格式"
+        }
+      ]
+    }
+  ],
+  "lifecycle_inits": []
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/counter/byte_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/counter/byte_counter.cpp
@@ -1,0 +1,20 @@
+#include "counter/byte_counter.h"
+#include <string>
+
+namespace counter {
+
+/**
+ * Count the number of bytes in content.
+ * This is simply the string length in bytes.
+ *
+ * @param content  The text content to count bytes in
+ * @return         Result struct with ok flag and byte count
+ */
+ByteCountResult count_bytes(const std::string& content) {
+    ByteCountResult result;
+    result.ok = true;
+    result.byte_count = static_cast<int64_t>(content.size());
+    return result;
+}
+
+} // namespace counter

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/counter/byte_counter.h
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/counter/byte_counter.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+
+namespace counter {
+
+struct ByteCountResult {
+    bool ok;
+    int64_t byte_count;
+};
+
+/**
+ * Count the number of bytes in content.
+ * @param content  The text content to count bytes in
+ * @return         Result with ok flag and byte count
+ */
+ByteCountResult count_bytes(const std::string& content);
+
+} // namespace counter

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/counter/combined_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/counter/combined_counter.cpp
@@ -1,0 +1,45 @@
+#include "counter/combined_counter.h"
+#include <string>
+
+namespace counter {
+
+/**
+ * Compute lines, words, and bytes in a single pass over the content.
+ * This satisfies the requirement that the file is read only once.
+ *
+ * @param content  The text content to analyze
+ * @return         Combined stats with ok flag and all three counts
+ */
+CombinedStats count_all(const std::string& content) {
+    CombinedStats result;
+    result.ok = true;
+    result.line_count = 0;
+    result.word_count = 0;
+    result.byte_count = static_cast<int64_t>(content.size());
+
+    bool in_word = false;
+
+    for (char c : content) {
+        // Count bytes (already computed above, but this is the single pass)
+        // Line counting: count newlines
+        if (c == '\n') {
+            ++result.line_count;
+        }
+
+        // Word counting: track transitions from whitespace to non-whitespace
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v') {
+            if (in_word) {
+                in_word = false;
+            }
+        } else {
+            if (!in_word) {
+                ++result.word_count;
+                in_word = true;
+            }
+        }
+    }
+
+    return result;
+}
+
+} // namespace counter

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/counter/combined_counter.h
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/counter/combined_counter.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace counter {
+
+struct CombinedStats {
+    bool ok;
+    int64_t line_count;
+    int64_t word_count;
+    int64_t byte_count;
+};
+
+/**
+ * Compute lines, words, and bytes in a single pass over the content.
+ * This satisfies the requirement that the file is read only once.
+ *
+ * @param content  The text content to analyze
+ * @return         Combined stats with ok flag and all three counts
+ */
+CombinedStats count_all(const std::string& content);
+
+} // namespace counter

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/counter/line_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/counter/line_counter.cpp
@@ -1,0 +1,26 @@
+#include "counter/line_counter.h"
+#include <string>
+
+namespace counter {
+
+/**
+ * Count the number of newline characters in content.
+ *
+ * @param content  The text content to count lines in
+ * @return         Result struct with ok flag and line count
+ */
+LineCountResult count_lines(const std::string& content) {
+    LineCountResult result;
+    result.ok = true;
+    result.line_count = 0;
+
+    for (char c : content) {
+        if (c == '\n') {
+            ++result.line_count;
+        }
+    }
+
+    return result;
+}
+
+} // namespace counter

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/counter/line_counter.h
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/counter/line_counter.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+
+namespace counter {
+
+struct LineCountResult {
+    bool ok;
+    int64_t line_count;
+};
+
+/**
+ * Count the number of newline characters in content.
+ * @param content  The text content to count lines in
+ * @return         Result with ok flag and line count
+ */
+LineCountResult count_lines(const std::string& content);
+
+} // namespace counter

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/counter/word_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/counter/word_counter.cpp
@@ -1,0 +1,28 @@
+#include "counter/word_counter.h"
+#include <string>
+#include <sstream>
+
+namespace counter {
+
+/**
+ * Count the number of whitespace-separated words in content.
+ * Words are sequences of non-whitespace characters.
+ *
+ * @param content  The text content to count words in
+ * @return         Result struct with ok flag and word count
+ */
+WordCountResult count_words(const std::string& content) {
+    WordCountResult result;
+    result.ok = true;
+    result.word_count = 0;
+
+    std::istringstream stream(content);
+    std::string word;
+    while (stream >> word) {
+        ++result.word_count;
+    }
+
+    return result;
+}
+
+} // namespace counter

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/counter/word_counter.h
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/counter/word_counter.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+
+namespace counter {
+
+struct WordCountResult {
+    bool ok;
+    int64_t word_count;
+};
+
+/**
+ * Count the number of whitespace-separated words in content.
+ * @param content  The text content to count words in
+ * @return         Result with ok flag and word count
+ */
+WordCountResult count_words(const std::string& content);
+
+} // namespace counter

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/input/arg_parser.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/input/arg_parser.cpp
@@ -1,0 +1,21 @@
+#include "input/arg_parser.h"
+#include <cstdlib>
+#include <string>
+#include <stdexcept>
+
+namespace input {
+
+std::string parse_file_argument(int argc, char* argv[]) {
+    if (argc != 2) {
+        throw std::runtime_error("Usage: wc-tool <file>");
+    }
+
+    const char* file_arg = argv[1];
+    if (file_arg == nullptr || file_arg[0] == '\0') {
+        throw std::runtime_error("Error: empty filename");
+    }
+
+    return std::string(file_arg);
+}
+
+} // namespace input

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/input/arg_parser.h
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/input/arg_parser.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+namespace input {
+
+/**
+ * Parse and validate command-line arguments.
+ * Expects exactly one argument: the filename to process.
+ * @return the validated file path string
+ * @throws std::runtime_error if argc != 2 or filename is empty
+ */
+std::string parse_file_argument(int argc, char* argv[]);
+
+} // namespace input

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/input/file_opener.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/input/file_opener.cpp
@@ -1,0 +1,33 @@
+#include "input/file_opener.h"
+#include <fstream>
+#include <string>
+
+namespace input {
+
+/**
+ * Open a file for reading.
+ *
+ * @param filename  Path to the file to open
+ * @return          Result struct with ok flag, ifstream, and optional error message
+ */
+FileOpenResult open_file(const std::string& filename) {
+    FileOpenResult result;
+    result.ok = false;
+    result.error_message.clear();
+
+    if (filename.empty()) {
+        result.error_message = "Error: empty filename";
+        return result;
+    }
+
+    result.stream.open(filename, std::ios::in);
+    if (!result.stream.is_open()) {
+        result.error_message = "Error: cannot open file '" + filename + "'";
+        return result;
+    }
+
+    result.ok = true;
+    return result;
+}
+
+} // namespace input

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/input/file_opener.h
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/input/file_opener.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <fstream>
+#include <string>
+
+namespace input {
+
+struct FileOpenResult {
+    bool ok;
+    std::ifstream stream;
+    std::string error_message;
+};
+
+/**
+ * Open a file for reading.
+ * @param filename  Path to the file to open
+ * @return          Result with ok flag, stream, and optional error message
+ */
+FileOpenResult open_file(const std::string& filename);
+
+} // namespace input

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/main.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/main.cpp
@@ -1,0 +1,52 @@
+// wc-tool — a command-line word count utility.
+// Usage: wc-tool <file>
+// Output: <lines> <words> <bytes> <filename>
+
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <sstream>
+#include "input/arg_parser.h"
+#include "input/file_opener.h"
+#include "counter/combined_counter.h"
+#include "output/formatter.h"
+
+int main(int argc, char* argv[]) {
+    try {
+        // 1. Parse and validate arguments
+        std::string filepath = input::parse_file_argument(argc, argv);
+
+        // 2. Open the file
+        auto file_result = input::open_file(filepath);
+        if (!file_result.ok) {
+            std::cerr << file_result.error_message << std::endl;
+            return 1;
+        }
+
+        // 3. Read file content into a string (single read)
+        std::ostringstream content_stream;
+        content_stream << file_result.stream.rdbuf();
+        std::string content = content_stream.str();
+
+        // 4. Count lines, words, and bytes in a single pass
+        auto stats = counter::count_all(content);
+        if (!stats.ok) {
+            std::cerr << "Error computing statistics" << std::endl;
+            return 1;
+        }
+
+        // 5. Format and print results
+        std::string output = output::format_output(
+            stats.line_count,
+            stats.word_count,
+            stats.byte_count,
+            filepath
+        );
+        std::cout << output << std::endl;
+
+        return 0;
+    } catch (const std::runtime_error& e) {
+        std::cerr << e.what() << std::endl;
+        return 1;
+    }
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/output/formatter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/output/formatter.cpp
@@ -1,0 +1,24 @@
+#include "output/formatter.h"
+#include <string>
+#include <sstream>
+
+namespace output {
+
+/**
+ * Format the count results as a string for output.
+ * Format: "<lines> <words> <bytes> <filename>"
+ *
+ * @param lines    Number of lines
+ * @param words    Number of words
+ * @param bytes    Number of bytes
+ * @param filename The filename to display
+ * @return         Formatted string
+ */
+std::string format_output(int64_t lines, int64_t words, int64_t bytes,
+                          const std::string& filename) {
+    std::ostringstream oss;
+    oss << lines << " " << words << " " << bytes << " " << filename;
+    return oss.str();
+}
+
+} // namespace output

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/output/formatter.h
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/src/output/formatter.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace output {
+
+/**
+ * Format the count results as a string for output.
+ * Format: "<lines> <words> <bytes> <filename>"
+ */
+std::string format_output(int64_t lines, int64_t words, int64_t bytes,
+                          const std::string& filename);
+
+} // namespace output

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/scenarios/e2e_empty_file.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/scenarios/e2e_empty_file.cpp
@@ -1,0 +1,53 @@
+/**
+ * Integration scenario test: e2e_empty_file
+ *
+ * End-to-end test: run wc-tool on an empty file,
+ * verify the output is "0 0 0 filename".
+ */
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+static void create_temp_file(const std::string& filename, const std::string& content) {
+    std::ofstream f(filename);
+    f << content;
+    f.close();
+}
+
+static std::string capture_output(const std::string& cmd) {
+    std::string capture_cmd = cmd + " > /tmp/wc_scenario_output.txt 2>&1";
+    std::system(capture_cmd.c_str());
+    std::ifstream f("/tmp/wc_scenario_output.txt");
+    std::string result((std::istreambuf_iterator<char>(f)),
+                        std::istreambuf_iterator<char>());
+    f.close();
+    return result;
+}
+
+int main() {
+    // ---- Scenario: empty file ----
+    // 0 lines, 0 words, 0 bytes
+    create_temp_file("/tmp/wc_scenario_empty.txt", "");
+    std::string cmd = "./wc-tool /tmp/wc_scenario_empty.txt";
+    std::string output = capture_output(cmd);
+
+    // Verify output format: "0 0 0 filename"
+    assert(output.find("0 0 0") != std::string::npos);
+    assert(output.find("/tmp/wc_scenario_empty.txt") != std::string::npos);
+
+    // ---- Scenario: file with only whitespace ----
+    // "   \n" = 3 bytes + 1 newline = 4 bytes, 1 line, 0 words
+    create_temp_file("/tmp/wc_scenario_whitespace.txt", "   \n");
+    cmd = "./wc-tool /tmp/wc_scenario_whitespace.txt";
+    output = capture_output(cmd);
+
+    assert(output.find("1") != std::string::npos);  // 1 line
+    assert(output.find("0") != std::string::npos);  // 0 words
+    assert(output.find("4") != std::string::npos);  // 4 bytes
+    assert(output.find("/tmp/wc_scenario_whitespace.txt") != std::string::npos);
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/scenarios/e2e_file_not_found.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/scenarios/e2e_file_not_found.cpp
@@ -1,0 +1,47 @@
+/**
+ * Integration scenario test: e2e_file_not_found
+ *
+ * End-to-end test: run wc-tool with a non-existent file,
+ * verify it outputs error info to stderr and returns non-zero exit code.
+ */
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+static int run_command(const std::string& cmd) {
+    return std::system(cmd.c_str());
+}
+
+static std::string capture_stderr(const std::string& cmd) {
+    // Redirect stderr to a temp file
+    std::string capture_cmd = cmd + " 2>/tmp/wc_scenario_stderr.txt";
+    run_command(capture_cmd);
+    std::ifstream f("/tmp/wc_scenario_stderr.txt");
+    std::string result((std::istreambuf_iterator<char>(f)),
+                        std::istreambuf_iterator<char>());
+    f.close();
+    return result;
+}
+
+int main() {
+    // ---- Scenario: non-existent file ----
+    std::string cmd = "./wc-tool /tmp/nonexistent_file_xyz_123.txt";
+    int exit_code = run_command(cmd);
+    assert(exit_code != 0); // Must return non-zero exit code
+
+    // Verify stderr contains an error message
+    std::string stderr_output = capture_stderr(cmd);
+    assert(stderr_output.length() > 0); // Must produce error message on stderr
+
+    // Verify the error message mentions the file not being found
+    assert(stderr_output.find("nonexistent") != std::string::npos ||
+           stderr_output.find("No such file") != std::string::npos ||
+           stderr_output.find("cannot open") != std::string::npos ||
+           stderr_output.find("Error") != std::string::npos ||
+           stderr_output.find("error") != std::string::npos);
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/scenarios/e2e_no_argument.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/scenarios/e2e_no_argument.cpp
@@ -1,0 +1,49 @@
+/**
+ * Integration scenario test: e2e_no_argument
+ *
+ * End-to-end test: run wc-tool without any file argument,
+ * verify it outputs an error to stderr and returns non-zero exit code.
+ */
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+static int run_command(const std::string& cmd) {
+    return std::system(cmd.c_str());
+}
+
+static std::string capture_stderr(const std::string& cmd) {
+    std::string capture_cmd = cmd + " 2>/tmp/wc_scenario_stderr.txt";
+    run_command(capture_cmd);
+    std::ifstream f("/tmp/wc_scenario_stderr.txt");
+    std::string result((std::istreambuf_iterator<char>(f)),
+                        std::istreambuf_iterator<char>());
+    f.close();
+    return result;
+}
+
+int main() {
+    // ---- Scenario 1: no arguments at all ----
+    std::string cmd1 = "./wc-tool";
+    int exit_code1 = run_command(cmd1);
+    assert(exit_code1 != 0); // Must return non-zero exit code
+
+    std::string stderr1 = capture_stderr(cmd1);
+    assert(stderr1.length() > 0); // Must produce error message on stderr
+
+    // ---- Scenario 2: only program name (argv[0]) ----
+    // Same as Scenario 1 in practice since the shell strips it
+    int exit_code2 = run_command(cmd1);
+    assert(exit_code2 != 0);
+
+    // ---- Scenario 3: verify stderr contains helpful message ----
+    assert(stderr1.find("Usage") != std::string::npos ||
+           stderr1.find("usage") != std::string::npos ||
+           stderr1.find("error") != std::string::npos ||
+           stderr1.find("Error") != std::string::npos);
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/scenarios/e2e_no_trailing_newline.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/scenarios/e2e_no_trailing_newline.cpp
@@ -1,0 +1,55 @@
+/**
+ * Integration scenario test: e2e_no_trailing_newline
+ *
+ * End-to-end test: run wc-tool on a file without a trailing newline,
+ * verify wc-compatible line counting behavior.
+ */
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+static void create_temp_file(const std::string& filename, const std::string& content) {
+    std::ofstream f(filename);
+    f << content;
+    f.close();
+}
+
+static std::string capture_output(const std::string& cmd) {
+    std::string capture_cmd = cmd + " > /tmp/wc_scenario_output.txt 2>&1";
+    std::system(capture_cmd.c_str());
+    std::ifstream f("/tmp/wc_scenario_output.txt");
+    std::string result((std::istreambuf_iterator<char>(f)),
+                        std::istreambuf_iterator<char>());
+    f.close();
+    return result;
+}
+
+int main() {
+    // ---- Scenario 1: single line without trailing newline ----
+    // "hello world" = 11 bytes, no newline
+    // Expected: 0 lines (no newline chars), 2 words, 11 bytes
+    create_temp_file("/tmp/wc_scenario_no_nl.txt", "hello world");
+    std::string cmd = "./wc-tool /tmp/wc_scenario_no_nl.txt";
+    std::string output = capture_output(cmd);
+
+    assert(output.find("2") != std::string::npos);  // 2 words
+    assert(output.find("11") != std::string::npos); // 11 bytes
+    assert(output.find("/tmp/wc_scenario_no_nl.txt") != std::string::npos);
+
+    // ---- Scenario 2: multiple lines, last without trailing newline ----
+    // "line1\nline2\nline3" = 17 bytes, 2 newlines
+    // Expected: 2 lines, 3 words, 17 bytes
+    create_temp_file("/tmp/wc_scenario_multi_nonl.txt", "line1\nline2\nline3");
+    cmd = "./wc-tool /tmp/wc_scenario_multi_nonl.txt";
+    output = capture_output(cmd);
+
+    assert(output.find("2") != std::string::npos);  // 2 lines (newline count)
+    assert(output.find("3") != std::string::npos);  // 3 words
+    assert(output.find("17") != std::string::npos); // 17 bytes
+    assert(output.find("/tmp/wc_scenario_multi_nonl.txt") != std::string::npos);
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/scenarios/e2e_normal_file.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/scenarios/e2e_normal_file.cpp
@@ -1,0 +1,57 @@
+/**
+ * Integration scenario test: e2e_normal_file
+ *
+ * End-to-end test: run wc-tool on a file with known content,
+ * verify the output format and counts are correct.
+ */
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+static void create_temp_file(const std::string& filename, const std::string& content) {
+    std::ofstream f(filename);
+    f << content;
+    f.close();
+}
+
+static std::string capture_output(const std::string& cmd) {
+    std::string capture_cmd = cmd + " > /tmp/wc_scenario_output.txt 2>&1";
+    std::system(capture_cmd.c_str());
+    std::ifstream f("/tmp/wc_scenario_output.txt");
+    std::string result((std::istreambuf_iterator<char>(f)),
+                        std::istreambuf_iterator<char>());
+    f.close();
+    return result;
+}
+
+int main() {
+    // ---- Scenario 1: normal file with known content ----
+    // "hello world\nfoo bar baz\n"
+    // Expected: 2 lines, 5 words, 24 bytes
+    create_temp_file("/tmp/wc_scenario_normal.txt", "hello world\nfoo bar baz\n");
+    std::string cmd = "./wc-tool /tmp/wc_scenario_normal.txt";
+    std::string output = capture_output(cmd);
+
+    // Verify output contains expected values
+    assert(output.find("2") != std::string::npos);  // 2 lines
+    assert(output.find("5") != std::string::npos);  // 5 words
+    assert(output.find("24") != std::string::npos); // 24 bytes
+    assert(output.find("/tmp/wc_scenario_normal.txt") != std::string::npos);
+
+    // ---- Scenario 2: file with multiple lines and words ----
+    // "a b\nc d\ne f\n"
+    // Expected: 3 lines, 6 words, 12 bytes
+    create_temp_file("/tmp/wc_scenario_multi.txt", "a b\nc d\ne f\n");
+    cmd = "./wc-tool /tmp/wc_scenario_multi.txt";
+    output = capture_output(cmd);
+
+    assert(output.find("3") != std::string::npos);  // 3 lines
+    assert(output.find("6") != std::string::npos);  // 6 words
+    assert(output.find("12") != std::string::npos); // 12 bytes
+    assert(output.find("/tmp/wc_scenario_multi.txt") != std::string::npos);
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/scenarios/test_arg_parser.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/scenarios/test_arg_parser.cpp
@@ -1,0 +1,119 @@
+/**
+ * Integration scenario test: arg_parser
+ *
+ * Exercises the argument parser through its public API,
+ * covering happy paths, error conditions, and edge cases.
+ */
+
+#include "input/arg_parser.h"
+#include <cassert>
+#include <cstring>
+#include <string>
+
+int main() {
+    // ---- Happy path: single valid file argument ----
+    {
+        char buf[] = "myfile.txt";
+        char* argv[] = {buf, buf};
+        std::string result = input::parse_file_argument(2, argv);
+        assert(result == "myfile.txt");
+    }
+
+    // ---- Happy path: absolute path ----
+    {
+        char buf[] = "/usr/local/bin/data.txt";
+        char* argv[] = {buf, buf};
+        std::string result = input::parse_file_argument(2, argv);
+        assert(result == "/usr/local/bin/data.txt");
+    }
+
+    // ---- Happy path: relative path with directory ----
+    {
+        char buf[] = "./data/input.csv";
+        char* argv[] = {buf, buf};
+        std::string result = input::parse_file_argument(2, argv);
+        assert(result == "./data/input.csv");
+    }
+
+    // ---- Happy path: filename with spaces ----
+    {
+        char buf[] = "my report.txt";
+        char* argv[] = {buf, buf};
+        std::string result = input::parse_file_argument(2, argv);
+        assert(result == "my report.txt");
+    }
+
+    // ---- Happy path: filename with dots ----
+    {
+        char buf[] = "archive.tar.gz";
+        char* argv[] = {buf, buf};
+        std::string result = input::parse_file_argument(2, argv);
+        assert(result == "archive.tar.gz");
+    }
+
+    // ---- Error: no arguments (only program name) ----
+    {
+        char buf[] = "wc-tool";
+        char* argv[] = {buf};
+        bool caught = false;
+        try {
+            input::parse_file_argument(1, argv);
+        } catch (const std::exception& ex) {
+            caught = true;
+            std::string msg = ex.what();
+            assert(msg.find("Usage") != std::string::npos);
+        }
+        assert(caught);
+    }
+
+    // ---- Error: too many arguments ----
+    {
+        char f1[] = "file1.txt";
+        char f2[] = "file2.txt";
+        char prog[] = "wc-tool";
+        char* argv[] = {prog, f1, f2};
+        bool caught = false;
+        try {
+            input::parse_file_argument(3, argv);
+        } catch (const std::exception& ex) {
+            caught = true;
+            std::string msg = ex.what();
+            assert(msg.find("Usage") != std::string::npos);
+        }
+        assert(caught);
+    }
+
+    // ---- Error: empty filename ----
+    {
+        char buf[] = "";
+        char* argv[] = {buf, buf};
+        bool caught = false;
+        try {
+            input::parse_file_argument(2, argv);
+        } catch (const std::exception& ex) {
+            caught = true;
+            std::string msg = ex.what();
+            assert(msg.find("empty") != std::string::npos);
+        }
+        assert(caught);
+    }
+
+    // ---- Multi-call consistency: valid arguments only ----
+    {
+        const char* filenames[] = {"a.txt", "b.log", "c.dat"};
+        for (int i = 0; i < 3; ++i) {
+            char* buf = new char[16];
+            const char* fname = filenames[i];
+            for (size_t j = 0; j < strlen(fname); ++j) {
+                buf[j] = fname[j];
+            }
+            buf[strlen(fname)] = '\0';
+            char* argv[] = {buf, buf};
+            std::string result = input::parse_file_argument(2, argv);
+            assert(result == fname);
+            delete[] buf;
+        }
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/scenarios/test_byte_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/scenarios/test_byte_counter.cpp
@@ -1,0 +1,81 @@
+/**
+ * Integration scenario test: byte_counter
+ *
+ * Exercises the byte counter through its public API,
+ * covering happy paths, error conditions, and edge cases.
+ */
+
+#include "counter/byte_counter.h"
+#include <cassert>
+#include <string>
+
+int main() {
+    // ---- Happy path: empty string ----
+    {
+        auto result = counter::count_bytes("");
+        assert(result.ok);
+        assert(result.byte_count == 0);
+    }
+
+    // ---- Happy path: single byte ----
+    {
+        auto result = counter::count_bytes("a");
+        assert(result.ok);
+        assert(result.byte_count == 1);
+    }
+
+    // ---- Happy path: multiple bytes ----
+    {
+        auto result = counter::count_bytes("hello world");
+        assert(result.ok);
+        assert(result.byte_count == 11);
+    }
+
+    // ---- Happy path: with newline characters ----
+    {
+        auto result = counter::count_bytes("a\nb\n");
+        assert(result.ok);
+        assert(result.byte_count == 4);
+    }
+
+    // ---- Happy path: only whitespace ----
+    {
+        auto result = counter::count_bytes("   \t\n");
+        assert(result.ok);
+        assert(result.byte_count == 5);
+    }
+
+    // ---- Happy path: ASCII printable characters ----
+    {
+        auto result = counter::count_bytes("!@#$%");
+        assert(result.ok);
+        assert(result.byte_count == 5);
+    }
+
+    // ---- Edge: large content ----
+    {
+        std::string s(10000, 'x');
+        auto result = counter::count_bytes(s);
+        assert(result.ok);
+        assert(result.byte_count == 10000);
+    }
+
+    // ---- Edge: string with null character embedded ----
+    {
+        std::string s(3, '\0');
+        auto result = counter::count_bytes(s);
+        assert(result.ok);
+        assert(result.byte_count == 3);
+    }
+
+    // ---- Multi-call consistency ----
+    {
+        std::string content = "hello world\n";
+        auto r1 = counter::count_bytes(content);
+        auto r2 = counter::count_bytes(content);
+        assert(r1.byte_count == r2.byte_count);
+        assert(r1.byte_count == 12);
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/scenarios/test_line_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/scenarios/test_line_counter.cpp
@@ -1,0 +1,106 @@
+/**
+ * Integration scenario test: line_counter
+ *
+ * Exercises the line counter through its public API,
+ * covering happy paths, error conditions, and edge cases.
+ */
+
+#include "counter/line_counter.h"
+#include <cassert>
+#include <string>
+
+int main() {
+    // ---- Happy path: empty content ----
+    {
+        auto result = counter::count_lines("");
+        assert(result.ok);
+        assert(result.line_count == 0);
+    }
+
+    // ---- Happy path: single line without trailing newline ----
+    {
+        auto result = counter::count_lines("hello");
+        assert(result.ok);
+        assert(result.line_count == 0);
+    }
+
+    // ---- Happy path: single line with trailing newline ----
+    {
+        auto result = counter::count_lines("hello\n");
+        assert(result.ok);
+        assert(result.line_count == 1);
+    }
+
+    // ---- Happy path: multiple lines with trailing newline ----
+    {
+        auto result = counter::count_lines("line1\nline2\nline3\n");
+        assert(result.ok);
+        assert(result.line_count == 3);
+    }
+
+    // ---- Happy path: multiple lines without trailing newline ----
+    {
+        auto result = counter::count_lines("line1\nline2\nline3");
+        assert(result.ok);
+        assert(result.line_count == 2);
+    }
+
+    // ---- Happy path: single newline only ----
+    {
+        auto result = counter::count_lines("\n");
+        assert(result.ok);
+        assert(result.line_count == 1);
+    }
+
+    // ---- Happy path: multiple consecutive newlines ----
+    {
+        auto result = counter::count_lines("\n\n\n");
+        assert(result.ok);
+        assert(result.line_count == 3);
+    }
+
+    // ---- Happy path: empty lines mixed ----
+    {
+        auto result = counter::count_lines("\nhello\n\nworld\n");
+        assert(result.ok);
+        assert(result.line_count == 4);
+    }
+
+    // ---- Happy path: only whitespace, no newlines ----
+    {
+        auto result = counter::count_lines("   ");
+        assert(result.ok);
+        assert(result.line_count == 0);
+    }
+
+    // ---- Edge: very large content ----
+    {
+        std::string large(10000, 'a');
+        large += '\n';
+        auto result = counter::count_lines(large);
+        assert(result.ok);
+        assert(result.line_count == 1);
+    }
+
+    // ---- Edge: large content with many lines ----
+    {
+        std::string large;
+        for (int i = 0; i < 1000; ++i) {
+            large += "line\n";
+        }
+        auto result = counter::count_lines(large);
+        assert(result.ok);
+        assert(result.line_count == 1000);
+    }
+
+    // ---- Multi-call consistency ----
+    {
+        std::string content = "a\nb\nc\n";
+        auto r1 = counter::count_lines(content);
+        auto r2 = counter::count_lines(content);
+        assert(r1.line_count == r2.line_count);
+        assert(r1.line_count == 3);
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/scenarios/test_output_formatter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/scenarios/test_output_formatter.cpp
@@ -1,0 +1,81 @@
+/**
+ * Integration scenario test: output_formatter
+ *
+ * Exercises the output formatter through its public API,
+ * covering happy paths, edge cases, and output format validation.
+ */
+
+#include "output/formatter.h"
+#include <cassert>
+#include <string>
+
+int main() {
+    // ---- Happy path: basic formatting ----
+    {
+        std::string output = output::format_output(10, 50, 200, "myfile.txt");
+        assert(output == "10 50 200 myfile.txt");
+    }
+
+    // ---- Happy path: zero counts ----
+    {
+        std::string output = output::format_output(0, 0, 0, "empty.txt");
+        assert(output == "0 0 0 empty.txt");
+    }
+
+    // ---- Happy path: single values ----
+    {
+        std::string output = output::format_output(1, 1, 1, "a.txt");
+        assert(output == "1 1 1 a.txt");
+    }
+
+    // ---- Happy path: large values ----
+    {
+        std::string output = output::format_output(999999, 5000000, 10000000, "big.txt");
+        assert(output == "999999 5000000 10000000 big.txt");
+    }
+
+    // ---- Happy path: filename with path ----
+    {
+        std::string output = output::format_output(1, 2, 3, "/path/to/file.txt");
+        assert(output == "1 2 3 /path/to/file.txt");
+    }
+
+    // ---- Happy path: filename with spaces ----
+    {
+        std::string output = output::format_output(1, 2, 3, "my file.txt");
+        assert(output == "1 2 3 my file.txt");
+    }
+
+    // ---- Edge: filename with special characters ----
+    {
+        std::string output = output::format_output(0, 0, 0, "file-with_special.chars");
+        assert(output == "0 0 0 file-with_special.chars");
+    }
+
+    // ---- Edge: maximum int64_t values ----
+    {
+        std::string output = output::format_output(
+            9223372036854775807LL,
+            9223372036854775807LL,
+            9223372036854775807LL,
+            "max.txt"
+        );
+        assert(output.find("9223372036854775807") != std::string::npos);
+        assert(output.find("max.txt") != std::string::npos);
+    }
+
+    // ---- Format validation: exactly 3 spaces as separators ----
+    {
+        std::string output = output::format_output(1, 2, 3, "test.txt");
+        // Count spaces between numbers
+        int space_count = 0;
+        for (size_t i = 0; i < output.size(); ++i) {
+            if (output[i] == ' ') {
+                space_count++;
+            }
+        }
+        assert(space_count == 3);
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/scenarios/test_word_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/scenarios/test_word_counter.cpp
@@ -1,0 +1,104 @@
+/**
+ * Integration scenario test: word_counter
+ *
+ * Exercises the word counter through its public API,
+ * covering happy paths, error conditions, and edge cases.
+ */
+
+#include "counter/word_counter.h"
+#include <cassert>
+#include <string>
+
+int main() {
+    // ---- Happy path: empty content ----
+    {
+        auto result = counter::count_words("");
+        assert(result.ok);
+        assert(result.word_count == 0);
+    }
+
+    // ---- Happy path: single word ----
+    {
+        auto result = counter::count_words("hello");
+        assert(result.ok);
+        assert(result.word_count == 1);
+    }
+
+    // ---- Happy path: multiple words ----
+    {
+        auto result = counter::count_words("hello world");
+        assert(result.ok);
+        assert(result.word_count == 2);
+    }
+
+    // ---- Happy path: multiple words with extra spaces ----
+    {
+        auto result = counter::count_words("  hello   world  ");
+        assert(result.ok);
+        assert(result.word_count == 2);
+    }
+
+    // ---- Happy path: words with newlines ----
+    {
+        auto result = counter::count_words("one\ntwo\nthree\n");
+        assert(result.ok);
+        assert(result.word_count == 3);
+    }
+
+    // ---- Happy path: tabs as separators ----
+    {
+        auto result = counter::count_words("a\tb\tc");
+        assert(result.ok);
+        assert(result.word_count == 3);
+    }
+
+    // ---- Happy path: mixed whitespace ----
+    {
+        auto result = counter::count_words("  \n\t  hello\t world\n");
+        assert(result.ok);
+        assert(result.word_count == 2);
+    }
+
+    // ---- Happy path: only whitespace ----
+    {
+        auto result = counter::count_words("   \n\t  ");
+        assert(result.ok);
+        assert(result.word_count == 0);
+    }
+
+    // ---- Happy path: single character words ----
+    {
+        auto result = counter::count_words("a b c d e");
+        assert(result.ok);
+        assert(result.word_count == 5);
+    }
+
+    // ---- Edge: large content with many words ----
+    {
+        std::string large;
+        for (int i = 0; i < 1000; ++i) {
+            large += "word ";
+        }
+        auto result = counter::count_words(large);
+        assert(result.ok);
+        assert(result.word_count == 1000);
+    }
+
+    // ---- Edge: consecutive newlines ----
+    {
+        auto result = counter::count_words("a\n\n\nb\n\n");
+        assert(result.ok);
+        assert(result.word_count == 2);
+    }
+
+    // ---- Multi-call consistency ----
+    {
+        std::string content = "hello world foo bar\n";
+        auto r1 = counter::count_words(content);
+        auto r2 = counter::count_words(content);
+        assert(r1.word_count == r2.word_count);
+        assert(r1.word_count == 4);
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_arg_parser.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_arg_parser.cpp
@@ -1,0 +1,70 @@
+#include <cassert>
+#include <string>
+#include <stdexcept>
+#include "input/arg_parser.h"
+
+int main() {
+    // --- Happy path: exactly one argument ---
+    {
+        char buf[] = "myfile.txt";
+        char* argv[] = {buf, buf}; // argv[0] = program, argv[1] = file
+        std::string result = input::parse_file_argument(2, argv);
+        assert(result == "myfile.txt");
+    }
+
+    // --- Happy path: file path with directory ---
+    {
+        char buf[] = "/home/user/document.txt";
+        char* argv[] = {buf, buf};
+        std::string result = input::parse_file_argument(2, argv);
+        assert(result == "/home/user/document.txt");
+    }
+
+    // --- Happy path: file path with spaces ---
+    {
+        char buf[] = "my file.txt";
+        char* argv[] = {buf, buf};
+        std::string result = input::parse_file_argument(2, argv);
+        assert(result == "my file.txt");
+    }
+
+    // --- Error: no arguments (only program name) ---
+    {
+        char buf[] = "wc-tool";
+        char* argv[] = {buf};
+        try {
+            input::parse_file_argument(1, argv);
+            assert(false && "Should have thrown");
+        } catch (const std::runtime_error& e) {
+            assert(std::string(e.what()).find("Usage") != std::string::npos);
+        }
+    }
+
+    // --- Error: too many arguments ---
+    {
+        char buf1[] = "file1.txt";
+        char buf2[] = "file2.txt";
+        char buf3[] = "wc-tool";
+        char* argv[] = {buf3, buf1, buf2};
+        try {
+            input::parse_file_argument(3, argv);
+            assert(false && "Should have thrown");
+        } catch (const std::runtime_error& e) {
+            assert(std::string(e.what()).find("Usage") != std::string::npos);
+        }
+    }
+
+    // --- Edge: empty filename ---
+    {
+        char buf[] = "";
+        char* argv[] = {buf, buf};
+        try {
+            input::parse_file_argument(2, argv);
+            assert(false && "Should have thrown");
+        } catch (const std::runtime_error& e) {
+            assert(std::string(e.what()).find("empty") != std::string::npos);
+        }
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_byte_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_byte_counter.cpp
@@ -1,0 +1,65 @@
+#include "counter/byte_counter.h"
+#include <cassert>
+#include <string>
+
+int main() {
+    // --- Happy path: empty string ---
+    {
+        auto result = counter::count_bytes("");
+        assert(result.ok);
+        assert(result.byte_count == 0);
+    }
+
+    // --- Happy path: single byte ---
+    {
+        auto result = counter::count_bytes("a");
+        assert(result.ok);
+        assert(result.byte_count == 1);
+    }
+
+    // --- Happy path: multiple bytes ---
+    {
+        auto result = counter::count_bytes("hello world");
+        assert(result.ok);
+        assert(result.byte_count == 11);
+    }
+
+    // --- Happy path: with newline characters ---
+    {
+        auto result = counter::count_bytes("a\nb\n");
+        assert(result.ok);
+        assert(result.byte_count == 4);
+    }
+
+    // --- Happy path: only whitespace ---
+    {
+        auto result = counter::count_bytes("   \t\n");
+        assert(result.ok);
+        assert(result.byte_count == 5);
+    }
+
+    // --- Happy path: ASCII printable characters ---
+    {
+        auto result = counter::count_bytes("!@#$%");
+        assert(result.ok);
+        assert(result.byte_count == 5);
+    }
+
+    // --- Edge: large content ---
+    {
+        std::string s(10000, 'x');
+        auto result = counter::count_bytes(s);
+        assert(result.ok);
+        assert(result.byte_count == 10000);
+    }
+
+    // --- Edge: string with null character embedded ---
+    {
+        std::string s(3, '\0');
+        auto result = counter::count_bytes(s);
+        assert(result.ok);
+        assert(result.byte_count == 3);
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_combined_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_combined_counter.cpp
@@ -1,0 +1,135 @@
+#include "counter/combined_counter.h"
+#include <cassert>
+#include <string>
+
+int main() {
+    // --- Happy path: empty content ---
+    {
+        auto result = counter::count_all("");
+        assert(result.ok);
+        assert(result.line_count == 0);
+        assert(result.word_count == 0);
+        assert(result.byte_count == 0);
+    }
+
+    // --- Happy path: single word, no newline ---
+    {
+        auto result = counter::count_all("hello");
+        assert(result.ok);
+        assert(result.line_count == 0);
+        assert(result.word_count == 1);
+        assert(result.byte_count == 5);
+    }
+
+    // --- Happy path: single word with trailing newline ---
+    {
+        auto result = counter::count_all("hello\n");
+        assert(result.ok);
+        assert(result.line_count == 1);
+        assert(result.word_count == 1);
+        assert(result.byte_count == 6);
+    }
+
+    // --- Happy path: multiple lines with trailing newline ---
+    {
+        auto result = counter::count_all("line1\nline2\nline3\n");
+        assert(result.ok);
+        assert(result.line_count == 3);
+        assert(result.word_count == 3);
+        assert(result.byte_count == 18);
+    }
+
+    // --- Happy path: multiple lines without trailing newline ---
+    {
+        auto result = counter::count_all("line1\nline2\nline3");
+        assert(result.ok);
+        assert(result.line_count == 2);
+        assert(result.word_count == 3);
+        assert(result.byte_count == 17);
+    }
+
+    // --- Happy path: multiple words per line ---
+    {
+        auto result = counter::count_all("hello world\nfoo bar\n");
+        assert(result.ok);
+        assert(result.line_count == 2);
+        assert(result.word_count == 4);
+        assert(result.byte_count == 20);
+    }
+
+    // --- Happy path: extra whitespace ---
+    {
+        auto result = counter::count_all("  hello   world  \n");
+        assert(result.ok);
+        assert(result.line_count == 1);
+        assert(result.word_count == 2);
+        assert(result.byte_count == 18);
+    }
+
+    // --- Happy path: tabs as separators ---
+    {
+        auto result = counter::count_all("a\tb\tc\n");
+        assert(result.ok);
+        assert(result.line_count == 1);
+        assert(result.word_count == 3);
+        assert(result.byte_count == 6);
+    }
+
+    // --- Happy path: only whitespace ---
+    {
+        auto result = counter::count_all("   \n\t  ");
+        assert(result.ok);
+        assert(result.line_count == 1);
+        assert(result.word_count == 0);
+        assert(result.byte_count == 7);
+    }
+
+    // --- Happy path: only newlines ---
+    {
+        auto result = counter::count_all("\n\n\n");
+        assert(result.ok);
+        assert(result.line_count == 3);
+        assert(result.word_count == 0);
+        assert(result.byte_count == 3);
+    }
+
+    // --- Happy path: mixed empty lines ---
+    {
+        auto result = counter::count_all("\nhello\n\nworld\n");
+        assert(result.ok);
+        assert(result.line_count == 4);
+        assert(result.word_count == 2);
+        assert(result.byte_count == 14);
+    }
+
+    // --- Happy path: single character words ---
+    {
+        auto result = counter::count_all("a b c d e");
+        assert(result.ok);
+        assert(result.line_count == 0);
+        assert(result.word_count == 5);
+        assert(result.byte_count == 9);
+    }
+
+    // --- Happy path: carriage return as whitespace ---
+    {
+        auto result = counter::count_all("hello\rworld\n");
+        assert(result.ok);
+        assert(result.line_count == 1);
+        assert(result.word_count == 2);
+        assert(result.byte_count == 12);
+    }
+
+    // --- Edge: very large content ---
+    {
+        std::string large(10000, 'a');
+        large += '\n';
+        auto result = counter::count_all(large);
+        assert(result.ok);
+        assert(result.line_count == 1);
+        assert(result.word_count == 1);
+        assert(result.byte_count == 10001);
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_e2e.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_e2e.cpp
@@ -1,0 +1,88 @@
+// E2E test executable — tests end-to-end scenarios via system() calls to the wc-tool binary.
+// Each scenario internally creates temporary files, runs the binary, and verifies output.
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <sstream>
+#include <fstream>
+
+// Helper: create a temporary file with given content
+static void create_temp_file(const std::string& filename, const std::string& content) {
+    std::ofstream f(filename);
+    f << content;
+    f.close();
+}
+
+// Helper: run a command and capture exit code
+static int run_command(const std::string& cmd) {
+    return std::system(cmd.c_str());
+}
+
+// Helper: read stdout from a command (using a temp file)
+static std::string capture_output(const std::string& cmd) {
+    std::string capture_cmd = cmd + " > /tmp/wc_tool_output.txt 2>&1";
+    run_command(capture_cmd);
+    std::ifstream f("/tmp/wc_tool_output.txt");
+    std::string result((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    f.close();
+    return result;
+}
+
+int main() {
+    // === Scenario 1: e2e_normal_file ===
+    // Create a file with known content and verify output
+    {
+        create_temp_file("/tmp/test_normal.txt", "hello world\nfoo bar baz\n");
+        // Expected: 2 lines, 5 words, 19 bytes (hello world\nfoo bar baz\n = 19 bytes)
+        // Actually: "hello world\nfoo bar baz\n" = 24 bytes
+        // Let me count: h-e-l-l-o- -w-o-r-l-d-\n = 12, f-o-o- -b-a-r- -b-a-z-\n = 12, total = 24
+        // Wait: "hello world\nfoo bar baz\n"
+        // h(1)e(2)l(3)l(4)o(5) (6)w(7)o(8)r(9)l(10)d(11)\n(12)f(13)o(14)o(15) (16)b(17)a(18)r(19) (20)b(21)a(22)z(23)\n(24)
+        // So 24 bytes, 2 lines, 5 words
+        std::string cmd = "./build/wc-tool /tmp/test_normal.txt";
+        std::string output = capture_output(cmd);
+        assert(output.find("2") != std::string::npos);
+        assert(output.find("5") != std::string::npos);
+        assert(output.find("24") != std::string::npos);
+        assert(output.find("/tmp/test_normal.txt") != std::string::npos);
+    }
+
+    // === Scenario 2: e2e_empty_file ===
+    {
+        create_temp_file("/tmp/test_empty.txt", "");
+        std::string cmd = "./build/wc-tool /tmp/test_empty.txt";
+        std::string output = capture_output(cmd);
+        assert(output.find("0") != std::string::npos);
+        assert(output.find("/tmp/test_empty.txt") != std::string::npos);
+    }
+
+    // === Scenario 3: e2e_no_argument ===
+    {
+        std::string cmd = "./build/wc-tool 2>/tmp/wc_tool_stderr.txt";
+        int exit_code = run_command(cmd);
+        assert(exit_code != 0); // Should return non-zero
+    }
+
+    // === Scenario 4: e2e_file_not_found ===
+    {
+        std::string cmd = "./build/wc-tool /tmp/nonexistent_file_xyz.txt 2>/tmp/wc_tool_stderr.txt";
+        int exit_code = run_command(cmd);
+        assert(exit_code != 0); // Should return non-zero
+    }
+
+    // === Scenario 5: e2e_no_trailing_newline ===
+    {
+        create_temp_file("/tmp/test_no_newline.txt", "hello world");
+        // "hello world" = 11 bytes, 1 line (no trailing newline but counts as 1), 2 words
+        std::string cmd = "./build/wc-tool /tmp/test_no_newline.txt";
+        std::string output = capture_output(cmd);
+        assert(output.find("1") != std::string::npos); // 1 line
+        assert(output.find("2") != std::string::npos); // 2 words
+        assert(output.find("11") != std::string::npos); // 11 bytes
+        assert(output.find("/tmp/test_no_newline.txt") != std::string::npos);
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_e2e_empty_file.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_e2e_empty_file.cpp
@@ -1,0 +1,36 @@
+// E2E test: empty file processing
+// Verifies that an empty file produces "0 0 0 filename".
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+static void create_temp_file(const std::string& filename, const std::string& content) {
+    std::ofstream f(filename);
+    f << content;
+    f.close();
+}
+
+static std::string capture_output(const std::string& cmd) {
+    std::string capture_cmd = cmd + " > /tmp/wc_tool_output.txt 2>&1";
+    std::system(capture_cmd.c_str());
+    std::ifstream f("/tmp/wc_tool_output.txt");
+    std::string result((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    f.close();
+    return result;
+}
+
+int main() {
+    // Scenario: empty file — ""
+    // 0 lines, 0 words, 0 bytes
+    create_temp_file("/tmp/test_e2e_empty.txt", "");
+    std::string cmd = "./wc-tool /tmp/test_e2e_empty.txt";
+    std::string output = capture_output(cmd);
+
+    assert(output.find("0") != std::string::npos);
+    assert(output.find("/tmp/test_e2e_empty.txt") != std::string::npos);
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_e2e_file_not_found.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_e2e_file_not_found.cpp
@@ -1,0 +1,35 @@
+// E2E test: file not found
+// Verifies that running wc-tool with a non-existent file produces an error to stderr
+// and a non-zero exit code.
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+static int run_command(const std::string& cmd) {
+    return std::system(cmd.c_str());
+}
+
+static std::string capture_stderr(const std::string& cmd) {
+    std::string capture_cmd = cmd + " 2>/tmp/wc_tool_stderr.txt";
+    run_command(capture_cmd);
+    std::ifstream f("/tmp/wc_tool_stderr.txt");
+    std::string result((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    f.close();
+    return result;
+}
+
+int main() {
+    // Scenario: non-existent file — should fail with non-zero exit
+    std::string cmd = "./build/wc-tool /tmp/nonexistent_file_xyz_123.txt";
+    int exit_code = run_command(cmd);
+    assert(exit_code != 0); // Must return non-zero
+
+    // Verify stderr contains an error message
+    std::string stderr_output = capture_stderr(cmd);
+    assert(stderr_output.length() > 0);
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_e2e_no_argument.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_e2e_no_argument.cpp
@@ -1,0 +1,35 @@
+// E2E test: no argument provided
+// Verifies that running wc-tool without a file argument produces an error to stderr
+// and a non-zero exit code.
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+static int run_command(const std::string& cmd) {
+    return std::system(cmd.c_str());
+}
+
+static std::string capture_stderr(const std::string& cmd) {
+    std::string capture_cmd = cmd + " 2>/tmp/wc_tool_stderr.txt";
+    run_command(capture_cmd);
+    std::ifstream f("/tmp/wc_tool_stderr.txt");
+    std::string result((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    f.close();
+    return result;
+}
+
+int main() {
+    // Scenario: no argument — should fail with non-zero exit
+    std::string cmd = "./build/wc-tool";
+    int exit_code = run_command(cmd);
+    assert(exit_code != 0); // Must return non-zero
+
+    // Verify stderr contains an error message
+    std::string stderr_output = capture_stderr(cmd);
+    assert(stderr_output.length() > 0);
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_e2e_no_trailing_newline.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_e2e_no_trailing_newline.cpp
@@ -1,0 +1,39 @@
+// E2E test: file without trailing newline
+// Verifies wc-compatible line counting: a file without a trailing newline
+// still counts the last line.
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+static void create_temp_file(const std::string& filename, const std::string& content) {
+    std::ofstream f(filename);
+    f << content;
+    f.close();
+}
+
+static std::string capture_output(const std::string& cmd) {
+    std::string capture_cmd = cmd + " > /tmp/wc_tool_output.txt 2>&1";
+    std::system(capture_cmd.c_str());
+    std::ifstream f("/tmp/wc_tool_output.txt");
+    std::string result((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    f.close();
+    return result;
+}
+
+int main() {
+    // Scenario: "hello world" — no trailing newline
+    // 1 line, 2 words, 11 bytes
+    create_temp_file("/tmp/test_e2e_no_newline.txt", "hello world");
+    std::string cmd = "./wc-tool /tmp/test_e2e_no_newline.txt";
+    std::string output = capture_output(cmd);
+
+    assert(output.find("1") != std::string::npos); // 1 line
+    assert(output.find("2") != std::string::npos); // 2 words
+    assert(output.find("11") != std::string::npos); // 11 bytes
+    assert(output.find("/tmp/test_e2e_no_newline.txt") != std::string::npos);
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_e2e_normal_file.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_e2e_normal_file.cpp
@@ -1,0 +1,39 @@
+// E2E test: normal file processing
+// Creates a file with known content and verifies the output format and counts.
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+static void create_temp_file(const std::string& filename, const std::string& content) {
+    std::ofstream f(filename);
+    f << content;
+    f.close();
+}
+
+static std::string capture_output(const std::string& cmd) {
+    std::string capture_cmd = cmd + " > /tmp/wc_tool_output.txt 2>&1";
+    std::system(capture_cmd.c_str());
+    std::ifstream f("/tmp/wc_tool_output.txt");
+    std::string result((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    f.close();
+    return result;
+}
+
+int main() {
+    // Scenario: normal file — "hello world\nfoo bar baz\n"
+    // 2 lines, 5 words, 24 bytes
+    create_temp_file("/tmp/test_e2e_normal.txt", "hello world\nfoo bar baz\n");
+    std::string cmd = "./wc-tool /tmp/test_e2e_normal.txt";
+    std::string output = capture_output(cmd);
+
+    // Verify output contains expected values
+    assert(output.find("2") != std::string::npos); // 2 lines
+    assert(output.find("5") != std::string::npos); // 5 words
+    assert(output.find("24") != std::string::npos); // 24 bytes
+    assert(output.find("/tmp/test_e2e_normal.txt") != std::string::npos);
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_file_opener.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_file_opener.cpp
@@ -1,0 +1,56 @@
+#include "input/file_opener.h"
+#include <cassert>
+#include <cstdio>
+#include <string>
+#include <unistd.h>
+
+static std::string create_temp_file(const std::string& content) {
+    std::string path = "/tmp/test_wc_tool_XXXXXX";
+    char buf[1024];
+    snprintf(buf, sizeof(buf), "%s", path.c_str());
+    int fd = mkstemp(buf);
+    if (fd < 0) return "";
+    write(fd, content.c_str(), content.size());
+    close(fd);
+    return buf;
+}
+
+int main() {
+    // --- Happy path: valid file ---
+    {
+        std::string tmp = create_temp_file("hello\nworld\n");
+        assert(!tmp.empty());
+        auto result = input::open_file(tmp);
+        assert(result.ok);
+        char buf[256];
+        result.stream.getline(buf, sizeof(buf));
+        assert(result.stream);
+        std::remove(tmp.c_str());
+    }
+
+    // --- Happy path: empty file ---
+    {
+        std::string tmp = create_temp_file("");
+        assert(!tmp.empty());
+        auto result = input::open_file(tmp);
+        assert(result.ok);
+        assert(!result.stream.eof());
+        std::remove(tmp.c_str());
+    }
+
+    // --- Error: file does not exist ---
+    {
+        auto result = input::open_file("/nonexistent/path/file_does_not_exist.txt");
+        assert(!result.ok);
+        assert(!result.error_message.empty());
+    }
+
+    // --- Error: empty filename ---
+    {
+        auto result = input::open_file("");
+        assert(!result.ok);
+        assert(!result.error_message.empty());
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_line_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_line_counter.cpp
@@ -1,0 +1,72 @@
+#include "counter/line_counter.h"
+#include <cassert>
+#include <string>
+
+int main() {
+    // --- Happy path: empty content ---
+    {
+        auto result = counter::count_lines("");
+        assert(result.ok);
+        assert(result.line_count == 0);
+    }
+
+    // --- Happy path: single line without trailing newline ---
+    {
+        auto result = counter::count_lines("hello");
+        assert(result.ok);
+        assert(result.line_count == 0);
+    }
+
+    // --- Happy path: single line with trailing newline ---
+    {
+        auto result = counter::count_lines("hello\n");
+        assert(result.ok);
+        assert(result.line_count == 1);
+    }
+
+    // --- Happy path: multiple lines with trailing newline ---
+    {
+        auto result = counter::count_lines("line1\nline2\nline3\n");
+        assert(result.ok);
+        assert(result.line_count == 3);
+    }
+
+    // --- Happy path: multiple lines without trailing newline ---
+    {
+        auto result = counter::count_lines("line1\nline2\nline3");
+        assert(result.ok);
+        assert(result.line_count == 2);
+    }
+
+    // --- Happy path: single newline only ---
+    {
+        auto result = counter::count_lines("\n");
+        assert(result.ok);
+        assert(result.line_count == 1);
+    }
+
+    // --- Happy path: multiple consecutive newlines ---
+    {
+        auto result = counter::count_lines("\n\n\n");
+        assert(result.ok);
+        assert(result.line_count == 3);
+    }
+
+    // --- Happy path: empty lines mixed ---
+    {
+        auto result = counter::count_lines("\nhello\n\nworld\n");
+        assert(result.ok);
+        assert(result.line_count == 4);
+    }
+
+    // --- Edge: very large content ---
+    {
+        std::string large(10000, 'a');
+        large += '\n';
+        auto result = counter::count_lines(large);
+        assert(result.ok);
+        assert(result.line_count == 1);
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_output_formatter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_output_formatter.cpp
@@ -1,0 +1,43 @@
+#include "output/formatter.h"
+#include <cassert>
+#include <string>
+
+int main() {
+    // --- Happy path: basic formatting ---
+    {
+        std::string output = output::format_output(10, 50, 200, "myfile.txt");
+        assert(output == "10 50 200 myfile.txt");
+    }
+
+    // --- Happy path: zero counts ---
+    {
+        std::string output = output::format_output(0, 0, 0, "empty.txt");
+        assert(output == "0 0 0 empty.txt");
+    }
+
+    // --- Happy path: single values ---
+    {
+        std::string output = output::format_output(1, 1, 1, "a.txt");
+        assert(output == "1 1 1 a.txt");
+    }
+
+    // --- Happy path: large values ---
+    {
+        std::string output = output::format_output(999999, 5000000, 10000000, "big.txt");
+        assert(output == "999999 5000000 10000000 big.txt");
+    }
+
+    // --- Happy path: filename with path ---
+    {
+        std::string output = output::format_output(1, 2, 3, "/path/to/file.txt");
+        assert(output == "1 2 3 /path/to/file.txt");
+    }
+
+    // --- Happy path: filename with spaces ---
+    {
+        std::string output = output::format_output(1, 2, 3, "my file.txt");
+        assert(output == "1 2 3 my file.txt");
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_word_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/input/tests/test_word_counter.cpp
@@ -1,0 +1,81 @@
+#include "counter/word_counter.h"
+#include <cassert>
+#include <string>
+
+int main() {
+    // --- Happy path: empty content ---
+    {
+        auto result = counter::count_words("");
+        assert(result.ok);
+        assert(result.word_count == 0);
+    }
+
+    // --- Happy path: single word ---
+    {
+        auto result = counter::count_words("hello");
+        assert(result.ok);
+        assert(result.word_count == 1);
+    }
+
+    // --- Happy path: multiple words ---
+    {
+        auto result = counter::count_words("hello world");
+        assert(result.ok);
+        assert(result.word_count == 2);
+    }
+
+    // --- Happy path: multiple words with extra spaces ---
+    {
+        auto result = counter::count_words("  hello   world  ");
+        assert(result.ok);
+        assert(result.word_count == 2);
+    }
+
+    // --- Happy path: words with newlines ---
+    {
+        auto result = counter::count_words("one\ntwo\nthree\n");
+        assert(result.ok);
+        assert(result.word_count == 3);
+    }
+
+    // --- Happy path: tabs as separators ---
+    {
+        auto result = counter::count_words("a\tb\tc");
+        assert(result.ok);
+        assert(result.word_count == 3);
+    }
+
+    // --- Happy path: mixed whitespace ---
+    {
+        auto result = counter::count_words("  \n\t  hello\t world\n");
+        assert(result.ok);
+        assert(result.word_count == 2);
+    }
+
+    // --- Happy path: only whitespace ---
+    {
+        auto result = counter::count_words("   \n\t  ");
+        assert(result.ok);
+        assert(result.word_count == 0);
+    }
+
+    // --- Happy path: single character words ---
+    {
+        auto result = counter::count_words("a b c d e");
+        assert(result.ok);
+        assert(result.word_count == 5);
+    }
+
+    // --- Edge: large content ---
+    {
+        std::string large;
+        for (int i = 0; i < 1000; ++i) {
+            large += "word ";
+        }
+        auto result = counter::count_words(large);
+        assert(result.ok);
+        assert(result.word_count == 1000);
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/project_config.json
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/delivery/project_config.json
@@ -1,0 +1,72 @@
+{
+  "project_name": "cpp_wc",
+  "development_mode": "local",
+  "process_type": "waterfall_v2",
+  "ui_language": "en",
+  "default_model": {
+    "provider": "Local",
+    "model": "qwen3.6-35b",
+    "api_key": "",
+    "base_url": "http://127.0.0.1:8088/v1",
+    "temperature": 0.7,
+    "max_tokens": 4096
+  },
+  "model_providers": [
+    {
+      "provider": "Local",
+      "api_key": "",
+      "base_url": "http://127.0.0.1:8088/v1",
+      "enabled": true
+    }
+  ],
+  "agents": {
+    "product_manager": {
+      "name": "product_manager",
+      "enabled": true
+    },
+    "architect": {
+      "name": "architect",
+      "enabled": true
+    },
+    "developer": {
+      "name": "developer",
+      "enabled": true
+    },
+    "qa_engineer": {
+      "name": "qa_engineer",
+      "enabled": true
+    },
+    "project_manager": {
+      "name": "project_manager",
+      "enabled": true
+    },
+    "rd_director": {
+      "name": "rd_director",
+      "enabled": true
+    }
+  },
+  "agent_model_selection": {},
+  "workflow": {
+    "max_review_iterations": 3,
+    "fail_on_review_rejection": false
+  },
+  "session": {
+    "max_concurrent_sessions": 5
+  },
+  "workspace": {
+    "projects_root": "projects",
+    "artifacts_root": "artifacts",
+    "auto_create_dirs": true
+  },
+  "logging": {
+    "level": "INFO",
+    "log_dir": "logs",
+    "json_format": false,
+    "rotate_daily": true
+  },
+  "github": {
+    "token": "",
+    "repo_owner": "",
+    "repo_name": ""
+  }
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/implementation/case.yaml
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/implementation/case.yaml
@@ -1,0 +1,56 @@
+aise_version: "0.1.0"
+scenario_id: cpp_wc_cli
+phase: implementation
+
+input_dir: input/
+project_config_file: project_config.json
+
+requirement: |
+  Build a C++17 ``wc``-like CLI — single binary, CMake, CTest, stdlib only.
+
+max_review_iterations: 1
+timeout_sec: 1800
+
+assertions:
+  # Per-component source files. Architect's stack_contract enumerates
+  # the exact paths; we spot-check the canonical line/word/byte counters.
+  - name: line_counter_present
+    path: src/counter/line_counter.cpp
+    predicate: file_exists
+    severity: warn   # naming may vary slightly (line.cpp vs line_counter.cpp)
+
+  - name: word_counter_present
+    path: src/counter/word_counter.cpp
+    predicate: file_exists
+    severity: warn
+
+  - name: byte_counter_present
+    path: src/counter/byte_counter.cpp
+    predicate: file_exists
+    severity: warn
+
+  # Header companions are conventional in C++ — at minimum line_counter
+  # should have one even if architect chose a header-only style.
+  - name: line_counter_header
+    path: src/counter/line_counter.h
+    predicate: file_exists
+    severity: warn
+
+  # Per-component unit tests
+  - name: line_counter_test_present
+    path: tests/test_line_counter.cpp
+    predicate: file_exists
+    severity: warn
+
+  - name: word_counter_test_present
+    path: tests/test_word_counter.cpp
+    predicate: file_exists
+    severity: warn
+
+  # Implementation MUST NOT write src/main.cpp (entry — main_entry's job).
+  # Captured at severity=warn matching the same dev-overreach signal we
+  # documented in PR #140 for python_cli/typescript/go.
+  - name: implementation_does_not_write_main
+    path: src/main.cpp
+    predicate: { forbidden_patterns: { patterns: ["int\\s+main\\s*\\("] } }
+    severity: warn

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/implementation/input/CMakeLists.txt
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/implementation/input/CMakeLists.txt
@@ -1,0 +1,122 @@
+cmake_minimum_required(VERSION 3.14)
+project(wc-tool VERSION 1.0.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Static library — all subsystem source compiled once
+add_library(wc-tool-lib
+    src/input/arg_parser.cpp
+    src/input/file_opener.cpp
+    src/counter/line_counter.cpp
+    src/counter/word_counter.cpp
+    src/counter/byte_counter.cpp
+    src/counter/combined_counter.cpp
+    src/output/formatter.cpp
+)
+target_include_directories(wc-tool-lib PUBLIC src)
+
+# Main executable
+add_executable(wc-tool src/main.cpp)
+target_link_libraries(wc-tool PRIVATE wc-tool-lib)
+
+# Unit test executables — each links against the shared library
+add_executable(test_line_counter tests/test_line_counter.cpp)
+target_link_libraries(test_line_counter PRIVATE wc-tool-lib)
+
+add_executable(test_word_counter tests/test_word_counter.cpp)
+target_link_libraries(test_word_counter PRIVATE wc-tool-lib)
+
+add_executable(test_byte_counter tests/test_byte_counter.cpp)
+target_link_libraries(test_byte_counter PRIVATE wc-tool-lib)
+
+add_executable(test_combined_counter tests/test_combined_counter.cpp)
+target_link_libraries(test_combined_counter PRIVATE wc-tool-lib)
+
+add_executable(test_arg_parser tests/test_arg_parser.cpp)
+target_link_libraries(test_arg_parser PRIVATE wc-tool-lib)
+
+add_executable(test_file_opener tests/test_file_opener.cpp)
+target_link_libraries(test_file_opener PRIVATE wc-tool-lib)
+
+add_executable(test_output_formatter tests/test_output_formatter.cpp)
+target_link_libraries(test_output_formatter PRIVATE wc-tool-lib)
+
+# E2E test executables — each links against the shared library
+add_executable(test_e2e_normal_file tests/test_e2e_normal_file.cpp)
+target_link_libraries(test_e2e_normal_file PRIVATE wc-tool-lib)
+
+add_executable(test_e2e_empty_file tests/test_e2e_empty_file.cpp)
+target_link_libraries(test_e2e_empty_file PRIVATE wc-tool-lib)
+
+add_executable(test_e2e_no_argument tests/test_e2e_no_argument.cpp)
+target_link_libraries(test_e2e_no_argument PRIVATE wc-tool-lib)
+
+add_executable(test_e2e_file_not_found tests/test_e2e_file_not_found.cpp)
+target_link_libraries(test_e2e_file_not_found PRIVATE wc-tool-lib)
+
+add_executable(test_e2e_no_trailing_newline tests/test_e2e_no_trailing_newline.cpp)
+target_link_libraries(test_e2e_no_trailing_newline PRIVATE wc-tool-lib)
+
+# === Scenario integration tests (tests/scenarios/) ===
+add_executable(scenario_line_counter tests/scenarios/test_line_counter.cpp)
+target_link_libraries(scenario_line_counter PRIVATE wc-tool-lib)
+
+add_executable(scenario_word_counter tests/scenarios/test_word_counter.cpp)
+target_link_libraries(scenario_word_counter PRIVATE wc-tool-lib)
+
+add_executable(scenario_byte_counter tests/scenarios/test_byte_counter.cpp)
+target_link_libraries(scenario_byte_counter PRIVATE wc-tool-lib)
+
+add_executable(scenario_arg_parser tests/scenarios/test_arg_parser.cpp)
+target_link_libraries(scenario_arg_parser PRIVATE wc-tool-lib)
+
+add_executable(scenario_output_formatter tests/scenarios/test_output_formatter.cpp)
+target_link_libraries(scenario_output_formatter PRIVATE wc-tool-lib)
+
+add_executable(scenario_e2e_normal_file tests/scenarios/e2e_normal_file.cpp)
+target_link_libraries(scenario_e2e_normal_file PRIVATE wc-tool-lib)
+
+add_executable(scenario_e2e_empty_file tests/scenarios/e2e_empty_file.cpp)
+target_link_libraries(scenario_e2e_empty_file PRIVATE wc-tool-lib)
+
+add_executable(scenario_e2e_no_argument tests/scenarios/e2e_no_argument.cpp)
+target_link_libraries(scenario_e2e_no_argument PRIVATE wc-tool-lib)
+
+add_executable(scenario_e2e_file_not_found tests/scenarios/e2e_file_not_found.cpp)
+target_link_libraries(scenario_e2e_file_not_found PRIVATE wc-tool-lib)
+
+add_executable(scenario_e2e_no_trailing_newline tests/scenarios/e2e_no_trailing_newline.cpp)
+target_link_libraries(scenario_e2e_no_trailing_newline PRIVATE wc-tool-lib)
+
+# Enable testing
+enable_testing()
+
+# Unit tests
+add_test(NAME LineCounterTest COMMAND test_line_counter)
+add_test(NAME WordCounterTest COMMAND test_word_counter)
+add_test(NAME ByteCounterTest COMMAND test_byte_counter)
+add_test(NAME CombinedCounterTest COMMAND test_combined_counter)
+add_test(NAME ArgParserTest COMMAND test_arg_parser)
+add_test(NAME OutputFormatterTest COMMAND test_output_formatter)
+add_test(NAME FileOpenerTest COMMAND test_file_opener)
+
+# E2E unit tests
+add_test(NAME E2ENormalFileTest COMMAND test_e2e_normal_file)
+add_test(NAME E2EEmptyFileTest COMMAND test_e2e_empty_file)
+add_test(NAME E2ENoArgumentTest COMMAND test_e2e_no_argument)
+add_test(NAME E2EFileNotFoundTest COMMAND test_e2e_file_not_found)
+add_test(NAME E2ENoTrailingNewlineTest COMMAND test_e2e_no_trailing_newline)
+
+# Scenario integration tests
+add_test(NAME ScenarioLineCounterTest COMMAND scenario_line_counter)
+add_test(NAME ScenarioWordCounterTest COMMAND scenario_word_counter)
+add_test(NAME ScenarioByteCounterTest COMMAND scenario_byte_counter)
+add_test(NAME ScenarioArgParserTest COMMAND scenario_arg_parser)
+add_test(NAME ScenarioOutputFormatterTest COMMAND scenario_output_formatter)
+add_test(NAME ScenarioE2ENormalFileTest COMMAND scenario_e2e_normal_file)
+add_test(NAME ScenarioE2EEmptyFileTest COMMAND scenario_e2e_empty_file)
+add_test(NAME ScenarioE2ENoArgumentTest COMMAND scenario_e2e_no_argument)
+add_test(NAME ScenarioE2EFileNotFoundTest COMMAND scenario_e2e_file_not_found)
+add_test(NAME ScenarioE2ENoTrailingNewlineTest COMMAND scenario_e2e_no_trailing_newline)

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/implementation/input/docs/architecture.md
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/implementation/input/docs/architecture.md
@@ -1,0 +1,526 @@
+# wc-tool 架构设计文档
+
+## 1. 概述
+
+本文档描述 wc-tool — 一个类 Unix `wc` 命令行工具 — 的架构设计。该工具读取指定文件，统计行数、单词数和字节数，并将结果输出到标准输出。
+
+## 2. 技术栈
+
+| 项目 | 选择 | 理由 |
+|------|------|------|
+| 语言 | C++17 | 标准库提供完整的文件系统、流处理、字符串处理能力 |
+| 构建系统 | CMake | 跨平台构建，与CTest原生集成，支持C++17标准 |
+| 测试框架 | CTest + cassert | 标准库断言，无第三方依赖，与CMake原生集成 |
+| 运行时依赖 | 无 | 仅使用C++标准库，单静态二进制，无动态链接 |
+| 代码风格 | C++17 严格模式 | 启用C++17，禁用扩展，确保可移植性 |
+
+## 3. 系统上下文 (C4 Context)
+
+```mermaid
+C4Context
+  title System Context - wc-tool
+  Person(user, "用户", "在命令行中运行wc-tool的终端用户")
+  System(wc_tool, "wc-tool", "命令行单词计数工具", "统计文件的行数、单词数和字节数")
+  System_Ext(file_system, "文件系统", "本地文件系统，提供输入文件")
+  System_Ext(shell, "命令行Shell", "Unix/Linux/macOS终端环境")
+
+  Rel(user, shell, "执行")
+  Rel(shell, wc_tool, "启动并传递参数")
+  Rel(wc_tool, file_system, "读取文件")
+  Rel(wc_tool, user, "输出结果到stdout")
+  
+  UpdateLayoutConfig()
+```
+
+## 4. 容器分解 (C4 Container)
+
+```mermaid
+C4Container
+  title Container View - wc-tool
+  System_Boundary(app, "wc-tool 应用") {
+    Component(main, "main.cpp", "入口点，协调各子系统", "C++")
+    Component(arg_parser, "arg_parser.cpp", "解析并验证命令行参数", "C++")
+    Component(file_opener, "file_opener.cpp", "打开文件流", "C++")
+    Component(line_counter, "line_counter.cpp", "统计换行符数量", "C++")
+    Component(word_counter, "word_counter.cpp", "统计单词数量", "C++")
+    Component(byte_counter, "byte_counter.cpp", "统计字节数量", "C++")
+    Component(formatter, "formatter.cpp", "格式化输出结果", "C++")
+  }
+  
+  Rel(main, arg_parser, "调用")
+  Rel(main, file_opener, "调用")
+  Rel(main, line_counter, "调用")
+  Rel(main, word_counter, "调用")
+  Rel(main, byte_counter, "调用")
+  Rel(main, formatter, "调用")
+  
+  UpdateLayoutConfig()
+```
+
+## 5. 组件分解 (C4 Component)
+
+```mermaid
+C4Component
+  title Component View - 内部组件关系
+  Container_Boundary(input_boundary, "输入子系统") {
+    Component(arg_parser, "arg_parser", "解析并验证命令行参数", "C++")
+    Component(file_opener, "file_opener", "打开文件流", "C++")
+  }
+  
+  Container_Boundary(counter_boundary, "计数子系统") {
+    Component(line_counter, "line_counter", "统计换行符数量", "C++")
+    Component(word_counter, "word_counter", "统计单词数量", "C++")
+    Component(byte_counter, "byte_counter", "统计字节数量", "C++")
+  }
+  
+  Container_Boundary(output_boundary, "输出子系统") {
+    Component(formatter, "formatter", "格式化输出结果", "C++")
+  }
+  
+  Rel(main, arg_parser, "parse_file_argument", "参数验证")
+  Rel(main, file_opener, "open_file", "文件打开")
+  Rel(main, line_counter, "count_lines", "行计数")
+  Rel(main, word_counter, "count_words", "词计数")
+  Rel(main, byte_counter, "count_bytes", "字节计数")
+  Rel(main, formatter, "print_result", "结果输出")
+  
+  UpdateLayoutConfig()
+```
+
+## 6. 数据模型
+
+### 6.1 输入数据
+
+```mermaid
+erDiagram
+    FILE {
+        string path "文件路径"
+        int64 size "文件大小（字节）"
+        int64 line_count "换行符数量"
+        int64 word_count "单词数量"
+        int64 byte_count "字节数量"
+    }
+    
+    COMMAND_LINE {
+        int argc "参数数量"
+        string* argv "参数数组"
+        string file_path "提取的文件路径"
+    }
+    
+    FILE ||--o{ COMMAND_LINE : "从命令行获取"
+```
+
+### 6.2 输出数据
+
+输出格式：`<lines> <words> <bytes> <filename>`
+
+```mermaid
+erDiagram
+    OUTPUT_RESULT {
+        int64 lines "行数"
+        int64 words "词数"
+        int64 bytes "字节数"
+        string filename "文件名"
+    }
+    
+    OUTPUT_RESULT ||--o{ STDOUT : "输出到标准输出"
+```
+
+## 7. 模块依赖关系
+
+```mermaid
+flowchart TD
+    subgraph src ["src/"]
+        main["src/main.cpp"]
+        input["src/input/"]
+        counter["src/counter/"]
+        output["src/output/"]
+    end
+    
+    main --> input
+    main --> counter
+    main --> output
+    counter --> input
+    
+    UpdateLayoutConfig()
+```
+
+## 8. 组件交互流程
+
+### 8.1 主流程
+
+```mermaid
+sequenceDiagram
+    participant Main as main.cpp
+    participant Arg as arg_parser
+    participant File as file_opener
+    participant Line as line_counter
+    participant Word as word_counter
+    participant Byte as byte_counter
+    participant Out as formatter
+
+    Main->>Arg: parse_file_argument(argc, argv)
+    Arg-->>Main: filepath
+    Main->>File: open_file(filepath)
+    File-->>Main: ifstream
+    Main->>Line: count_lines(stream)
+    Line-->>Main: lines
+    Main->>Word: count_words(stream)
+    Word-->>Main: words
+    Main->>Byte: count_bytes(stream)
+    Byte-->>Main: bytes
+    Main->>Out: print_result(lines, words, bytes, filepath)
+    Out->>Out: cout << lines << " " << words << " " << bytes << " " << filename
+```
+
+### 8.2 错误处理流程
+
+```mermaid
+flowchart LR
+  A["用户执行 wc-tool"] --> B{"参数有效?"}
+  B -->|否| C["输出错误到stderr"]
+  C --> D["退出码1"]
+  B -->|是| E{"文件存在?"}
+  E -->|否| F["输出错误到stderr"]
+  F --> D
+  E -->|是| G["读取文件"]
+  G --> H["统计行数"]
+  H --> I["统计词数"]
+  I --> J["统计字节数"]
+  J --> K["输出结果"]
+```
+
+## 9. 测试架构
+
+### 9.1 单元测试
+
+| 测试名称 | 测试可执行文件 | 测试内容 | CTest 名称 |
+|----------|---------------|---------|-----------|
+| 行计数 | test_line_counter | FR-002 | LineCounterTest |
+| 单词计数 | test_word_counter | FR-003 | WordCounterTest |
+| 字节计数 | test_byte_counter | FR-004 | ByteCounterTest |
+| 参数解析 | test_arg_parser | FR-001 | ArgParserTest |
+| 输出格式化 | test_output_formatter | FR-005 | OutputFormatterTest |
+
+### 9.2 端到端测试 — 独立可执行
+
+每个端到端场景拥有**独立的测试可执行文件**和**唯一的 CTest 测试名**，确保可以通过 `ctest -R <name>` 单独执行：
+
+| 场景 ID | 描述 | CTest 名称 | 测试可执行文件 |
+|---------|------|-----------|---------------|
+| e2e_normal_file | 正常文件处理 | E2ENormalFileTest | test_e2e_normal_file |
+| e2e_empty_file | 空文件处理 | E2EEmptyFileTest | test_e2e_empty_file |
+| e2e_no_argument | 缺少参数 | E2ENoArgumentTest | test_e2e_no_argument |
+| e2e_file_not_found | 文件不存在 | E2EFileNotFoundTest | test_e2e_file_not_found |
+| e2e_no_trailing_newline | 无尾部换行符 | E2ENoTrailingNewlineTest | test_e2e_no_trailing_newline |
+
+```mermaid
+flowchart LR
+    subgraph unit_tests ["单元测试"]
+        tlc["LineCounterTest"]
+        twc["WordCounterTest"]
+        tbc["ByteCounterTest"]
+        tap["ArgParserTest"]
+        tof["OutputFormatterTest"]
+    end
+
+    subgraph e2e_tests ["端到端测试 — 独立可执行"]
+        en["E2ENormalFileTest"]
+        ee["E2EEmptyFileTest"]
+        ea["E2ENoArgumentTest"]
+        ef["E2EFileNotFoundTest"]
+        et["E2ENoTrailingNewlineTest"]
+    end
+
+    tlc -.->|依赖| en
+    twc -.->|依赖| en
+    tbc -.->|依赖| en
+    tap -.->|依赖| ea
+    tap -.->|依赖| ef
+    tof -.->|依赖| et
+```
+
+### 9.3 测试执行命令
+
+每个测试可独立执行：
+
+```
+ctest --test-dir build --output-on-failure --verbose -R E2ENormalFile
+ctest --test-dir build --output-on-failure --verbose -R E2EEmptyFile
+ctest --test-dir build --output-on-failure --verbose -R E2ENoArgument
+ctest --test-dir build --output-on-failure --verbose -R E2EFileNotFound
+ctest --test-dir build --output-on-failure --verbose -R E2ENoTrailingNewline
+```
+
+所有测试一起执行：
+
+```
+ctest --test-dir build --output-on-failure --verbose
+```
+
+## 9. 子系统详细设计
+
+### 9.1 输入子系统 (input)
+
+**职责**: 命令行参数解析和文件打开
+
+**组件**:
+- `arg_parser`: 验证argc == 2，提取argv[1]作为文件路径
+- `file_opener`: 使用`std::ifstream`以二进制模式打开文件
+
+**公共接口**:
+```cpp
+// arg_parser.h
+namespace input {
+    std::string parse_file_argument(int argc, char* argv[]);
+}
+
+// file_opener.h
+namespace input {
+    std::ifstream open_file(const std::string& path);
+}
+```
+
+### 9.2 计数子系统 (counter)
+
+**职责**: 行计数、单词计数和字节计数算法
+
+**组件**:
+- `line_counter`: 遍历文件流，统计'\n'字符数量
+- `word_counter`: 遍历文件流，统计非空白字符序列数量
+- `byte_counter`: 遍历文件流，统计所有字符数量
+
+**公共接口**:
+```cpp
+// line_counter.h
+namespace counter {
+    std::intmax_t count_lines(std::istream& stream);
+}
+
+// word_counter.h
+namespace counter {
+    std::intmax_t count_words(std::istream& stream);
+}
+
+// byte_counter.h
+namespace counter {
+    std::intmax_t count_bytes(std::istream& stream);
+}
+```
+
+### 9.3 输出子系统 (output)
+
+**职责**: 格式化并打印结果
+
+**组件**:
+- `formatter`: 将统计结果格式化为`<lines> <words> <bytes> <filename>`格式并输出到stdout
+
+**公共接口**:
+```cpp
+// formatter.h
+namespace output {
+    void print_result(std::intmax_t lines, std::intmax_t words, std::intmax_t bytes, const std::string& filename);
+}
+```
+
+## 10. 构建系统
+
+### 10.1 CMakeLists.txt
+
+```cmake
+cmake_minimum_required(VERSION 3.14)
+project(wc-tool VERSION 1.0.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# 主可执行文件
+add_executable(wc-tool
+    src/main.cpp
+    src/input/arg_parser.cpp
+    src/input/file_opener.cpp
+    src/counter/line_counter.cpp
+    src/counter/word_counter.cpp
+    src/counter/byte_counter.cpp
+    src/output/formatter.cpp
+)
+
+target_include_directories(wc-tool PRIVATE src)
+
+# 单元测试可执行文件
+add_executable(test_line_counter tests/test_line_counter.cpp)
+target_include_directories(test_line_counter PRIVATE src)
+
+add_executable(test_word_counter tests/test_word_counter.cpp)
+target_include_directories(test_word_counter PRIVATE src)
+
+add_executable(test_byte_counter tests/test_byte_counter.cpp)
+target_include_directories(test_byte_counter PRIVATE src)
+
+add_executable(test_arg_parser tests/test_arg_parser.cpp)
+target_include_directories(test_arg_parser PRIVATE src)
+
+add_executable(test_output_formatter tests/test_output_formatter.cpp)
+target_include_directories(test_output_formatter PRIVATE src)
+
+# 端到端测试 — 每个场景独立可执行文件
+add_executable(test_e2e_normal_file tests/test_e2e_normal_file.cpp)
+target_include_directories(test_e2e_normal_file PRIVATE src)
+
+add_executable(test_e2e_empty_file tests/test_e2e_empty_file.cpp)
+target_include_directories(test_e2e_empty_file PRIVATE src)
+
+add_executable(test_e2e_no_argument tests/test_e2e_no_argument.cpp)
+target_include_directories(test_e2e_no_argument PRIVATE src)
+
+add_executable(test_e2e_file_not_found tests/test_e2e_file_not_found.cpp)
+target_include_directories(test_e2e_file_not_found PRIVATE src)
+
+add_executable(test_e2e_no_trailing_newline tests/test_e2e_no_trailing_newline.cpp)
+target_include_directories(test_e2e_no_trailing_newline PRIVATE src)
+
+# 启用测试
+enable_testing()
+
+add_test(NAME LineCounterTest COMMAND test_line_counter)
+add_test(NAME WordCounterTest COMMAND test_word_counter)
+add_test(NAME ByteCounterTest COMMAND test_byte_counter)
+add_test(NAME ArgParserTest COMMAND test_arg_parser)
+add_test(NAME OutputFormatterTest COMMAND test_output_formatter)
+
+# 端到端测试 — 每个场景独立的 CTest 名称
+add_test(NAME E2ENormalFileTest COMMAND test_e2e_normal_file)
+add_test(NAME E2EEmptyFileTest COMMAND test_e2e_empty_file)
+add_test(NAME E2ENoArgumentTest COMMAND test_e2e_no_argument)
+add_test(NAME E2EFileNotFoundTest COMMAND test_e2e_file_not_found)
+add_test(NAME E2ENoTrailingNewlineTest COMMAND test_e2e_no_trailing_newline)
+```
+
+### 10.2 测试执行
+
+每个测试可独立执行：
+
+```
+ctest --test-dir build --output-on-failure --verbose -R E2ENormalFileTest
+ctest --test-dir build --output-on-failure --verbose -R E2EEmptyFileTest
+ctest --test-dir build --output-on-failure --verbose -R E2ENoArgumentTest
+ctest --test-dir build --output-on-failure --verbose -R E2EFileNotFoundTest
+ctest --test-dir build --output-on-failure --verbose -R E2ENoTrailingNewlineTest
+```
+
+所有测试一起执行：
+
+```
+ctest --test-dir build --output-on-failure --verbose
+```
+
+## 11. 测试策略
+
+### 11.1 单元测试
+
+每个计数原语有独立的测试可执行文件：
+
+| 测试名称 | 测试文件 | 测试内容 |
+|---------|---------|---------|
+| LineCounterTest | tests/test_line_counter.cpp | 空文件、单行、多行、无换行符、连续换行符 |
+| WordCounterTest | tests/test_word_counter.cpp | 空文件、单词、多词、连续空格、制表符、换行符、纯空白 |
+| ByteCounterTest | tests/test_byte_counter.cpp | 空文件、单字节、多字节、换行符、混合内容 |
+| ArgParserTest | tests/test_arg_parser.cpp | 有效参数、缺少参数、过多参数 |
+| OutputFormatterTest | tests/test_output_formatter.cpp | 正常输出、零值、大数值 |
+
+### 11.2 端到端测试
+
+每个端到端场景拥有**独立的测试可执行文件**和**唯一的 CTest 测试名**，确保可以通过 `ctest -R <name>` 单独执行：
+
+| 场景 ID | 描述 | CTest 名称 | 测试可执行文件 |
+|---------|------|-----------|---------------|
+| e2e_normal_file | 正常文件处理 | E2ENormalFileTest | test_e2e_normal_file |
+| e2e_empty_file | 空文件处理 | E2EEmptyFileTest | test_e2e_empty_file |
+| e2e_no_argument | 缺少参数 | E2ENoArgumentTest | test_e2e_no_argument |
+| e2e_file_not_found | 文件不存在 | E2EFileNotFoundTest | test_e2e_file_not_found |
+| e2e_no_trailing_newline | 无尾部换行符 | E2ENoTrailingNewlineTest | test_e2e_no_trailing_newline |
+
+```mermaid
+flowchart LR
+    subgraph unit_tests ["单元测试"]
+        tlc["LineCounterTest"]
+        twc["WordCounterTest"]
+        tbc["ByteCounterTest"]
+        tap["ArgParserTest"]
+        tof["OutputFormatterTest"]
+    end
+
+    subgraph e2e_tests ["端到端测试 — 独立可执行"]
+        en["E2ENormalFileTest"]
+        ee["E2EEmptyFileTest"]
+        ea["E2ENoArgumentTest"]
+        ef["E2EFileNotFoundTest"]
+        et["E2ENoTrailingNewlineTest"]
+    end
+
+    tlc -.->|依赖| en
+    twc -.->|依赖| en
+    tbc -.->|依赖| en
+    tap -.->|依赖| ea
+    tap -.->|依赖| ef
+    tof -.->|依赖| et
+```
+
+## 12. 错误处理
+
+| 错误场景 | 处理方式 | 错误位置 |
+|---------|---------|---------|
+| 无参数 | 输出"Usage: wc-tool <file>"到stderr，exit(1) | arg_parser |
+| 文件不存在 | 输出"Cannot open file: <path>"到stderr，exit(1) | file_opener |
+| 文件无法读取 | 输出"Cannot open file: <path>"到stderr，exit(1) | file_opener |
+
+## 13. 启动序列
+
+```mermaid
+sequenceDiagram
+    participant Main as main.cpp
+    participant Arg as arg_parser
+    participant File as file_opener
+    participant Line as line_counter
+    participant Word as word_counter
+    participant Byte as byte_counter
+    participant Out as formatter
+
+    Note over Main: 构造阶段
+    Main->>Arg: 初始化
+    Main->>File: 初始化
+    Main->>Line: 初始化
+    Main->>Word: 初始化
+    Main->>Byte: 初始化
+    Main->>Out: 初始化
+
+    Note over Main: 主循环阶段
+    Main->>Arg: parse_file_argument(argc, argv)
+    Arg-->>Main: filepath
+    Main->>File: open_file(filepath)
+    File-->>Main: ifstream
+    Main->>Line: count_lines(stream)
+    Line-->>Main: lines
+    Main->>Word: count_words(stream)
+    Word-->>Main: words
+    Main->>Byte: count_bytes(stream)
+    Byte-->>Main: bytes
+    Main->>Out: print_result(lines, words, bytes, filepath)
+    Out->>Out: cout << lines << " " << words << " " << bytes << " " << filename
+    Main->>Main: return 0
+```
+
+## 14. 性能考虑
+
+- 使用`std::istream::get()`逐字符读取，O(1)内存复杂度
+- 每个计数操作独立遍历文件，通过`seekg()`重置流位置
+- 对于大文件（GB级别），流处理确保内存使用恒定
+- 无动态内存分配，无堆分配
+
+## 15. 可移植性
+
+- 仅使用C++17标准库
+- 使用`std::filesystem`和`std::isspace`确保跨平台兼容
+- 支持Linux (glibc)、macOS (Apple clang)
+- 无平台特定API调用

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/implementation/input/docs/behavioral_contract.json
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/implementation/input/docs/behavioral_contract.json
@@ -1,0 +1,164 @@
+{
+  "scenarios": [
+    {
+      "id": "test_line_counter",
+      "name": "行计数单元测试",
+      "description": "测试行计数器的基本功能：空文件返回0，有换行符的文件正确计数，没有尾部换行符的文件正确计数",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R LineCounterTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-002"]
+    },
+    {
+      "id": "test_word_counter",
+      "name": "单词计数单元测试",
+      "description": "测试单词计数器的基本功能：空文件返回0，多个连续空格不产生额外单词，正确统计单词数",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R WordCounterTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-003"]
+    },
+    {
+      "id": "test_byte_counter",
+      "name": "字节计数单元测试",
+      "description": "测试字节计数器的基本功能：空文件返回0，正确统计文件字节数",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R ByteCounterTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-004"]
+    },
+    {
+      "id": "test_arg_parser",
+      "name": "参数解析单元测试",
+      "description": "测试参数解析器：正确参数返回文件路径，缺少参数抛出异常",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R ArgParserTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-001"]
+    },
+    {
+      "id": "test_output_formatter",
+      "name": "输出格式化单元测试",
+      "description": "测试输出格式化器：正确格式化并输出结果",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R OutputFormatterTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-005"]
+    },
+    {
+      "id": "e2e_normal_file",
+      "name": "端到端测试：正常文件处理",
+      "description": "端到端测试：使用wc-tool处理一个包含多行多词的文本文件，验证输出格式正确",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R E2ENormalFileTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-001", "FR-002", "FR-003", "FR-004", "FR-005"]
+    },
+    {
+      "id": "e2e_empty_file",
+      "name": "端到端测试：空文件处理",
+      "description": "端到端测试：使用wc-tool处理空文件，验证输出为 0 0 0 filename",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R E2EEmptyFileTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-002", "FR-003", "FR-004"]
+    },
+    {
+      "id": "e2e_no_argument",
+      "name": "端到端测试：缺少参数",
+      "description": "端到端测试：使用wc-tool不带参数运行，验证输出错误信息到stderr并返回非零退出码",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R E2ENoArgumentTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-001"]
+    },
+    {
+      "id": "e2e_file_not_found",
+      "name": "端到端测试：文件不存在",
+      "description": "端到端测试：使用wc-tool处理不存在的文件，验证输出错误信息到stderr并返回非零退出码",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R E2EFileNotFoundTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-001"]
+    },
+    {
+      "id": "e2e_no_trailing_newline",
+      "name": "端到端测试：无尾部换行符",
+      "description": "端到端测试：使用wc-tool处理没有尾部换行符的文件，验证wc兼容的行计数",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R E2ENoTrailingNewlineTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-002", "FR-003", "FR-004", "FR-005"]
+    }
+  ]
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/implementation/input/docs/requirement.md
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/implementation/input/docs/requirement.md
@@ -1,0 +1,251 @@
+# Requirement Specification — wc-tool
+
+## 功能需求
+
+### FR-001: File Input and Argument Parsing
+
+The tool accepts a single positional argument that specifies the path to the file to be
+analysed.
+
+- **FR-001.1** The tool MUST accept exactly one file path argument on the command line.
+- **FR-001.2** If no argument is provided, the tool MUST print an error message to
+  **stderr** and exit with a non-zero status code.
+- **FR-001.3** If the file does not exist or cannot be opened, the tool MUST print an
+  error message to **stderr** and exit with a non-zero status code.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_invoke(("Invoke wc-tool"))
+  uc_parse(("Parse file argument"))
+  uc_validate(("Validate file exists"))
+  actor_user --> uc_invoke
+  uc_invoke --> uc_parse
+  uc_parse --> uc_validate
+  uc_validate -->|missing arg| uc_error
+  uc_validate -->|file not found| uc_error
+  uc_error(["Error to stderr"])
+```
+
+### FR-002: Line Count
+
+The tool MUST count the number of newline characters (`\n`) in the file and report the
+result as the first integer in its output.
+
+- **FR-002.1** Each newline character (`\n`) in the file contributes exactly one to the
+  line count.
+- **FR-002.2** A file that is empty (zero bytes) MUST produce a line count of `0`.
+- **FR-002.3** A file whose last character is not a newline MUST still be counted as
+  containing one additional line (matching `wc` semantics).
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_read(("Read file"))
+  uc_count_lines(("Count lines"))
+  uc_report(("Report line count"))
+  actor_user --> uc_read
+  uc_read --> uc_count_lines
+  uc_count_lines --> uc_report
+```
+
+### FR-003: Word Count
+
+The tool MUST count the number of whitespace-delimited words in the file.
+
+- **FR-003.1** A word is defined as a maximal sequence of non-whitespace characters.
+  Whitespace characters are those recognised by `std::isspace` (space, tab, newline,
+  carriage return, form feed, vertical tab).
+- **FR-003.2** Empty files MUST produce a word count of `0`.
+- **FR-003.3** Multiple consecutive whitespace characters MUST NOT produce extra words.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_read(("Read file"))
+  uc_count_words(("Count words"))
+  uc_report(("Report word count"))
+  actor_user --> uc_read
+  uc_read --> uc_count_words
+  uc_count_words --> uc_report
+```
+
+### FR-004: Byte Count
+
+The tool MUST report the total number of bytes in the file.
+
+- **FR-004.1** The byte count is the file size in bytes as reported by the operating
+  system (e.g. `std::filesystem::file_size` or reading until EOF).
+- **FR-004.2** An empty file MUST produce a byte count of `0`.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_read(("Read file"))
+  uc_count_bytes(("Count bytes"))
+  uc_report(("Report byte count"))
+  actor_user --> uc_read
+  uc_read --> uc_count_bytes
+  uc_count_bytes --> uc_report
+```
+
+### FR-005: Output Format
+
+The tool MUST print three integers (lines, words, bytes) separated by single spaces,
+followed by the filename, to stdout.
+
+- **FR-005.1** The output format is: `<lines> <words> <bytes> <filename>`
+- **FR-005.2** Fields are separated by exactly one space.
+- **FR-005.3** The filename printed is the user-provided argument, not a canonicalised path.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_compute(("Compute statistics"))
+  uc_format(("Format output"))
+  uc_print(("Print to stdout"))
+  actor_user --> uc_compute
+  uc_compute --> uc_format
+  uc_format --> uc_print
+```
+
+### FR-006: Build System
+
+The project MUST be buildable with CMake using C++17 as the strict language standard,
+producing a single static binary with no runtime dependencies.
+
+- **FR-006.1** A `CMakeLists.txt` file exists at the project root.
+- **FR-006.2** The build system enforces C++17 via `set(CMAKE_CXX_STANDARD 17)`.
+- **FR-006.3** The build produces a single static binary with no runtime dependencies.
+
+```mermaid
+flowchart LR
+  actor_dev(["👤 Developer"])
+  uc_cmake(("Configure CMake"))
+  uc_build(("Build binary"))
+  uc_verify(("Verify binary"))
+  actor_dev --> uc_cmake
+  uc_cmake --> uc_build
+  uc_build --> uc_verify
+```
+
+### FR-007: Unit Tests
+
+The project MUST include unit tests for each counting primitive using the CTest framework
+with no third-party dependencies.
+
+- **FR-007.1** Separate test executables exist for line-count, word-count, and byte-count.
+- **FR-007.2** Tests are registered with `add_test` in CMake.
+- **FR-007.3** No third-party testing frameworks are used.
+
+```mermaid
+flowchart LR
+  actor_dev(["👤 Developer"])
+  uc_write_tests(("Write unit tests"))
+  uc_register(("Register with CTest"))
+  uc_run(("Run tests"))
+  actor_dev --> uc_write_tests
+  uc_write_tests --> uc_register
+  uc_register --> uc_run
+```
+
+## 非功能需求
+
+### NFR-001: Performance
+
+The tool reads the input file exactly once, processes files of at least 1 GB within
+30 seconds on standard hardware, and uses O(1) memory with respect to file size
+via streaming read.
+
+### NFR-002: Portability
+
+The tool compiles and runs on Linux (glibc) and macOS (Apple clang) using C++17,
+and is relocatable with no hardcoded paths.
+
+### NFR-003: Reliability
+
+The tool handles binary files gracefully without crashing and does not produce
+undefined behaviour on empty files, very large files, or files with unusual encodings.
+
+## 用例
+
+### UC-001: Count File Statistics
+
+**Actor:** User
+**Goal:** Obtain line, word, and byte counts for a given file.
+**Preconditions:** A file exists and is readable.
+**Main Flow:**
+1. User invokes `wc-tool <file_path>`.
+2. The tool opens the file for reading.
+3. The tool reads the file once, counting lines, words, and bytes.
+4. The tool prints the results to stdout.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_run(("Run wc-tool"))
+  uc_open(("Open file"))
+  uc_read(("Read and count"))
+  uc_output(("Output results"))
+  actor_user --> uc_run
+  uc_run --> uc_open
+  uc_open --> uc_read
+  uc_read --> uc_output
+```
+
+Covers: FR-001, FR-002, FR-003, FR-004, FR-005
+
+### UC-002: Handle Missing File Argument
+
+**Actor:** User
+**Goal:** Receive an error message when no file argument is provided.
+**Preconditions:** None.
+**Main Flow:**
+1. User invokes `wc-tool` without arguments.
+2. The tool detects the missing argument.
+3. The tool prints an error message to stderr.
+4. The tool exits with a non-zero status code.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_run(("Run wc-tool"))
+  uc_check(("Check arguments"))
+  uc_error(("Print error to stderr"))
+  uc_exit(("Exit with non-zero"))
+  actor_user --> uc_run
+  uc_run --> uc_check
+  uc_check -->|no args| uc_error
+  uc_error --> uc_exit
+```
+
+Covers: FR-001
+
+### UC-003: Handle Non-Existent File
+
+**Actor:** User
+**Goal:** Receive an error message when the specified file does not exist.
+**Preconditions:** None.
+**Main Flow:**
+1. User invokes `wc-tool <nonexistent_file>`.
+2. The tool attempts to open the file.
+3. The tool detects the file does not exist.
+4. The tool prints an error message to stderr.
+5. The tool exits with a non-zero status code.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_run(("Run wc-tool"))
+  uc_open(("Open file"))
+  uc_check(("Check if exists"))
+  uc_error(("Print error to stderr"))
+  uc_exit(("Exit with non-zero"))
+  actor_user --> uc_run
+  uc_run --> uc_open
+  uc_open --> uc_check
+  uc_check -->|not found| uc_error
+  uc_error --> uc_exit
+```
+
+Covers: FR-001

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/implementation/input/docs/requirement_contract.json
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/implementation/input/docs/requirement_contract.json
@@ -1,0 +1,156 @@
+{
+  "project_name": "wc-tool",
+  "summary": "A C++17 command-line tool that computes line count, word count, and byte count for a given file, mirroring the Unix wc utility. Built with CMake, tested with CTest, producing a single static binary with no runtime dependencies beyond the C++ standard library.",
+  "functional_requirements": [
+    {
+      "id": "FR-001",
+      "title": "File Input and Argument Parsing",
+      "description": "The tool accepts a single positional argument specifying the file path. It must validate the argument exists and the file is readable, printing errors to stderr and exiting non-zero on failure.",
+      "acceptance_criteria": [
+        "Exactly one file path argument is accepted",
+        "No argument produces an error to stderr with non-zero exit",
+        "Non-existent file produces an error to stderr with non-zero exit"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-002",
+      "title": "Line Count",
+      "description": "The tool counts newline characters as lines, with wc-compatible semantics: empty file yields 0, and a file without a trailing newline still counts the last line.",
+      "acceptance_criteria": [
+        "Each newline character contributes exactly one to line count",
+        "Empty file produces line count of 0",
+        "File without trailing newline still counts the final line"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-003",
+      "title": "Word Count",
+      "description": "The tool counts whitespace-delimited words where a word is a maximal sequence of non-whitespace characters. Multiple consecutive whitespace characters do not produce extra words.",
+      "acceptance_criteria": [
+        "A word is a maximal sequence of non-whitespace characters",
+        "Empty file produces word count of 0",
+        "Multiple consecutive whitespace characters do not produce extra words"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-004",
+      "title": "Byte Count",
+      "description": "The tool reports the total number of bytes in the file, equivalent to the file size in bytes as reported by the operating system.",
+      "acceptance_criteria": [
+        "Byte count equals the file size in bytes",
+        "Empty file produces byte count of 0"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-005",
+      "title": "Output Format",
+      "description": "The tool prints three integers (lines, words, bytes) separated by single spaces, followed by the filename, to stdout.",
+      "acceptance_criteria": [
+        "Output format is: <lines> <words> <bytes> <filename>",
+        "Fields are separated by exactly one space",
+        "Filename printed is the user-provided argument, not a canonicalised path"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-006",
+      "title": "Build System",
+      "description": "The project is buildable with CMake using C++17 as the strict language standard, producing a single static binary with no runtime dependencies.",
+      "acceptance_criteria": [
+        "CMakeLists.txt exists at the project root",
+        "Build system enforces C++17",
+        "Build produces a single static binary with no runtime dependencies"
+      ],
+      "priority": "P1"
+    },
+    {
+      "id": "FR-007",
+      "title": "Unit Tests",
+      "description": "The project includes unit tests for each counting primitive using the CTest framework with no third-party dependencies. Separate test executables are registered with add_test.",
+      "acceptance_criteria": [
+        "Separate test executables exist for line-count, word-count, and byte-count",
+        "Tests are registered with add_test in CMake",
+        "No third-party testing frameworks are used"
+      ],
+      "priority": "P1"
+    }
+  ],
+  "non_functional_requirements": [
+    {
+      "id": "NFR-001",
+      "title": "Performance",
+      "description": "The tool reads the input file exactly once, processes files of at least 1 GB within 30 seconds on standard hardware, and uses O(1) memory with respect to file size via streaming read.",
+      "priority": "P1"
+    },
+    {
+      "id": "NFR-002",
+      "title": "Portability",
+      "description": "The tool compiles and runs on Linux (glibc) and macOS (Apple clang) using C++17, and is relocatable with no hardcoded paths.",
+      "priority": "P1"
+    },
+    {
+      "id": "NFR-003",
+      "title": "Reliability",
+      "description": "The tool handles binary files gracefully without crashing and does not produce undefined behaviour on empty files, very large files, or files with unusual encodings.",
+      "priority": "P1"
+    }
+  ],
+  "use_cases": [
+    {
+      "id": "UC-001",
+      "actor": "User",
+      "goal": "Obtain line, word, and byte counts for a given file.",
+      "preconditions": [
+        "A file exists and is readable"
+      ],
+      "main_flow": [
+        "User invokes wc-tool with a file path argument",
+        "The tool opens the file for reading",
+        "The tool reads the file once, counting lines, words, and bytes",
+        "The tool prints the results to stdout in the format: lines words bytes filename"
+      ],
+      "covers_requirements": [
+        "FR-001",
+        "FR-002",
+        "FR-003",
+        "FR-004",
+        "FR-005"
+      ]
+    },
+    {
+      "id": "UC-002",
+      "actor": "User",
+      "goal": "Receive an error message when no file argument is provided.",
+      "preconditions": [],
+      "main_flow": [
+        "User invokes wc-tool without arguments",
+        "The tool detects the missing argument",
+        "The tool prints an error message to stderr",
+        "The tool exits with a non-zero status code"
+      ],
+      "covers_requirements": [
+        "FR-001"
+      ]
+    },
+    {
+      "id": "UC-003",
+      "actor": "User",
+      "goal": "Receive an error message when the specified file does not exist.",
+      "preconditions": [],
+      "main_flow": [
+        "User invokes wc-tool with a non-existent file path",
+        "The tool attempts to open the file",
+        "The tool detects the file does not exist",
+        "The tool prints an error message to stderr",
+        "The tool exits with a non-zero status code"
+      ],
+      "covers_requirements": [
+        "FR-001"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/implementation/input/docs/stack_contract.json
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/implementation/input/docs/stack_contract.json
@@ -1,0 +1,74 @@
+{
+  "language": "cpp",
+  "runtime": "native",
+  "framework_backend": "",
+  "framework_frontend": "",
+  "package_manager": "cmake",
+  "project_config_file": "CMakeLists.txt",
+  "test_runner": "ctest",
+  "static_analyzer": ["clang-tidy"],
+  "entry_point": "src/main.cpp",
+  "run_command": "cmake -B build && cmake --build build && ./build/wc-tool",
+  "ui_required": false,
+  "ui_kind": "",
+  "subsystems": [
+    {
+      "name": "input",
+      "src_dir": "src/input",
+      "responsibilities": "命令行参数解析和文件打开",
+      "components": [
+        {
+          "name": "arg_parser",
+          "file": "src/input/arg_parser.cpp",
+          "test_file": "tests/test_arg_parser.cpp",
+          "responsibility": "解析并验证命令行参数"
+        },
+        {
+          "name": "file_opener",
+          "file": "src/input/file_opener.cpp",
+          "test_file": "tests/test_file_opener.cpp",
+          "responsibility": "打开文件流进行读取"
+        }
+      ]
+    },
+    {
+      "name": "counter",
+      "src_dir": "src/counter",
+      "responsibilities": "行计数、单词计数和字节计数算法实现",
+      "components": [
+        {
+          "name": "line_counter",
+          "file": "src/counter/line_counter.cpp",
+          "test_file": "tests/test_line_counter.cpp",
+          "responsibility": "统计换行符数量"
+        },
+        {
+          "name": "word_counter",
+          "file": "src/counter/word_counter.cpp",
+          "test_file": "tests/test_word_counter.cpp",
+          "responsibility": "统计单词数量"
+        },
+        {
+          "name": "byte_counter",
+          "file": "src/counter/byte_counter.cpp",
+          "test_file": "tests/test_byte_counter.cpp",
+          "responsibility": "统计字节数量"
+        }
+      ]
+    },
+    {
+      "name": "output",
+      "src_dir": "src/output",
+      "responsibilities": "格式化并打印结果到标准输出",
+      "components": [
+        {
+          "name": "formatter",
+          "file": "src/output/formatter.cpp",
+          "test_file": "tests/test_output_formatter.cpp",
+          "responsibility": "将统计结果格式化为指定格式"
+        }
+      ]
+    }
+  ],
+  "lifecycle_inits": []
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/implementation/project_config.json
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/implementation/project_config.json
@@ -1,0 +1,72 @@
+{
+  "project_name": "cpp_wc",
+  "development_mode": "local",
+  "process_type": "waterfall_v2",
+  "ui_language": "en",
+  "default_model": {
+    "provider": "Local",
+    "model": "qwen3.6-35b",
+    "api_key": "",
+    "base_url": "http://127.0.0.1:8088/v1",
+    "temperature": 0.7,
+    "max_tokens": 4096
+  },
+  "model_providers": [
+    {
+      "provider": "Local",
+      "api_key": "",
+      "base_url": "http://127.0.0.1:8088/v1",
+      "enabled": true
+    }
+  ],
+  "agents": {
+    "product_manager": {
+      "name": "product_manager",
+      "enabled": true
+    },
+    "architect": {
+      "name": "architect",
+      "enabled": true
+    },
+    "developer": {
+      "name": "developer",
+      "enabled": true
+    },
+    "qa_engineer": {
+      "name": "qa_engineer",
+      "enabled": true
+    },
+    "project_manager": {
+      "name": "project_manager",
+      "enabled": true
+    },
+    "rd_director": {
+      "name": "rd_director",
+      "enabled": true
+    }
+  },
+  "agent_model_selection": {},
+  "workflow": {
+    "max_review_iterations": 3,
+    "fail_on_review_rejection": false
+  },
+  "session": {
+    "max_concurrent_sessions": 5
+  },
+  "workspace": {
+    "projects_root": "projects",
+    "artifacts_root": "artifacts",
+    "auto_create_dirs": true
+  },
+  "logging": {
+    "level": "INFO",
+    "log_dir": "logs",
+    "json_format": false,
+    "rotate_daily": true
+  },
+  "github": {
+    "token": "",
+    "repo_owner": "",
+    "repo_name": ""
+  }
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/case.yaml
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/case.yaml
@@ -1,0 +1,40 @@
+aise_version: "0.1.0"
+scenario_id: cpp_wc_cli
+phase: main_entry
+
+input_dir: input/
+project_config_file: project_config.json
+
+requirement: |
+  Build a C++17 ``wc``-like CLI — wire main.cpp.
+
+max_review_iterations: 1
+timeout_sec: 1200
+
+assertions:
+  - name: main_present
+    path: src/main.cpp
+    predicate: file_exists
+
+  - name: main_substantial
+    path: src/main.cpp
+    predicate: { min_bytes: 100 }
+
+  # Canonical C++ entry shape — int main(...) with argc/argv.
+  - name: has_int_main
+    path: src/main.cpp
+    predicate: { regex_count: { pattern: "\\bint\\s+main\\s*\\(", min: 1 } }
+
+  - name: has_argc_or_argv
+    path: src/main.cpp
+    predicate: { contains_keywords: { any_of: [argc, argv] } }
+
+  # Wires the counters — at least references one of the counter modules
+  - name: wires_a_counter
+    path: src/main.cpp
+    predicate: { contains_keywords: { any_of: [line_counter, word_counter, byte_counter, combined_counter, "counter/"] } }
+
+  # Standard library i/o (no third-party deps allowed)
+  - name: uses_stdlib_io
+    path: src/main.cpp
+    predicate: { contains_keywords: { any_of: ["<iostream>", "<fstream>", "<cstdio>"] } }

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/CMakeLists.txt
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/CMakeLists.txt
@@ -1,0 +1,122 @@
+cmake_minimum_required(VERSION 3.14)
+project(wc-tool VERSION 1.0.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Static library — all subsystem source compiled once
+add_library(wc-tool-lib
+    src/input/arg_parser.cpp
+    src/input/file_opener.cpp
+    src/counter/line_counter.cpp
+    src/counter/word_counter.cpp
+    src/counter/byte_counter.cpp
+    src/counter/combined_counter.cpp
+    src/output/formatter.cpp
+)
+target_include_directories(wc-tool-lib PUBLIC src)
+
+# Main executable
+add_executable(wc-tool src/main.cpp)
+target_link_libraries(wc-tool PRIVATE wc-tool-lib)
+
+# Unit test executables — each links against the shared library
+add_executable(test_line_counter tests/test_line_counter.cpp)
+target_link_libraries(test_line_counter PRIVATE wc-tool-lib)
+
+add_executable(test_word_counter tests/test_word_counter.cpp)
+target_link_libraries(test_word_counter PRIVATE wc-tool-lib)
+
+add_executable(test_byte_counter tests/test_byte_counter.cpp)
+target_link_libraries(test_byte_counter PRIVATE wc-tool-lib)
+
+add_executable(test_combined_counter tests/test_combined_counter.cpp)
+target_link_libraries(test_combined_counter PRIVATE wc-tool-lib)
+
+add_executable(test_arg_parser tests/test_arg_parser.cpp)
+target_link_libraries(test_arg_parser PRIVATE wc-tool-lib)
+
+add_executable(test_file_opener tests/test_file_opener.cpp)
+target_link_libraries(test_file_opener PRIVATE wc-tool-lib)
+
+add_executable(test_output_formatter tests/test_output_formatter.cpp)
+target_link_libraries(test_output_formatter PRIVATE wc-tool-lib)
+
+# E2E test executables — each links against the shared library
+add_executable(test_e2e_normal_file tests/test_e2e_normal_file.cpp)
+target_link_libraries(test_e2e_normal_file PRIVATE wc-tool-lib)
+
+add_executable(test_e2e_empty_file tests/test_e2e_empty_file.cpp)
+target_link_libraries(test_e2e_empty_file PRIVATE wc-tool-lib)
+
+add_executable(test_e2e_no_argument tests/test_e2e_no_argument.cpp)
+target_link_libraries(test_e2e_no_argument PRIVATE wc-tool-lib)
+
+add_executable(test_e2e_file_not_found tests/test_e2e_file_not_found.cpp)
+target_link_libraries(test_e2e_file_not_found PRIVATE wc-tool-lib)
+
+add_executable(test_e2e_no_trailing_newline tests/test_e2e_no_trailing_newline.cpp)
+target_link_libraries(test_e2e_no_trailing_newline PRIVATE wc-tool-lib)
+
+# === Scenario integration tests (tests/scenarios/) ===
+add_executable(scenario_line_counter tests/scenarios/test_line_counter.cpp)
+target_link_libraries(scenario_line_counter PRIVATE wc-tool-lib)
+
+add_executable(scenario_word_counter tests/scenarios/test_word_counter.cpp)
+target_link_libraries(scenario_word_counter PRIVATE wc-tool-lib)
+
+add_executable(scenario_byte_counter tests/scenarios/test_byte_counter.cpp)
+target_link_libraries(scenario_byte_counter PRIVATE wc-tool-lib)
+
+add_executable(scenario_arg_parser tests/scenarios/test_arg_parser.cpp)
+target_link_libraries(scenario_arg_parser PRIVATE wc-tool-lib)
+
+add_executable(scenario_output_formatter tests/scenarios/test_output_formatter.cpp)
+target_link_libraries(scenario_output_formatter PRIVATE wc-tool-lib)
+
+add_executable(scenario_e2e_normal_file tests/scenarios/e2e_normal_file.cpp)
+target_link_libraries(scenario_e2e_normal_file PRIVATE wc-tool-lib)
+
+add_executable(scenario_e2e_empty_file tests/scenarios/e2e_empty_file.cpp)
+target_link_libraries(scenario_e2e_empty_file PRIVATE wc-tool-lib)
+
+add_executable(scenario_e2e_no_argument tests/scenarios/e2e_no_argument.cpp)
+target_link_libraries(scenario_e2e_no_argument PRIVATE wc-tool-lib)
+
+add_executable(scenario_e2e_file_not_found tests/scenarios/e2e_file_not_found.cpp)
+target_link_libraries(scenario_e2e_file_not_found PRIVATE wc-tool-lib)
+
+add_executable(scenario_e2e_no_trailing_newline tests/scenarios/e2e_no_trailing_newline.cpp)
+target_link_libraries(scenario_e2e_no_trailing_newline PRIVATE wc-tool-lib)
+
+# Enable testing
+enable_testing()
+
+# Unit tests
+add_test(NAME LineCounterTest COMMAND test_line_counter)
+add_test(NAME WordCounterTest COMMAND test_word_counter)
+add_test(NAME ByteCounterTest COMMAND test_byte_counter)
+add_test(NAME CombinedCounterTest COMMAND test_combined_counter)
+add_test(NAME ArgParserTest COMMAND test_arg_parser)
+add_test(NAME OutputFormatterTest COMMAND test_output_formatter)
+add_test(NAME FileOpenerTest COMMAND test_file_opener)
+
+# E2E unit tests
+add_test(NAME E2ENormalFileTest COMMAND test_e2e_normal_file)
+add_test(NAME E2EEmptyFileTest COMMAND test_e2e_empty_file)
+add_test(NAME E2ENoArgumentTest COMMAND test_e2e_no_argument)
+add_test(NAME E2EFileNotFoundTest COMMAND test_e2e_file_not_found)
+add_test(NAME E2ENoTrailingNewlineTest COMMAND test_e2e_no_trailing_newline)
+
+# Scenario integration tests
+add_test(NAME ScenarioLineCounterTest COMMAND scenario_line_counter)
+add_test(NAME ScenarioWordCounterTest COMMAND scenario_word_counter)
+add_test(NAME ScenarioByteCounterTest COMMAND scenario_byte_counter)
+add_test(NAME ScenarioArgParserTest COMMAND scenario_arg_parser)
+add_test(NAME ScenarioOutputFormatterTest COMMAND scenario_output_formatter)
+add_test(NAME ScenarioE2ENormalFileTest COMMAND scenario_e2e_normal_file)
+add_test(NAME ScenarioE2EEmptyFileTest COMMAND scenario_e2e_empty_file)
+add_test(NAME ScenarioE2ENoArgumentTest COMMAND scenario_e2e_no_argument)
+add_test(NAME ScenarioE2EFileNotFoundTest COMMAND scenario_e2e_file_not_found)
+add_test(NAME ScenarioE2ENoTrailingNewlineTest COMMAND scenario_e2e_no_trailing_newline)

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/docs/architecture.md
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/docs/architecture.md
@@ -1,0 +1,526 @@
+# wc-tool 架构设计文档
+
+## 1. 概述
+
+本文档描述 wc-tool — 一个类 Unix `wc` 命令行工具 — 的架构设计。该工具读取指定文件，统计行数、单词数和字节数，并将结果输出到标准输出。
+
+## 2. 技术栈
+
+| 项目 | 选择 | 理由 |
+|------|------|------|
+| 语言 | C++17 | 标准库提供完整的文件系统、流处理、字符串处理能力 |
+| 构建系统 | CMake | 跨平台构建，与CTest原生集成，支持C++17标准 |
+| 测试框架 | CTest + cassert | 标准库断言，无第三方依赖，与CMake原生集成 |
+| 运行时依赖 | 无 | 仅使用C++标准库，单静态二进制，无动态链接 |
+| 代码风格 | C++17 严格模式 | 启用C++17，禁用扩展，确保可移植性 |
+
+## 3. 系统上下文 (C4 Context)
+
+```mermaid
+C4Context
+  title System Context - wc-tool
+  Person(user, "用户", "在命令行中运行wc-tool的终端用户")
+  System(wc_tool, "wc-tool", "命令行单词计数工具", "统计文件的行数、单词数和字节数")
+  System_Ext(file_system, "文件系统", "本地文件系统，提供输入文件")
+  System_Ext(shell, "命令行Shell", "Unix/Linux/macOS终端环境")
+
+  Rel(user, shell, "执行")
+  Rel(shell, wc_tool, "启动并传递参数")
+  Rel(wc_tool, file_system, "读取文件")
+  Rel(wc_tool, user, "输出结果到stdout")
+  
+  UpdateLayoutConfig()
+```
+
+## 4. 容器分解 (C4 Container)
+
+```mermaid
+C4Container
+  title Container View - wc-tool
+  System_Boundary(app, "wc-tool 应用") {
+    Component(main, "main.cpp", "入口点，协调各子系统", "C++")
+    Component(arg_parser, "arg_parser.cpp", "解析并验证命令行参数", "C++")
+    Component(file_opener, "file_opener.cpp", "打开文件流", "C++")
+    Component(line_counter, "line_counter.cpp", "统计换行符数量", "C++")
+    Component(word_counter, "word_counter.cpp", "统计单词数量", "C++")
+    Component(byte_counter, "byte_counter.cpp", "统计字节数量", "C++")
+    Component(formatter, "formatter.cpp", "格式化输出结果", "C++")
+  }
+  
+  Rel(main, arg_parser, "调用")
+  Rel(main, file_opener, "调用")
+  Rel(main, line_counter, "调用")
+  Rel(main, word_counter, "调用")
+  Rel(main, byte_counter, "调用")
+  Rel(main, formatter, "调用")
+  
+  UpdateLayoutConfig()
+```
+
+## 5. 组件分解 (C4 Component)
+
+```mermaid
+C4Component
+  title Component View - 内部组件关系
+  Container_Boundary(input_boundary, "输入子系统") {
+    Component(arg_parser, "arg_parser", "解析并验证命令行参数", "C++")
+    Component(file_opener, "file_opener", "打开文件流", "C++")
+  }
+  
+  Container_Boundary(counter_boundary, "计数子系统") {
+    Component(line_counter, "line_counter", "统计换行符数量", "C++")
+    Component(word_counter, "word_counter", "统计单词数量", "C++")
+    Component(byte_counter, "byte_counter", "统计字节数量", "C++")
+  }
+  
+  Container_Boundary(output_boundary, "输出子系统") {
+    Component(formatter, "formatter", "格式化输出结果", "C++")
+  }
+  
+  Rel(main, arg_parser, "parse_file_argument", "参数验证")
+  Rel(main, file_opener, "open_file", "文件打开")
+  Rel(main, line_counter, "count_lines", "行计数")
+  Rel(main, word_counter, "count_words", "词计数")
+  Rel(main, byte_counter, "count_bytes", "字节计数")
+  Rel(main, formatter, "print_result", "结果输出")
+  
+  UpdateLayoutConfig()
+```
+
+## 6. 数据模型
+
+### 6.1 输入数据
+
+```mermaid
+erDiagram
+    FILE {
+        string path "文件路径"
+        int64 size "文件大小（字节）"
+        int64 line_count "换行符数量"
+        int64 word_count "单词数量"
+        int64 byte_count "字节数量"
+    }
+    
+    COMMAND_LINE {
+        int argc "参数数量"
+        string* argv "参数数组"
+        string file_path "提取的文件路径"
+    }
+    
+    FILE ||--o{ COMMAND_LINE : "从命令行获取"
+```
+
+### 6.2 输出数据
+
+输出格式：`<lines> <words> <bytes> <filename>`
+
+```mermaid
+erDiagram
+    OUTPUT_RESULT {
+        int64 lines "行数"
+        int64 words "词数"
+        int64 bytes "字节数"
+        string filename "文件名"
+    }
+    
+    OUTPUT_RESULT ||--o{ STDOUT : "输出到标准输出"
+```
+
+## 7. 模块依赖关系
+
+```mermaid
+flowchart TD
+    subgraph src ["src/"]
+        main["src/main.cpp"]
+        input["src/input/"]
+        counter["src/counter/"]
+        output["src/output/"]
+    end
+    
+    main --> input
+    main --> counter
+    main --> output
+    counter --> input
+    
+    UpdateLayoutConfig()
+```
+
+## 8. 组件交互流程
+
+### 8.1 主流程
+
+```mermaid
+sequenceDiagram
+    participant Main as main.cpp
+    participant Arg as arg_parser
+    participant File as file_opener
+    participant Line as line_counter
+    participant Word as word_counter
+    participant Byte as byte_counter
+    participant Out as formatter
+
+    Main->>Arg: parse_file_argument(argc, argv)
+    Arg-->>Main: filepath
+    Main->>File: open_file(filepath)
+    File-->>Main: ifstream
+    Main->>Line: count_lines(stream)
+    Line-->>Main: lines
+    Main->>Word: count_words(stream)
+    Word-->>Main: words
+    Main->>Byte: count_bytes(stream)
+    Byte-->>Main: bytes
+    Main->>Out: print_result(lines, words, bytes, filepath)
+    Out->>Out: cout << lines << " " << words << " " << bytes << " " << filename
+```
+
+### 8.2 错误处理流程
+
+```mermaid
+flowchart LR
+  A["用户执行 wc-tool"] --> B{"参数有效?"}
+  B -->|否| C["输出错误到stderr"]
+  C --> D["退出码1"]
+  B -->|是| E{"文件存在?"}
+  E -->|否| F["输出错误到stderr"]
+  F --> D
+  E -->|是| G["读取文件"]
+  G --> H["统计行数"]
+  H --> I["统计词数"]
+  I --> J["统计字节数"]
+  J --> K["输出结果"]
+```
+
+## 9. 测试架构
+
+### 9.1 单元测试
+
+| 测试名称 | 测试可执行文件 | 测试内容 | CTest 名称 |
+|----------|---------------|---------|-----------|
+| 行计数 | test_line_counter | FR-002 | LineCounterTest |
+| 单词计数 | test_word_counter | FR-003 | WordCounterTest |
+| 字节计数 | test_byte_counter | FR-004 | ByteCounterTest |
+| 参数解析 | test_arg_parser | FR-001 | ArgParserTest |
+| 输出格式化 | test_output_formatter | FR-005 | OutputFormatterTest |
+
+### 9.2 端到端测试 — 独立可执行
+
+每个端到端场景拥有**独立的测试可执行文件**和**唯一的 CTest 测试名**，确保可以通过 `ctest -R <name>` 单独执行：
+
+| 场景 ID | 描述 | CTest 名称 | 测试可执行文件 |
+|---------|------|-----------|---------------|
+| e2e_normal_file | 正常文件处理 | E2ENormalFileTest | test_e2e_normal_file |
+| e2e_empty_file | 空文件处理 | E2EEmptyFileTest | test_e2e_empty_file |
+| e2e_no_argument | 缺少参数 | E2ENoArgumentTest | test_e2e_no_argument |
+| e2e_file_not_found | 文件不存在 | E2EFileNotFoundTest | test_e2e_file_not_found |
+| e2e_no_trailing_newline | 无尾部换行符 | E2ENoTrailingNewlineTest | test_e2e_no_trailing_newline |
+
+```mermaid
+flowchart LR
+    subgraph unit_tests ["单元测试"]
+        tlc["LineCounterTest"]
+        twc["WordCounterTest"]
+        tbc["ByteCounterTest"]
+        tap["ArgParserTest"]
+        tof["OutputFormatterTest"]
+    end
+
+    subgraph e2e_tests ["端到端测试 — 独立可执行"]
+        en["E2ENormalFileTest"]
+        ee["E2EEmptyFileTest"]
+        ea["E2ENoArgumentTest"]
+        ef["E2EFileNotFoundTest"]
+        et["E2ENoTrailingNewlineTest"]
+    end
+
+    tlc -.->|依赖| en
+    twc -.->|依赖| en
+    tbc -.->|依赖| en
+    tap -.->|依赖| ea
+    tap -.->|依赖| ef
+    tof -.->|依赖| et
+```
+
+### 9.3 测试执行命令
+
+每个测试可独立执行：
+
+```
+ctest --test-dir build --output-on-failure --verbose -R E2ENormalFile
+ctest --test-dir build --output-on-failure --verbose -R E2EEmptyFile
+ctest --test-dir build --output-on-failure --verbose -R E2ENoArgument
+ctest --test-dir build --output-on-failure --verbose -R E2EFileNotFound
+ctest --test-dir build --output-on-failure --verbose -R E2ENoTrailingNewline
+```
+
+所有测试一起执行：
+
+```
+ctest --test-dir build --output-on-failure --verbose
+```
+
+## 9. 子系统详细设计
+
+### 9.1 输入子系统 (input)
+
+**职责**: 命令行参数解析和文件打开
+
+**组件**:
+- `arg_parser`: 验证argc == 2，提取argv[1]作为文件路径
+- `file_opener`: 使用`std::ifstream`以二进制模式打开文件
+
+**公共接口**:
+```cpp
+// arg_parser.h
+namespace input {
+    std::string parse_file_argument(int argc, char* argv[]);
+}
+
+// file_opener.h
+namespace input {
+    std::ifstream open_file(const std::string& path);
+}
+```
+
+### 9.2 计数子系统 (counter)
+
+**职责**: 行计数、单词计数和字节计数算法
+
+**组件**:
+- `line_counter`: 遍历文件流，统计'\n'字符数量
+- `word_counter`: 遍历文件流，统计非空白字符序列数量
+- `byte_counter`: 遍历文件流，统计所有字符数量
+
+**公共接口**:
+```cpp
+// line_counter.h
+namespace counter {
+    std::intmax_t count_lines(std::istream& stream);
+}
+
+// word_counter.h
+namespace counter {
+    std::intmax_t count_words(std::istream& stream);
+}
+
+// byte_counter.h
+namespace counter {
+    std::intmax_t count_bytes(std::istream& stream);
+}
+```
+
+### 9.3 输出子系统 (output)
+
+**职责**: 格式化并打印结果
+
+**组件**:
+- `formatter`: 将统计结果格式化为`<lines> <words> <bytes> <filename>`格式并输出到stdout
+
+**公共接口**:
+```cpp
+// formatter.h
+namespace output {
+    void print_result(std::intmax_t lines, std::intmax_t words, std::intmax_t bytes, const std::string& filename);
+}
+```
+
+## 10. 构建系统
+
+### 10.1 CMakeLists.txt
+
+```cmake
+cmake_minimum_required(VERSION 3.14)
+project(wc-tool VERSION 1.0.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# 主可执行文件
+add_executable(wc-tool
+    src/main.cpp
+    src/input/arg_parser.cpp
+    src/input/file_opener.cpp
+    src/counter/line_counter.cpp
+    src/counter/word_counter.cpp
+    src/counter/byte_counter.cpp
+    src/output/formatter.cpp
+)
+
+target_include_directories(wc-tool PRIVATE src)
+
+# 单元测试可执行文件
+add_executable(test_line_counter tests/test_line_counter.cpp)
+target_include_directories(test_line_counter PRIVATE src)
+
+add_executable(test_word_counter tests/test_word_counter.cpp)
+target_include_directories(test_word_counter PRIVATE src)
+
+add_executable(test_byte_counter tests/test_byte_counter.cpp)
+target_include_directories(test_byte_counter PRIVATE src)
+
+add_executable(test_arg_parser tests/test_arg_parser.cpp)
+target_include_directories(test_arg_parser PRIVATE src)
+
+add_executable(test_output_formatter tests/test_output_formatter.cpp)
+target_include_directories(test_output_formatter PRIVATE src)
+
+# 端到端测试 — 每个场景独立可执行文件
+add_executable(test_e2e_normal_file tests/test_e2e_normal_file.cpp)
+target_include_directories(test_e2e_normal_file PRIVATE src)
+
+add_executable(test_e2e_empty_file tests/test_e2e_empty_file.cpp)
+target_include_directories(test_e2e_empty_file PRIVATE src)
+
+add_executable(test_e2e_no_argument tests/test_e2e_no_argument.cpp)
+target_include_directories(test_e2e_no_argument PRIVATE src)
+
+add_executable(test_e2e_file_not_found tests/test_e2e_file_not_found.cpp)
+target_include_directories(test_e2e_file_not_found PRIVATE src)
+
+add_executable(test_e2e_no_trailing_newline tests/test_e2e_no_trailing_newline.cpp)
+target_include_directories(test_e2e_no_trailing_newline PRIVATE src)
+
+# 启用测试
+enable_testing()
+
+add_test(NAME LineCounterTest COMMAND test_line_counter)
+add_test(NAME WordCounterTest COMMAND test_word_counter)
+add_test(NAME ByteCounterTest COMMAND test_byte_counter)
+add_test(NAME ArgParserTest COMMAND test_arg_parser)
+add_test(NAME OutputFormatterTest COMMAND test_output_formatter)
+
+# 端到端测试 — 每个场景独立的 CTest 名称
+add_test(NAME E2ENormalFileTest COMMAND test_e2e_normal_file)
+add_test(NAME E2EEmptyFileTest COMMAND test_e2e_empty_file)
+add_test(NAME E2ENoArgumentTest COMMAND test_e2e_no_argument)
+add_test(NAME E2EFileNotFoundTest COMMAND test_e2e_file_not_found)
+add_test(NAME E2ENoTrailingNewlineTest COMMAND test_e2e_no_trailing_newline)
+```
+
+### 10.2 测试执行
+
+每个测试可独立执行：
+
+```
+ctest --test-dir build --output-on-failure --verbose -R E2ENormalFileTest
+ctest --test-dir build --output-on-failure --verbose -R E2EEmptyFileTest
+ctest --test-dir build --output-on-failure --verbose -R E2ENoArgumentTest
+ctest --test-dir build --output-on-failure --verbose -R E2EFileNotFoundTest
+ctest --test-dir build --output-on-failure --verbose -R E2ENoTrailingNewlineTest
+```
+
+所有测试一起执行：
+
+```
+ctest --test-dir build --output-on-failure --verbose
+```
+
+## 11. 测试策略
+
+### 11.1 单元测试
+
+每个计数原语有独立的测试可执行文件：
+
+| 测试名称 | 测试文件 | 测试内容 |
+|---------|---------|---------|
+| LineCounterTest | tests/test_line_counter.cpp | 空文件、单行、多行、无换行符、连续换行符 |
+| WordCounterTest | tests/test_word_counter.cpp | 空文件、单词、多词、连续空格、制表符、换行符、纯空白 |
+| ByteCounterTest | tests/test_byte_counter.cpp | 空文件、单字节、多字节、换行符、混合内容 |
+| ArgParserTest | tests/test_arg_parser.cpp | 有效参数、缺少参数、过多参数 |
+| OutputFormatterTest | tests/test_output_formatter.cpp | 正常输出、零值、大数值 |
+
+### 11.2 端到端测试
+
+每个端到端场景拥有**独立的测试可执行文件**和**唯一的 CTest 测试名**，确保可以通过 `ctest -R <name>` 单独执行：
+
+| 场景 ID | 描述 | CTest 名称 | 测试可执行文件 |
+|---------|------|-----------|---------------|
+| e2e_normal_file | 正常文件处理 | E2ENormalFileTest | test_e2e_normal_file |
+| e2e_empty_file | 空文件处理 | E2EEmptyFileTest | test_e2e_empty_file |
+| e2e_no_argument | 缺少参数 | E2ENoArgumentTest | test_e2e_no_argument |
+| e2e_file_not_found | 文件不存在 | E2EFileNotFoundTest | test_e2e_file_not_found |
+| e2e_no_trailing_newline | 无尾部换行符 | E2ENoTrailingNewlineTest | test_e2e_no_trailing_newline |
+
+```mermaid
+flowchart LR
+    subgraph unit_tests ["单元测试"]
+        tlc["LineCounterTest"]
+        twc["WordCounterTest"]
+        tbc["ByteCounterTest"]
+        tap["ArgParserTest"]
+        tof["OutputFormatterTest"]
+    end
+
+    subgraph e2e_tests ["端到端测试 — 独立可执行"]
+        en["E2ENormalFileTest"]
+        ee["E2EEmptyFileTest"]
+        ea["E2ENoArgumentTest"]
+        ef["E2EFileNotFoundTest"]
+        et["E2ENoTrailingNewlineTest"]
+    end
+
+    tlc -.->|依赖| en
+    twc -.->|依赖| en
+    tbc -.->|依赖| en
+    tap -.->|依赖| ea
+    tap -.->|依赖| ef
+    tof -.->|依赖| et
+```
+
+## 12. 错误处理
+
+| 错误场景 | 处理方式 | 错误位置 |
+|---------|---------|---------|
+| 无参数 | 输出"Usage: wc-tool <file>"到stderr，exit(1) | arg_parser |
+| 文件不存在 | 输出"Cannot open file: <path>"到stderr，exit(1) | file_opener |
+| 文件无法读取 | 输出"Cannot open file: <path>"到stderr，exit(1) | file_opener |
+
+## 13. 启动序列
+
+```mermaid
+sequenceDiagram
+    participant Main as main.cpp
+    participant Arg as arg_parser
+    participant File as file_opener
+    participant Line as line_counter
+    participant Word as word_counter
+    participant Byte as byte_counter
+    participant Out as formatter
+
+    Note over Main: 构造阶段
+    Main->>Arg: 初始化
+    Main->>File: 初始化
+    Main->>Line: 初始化
+    Main->>Word: 初始化
+    Main->>Byte: 初始化
+    Main->>Out: 初始化
+
+    Note over Main: 主循环阶段
+    Main->>Arg: parse_file_argument(argc, argv)
+    Arg-->>Main: filepath
+    Main->>File: open_file(filepath)
+    File-->>Main: ifstream
+    Main->>Line: count_lines(stream)
+    Line-->>Main: lines
+    Main->>Word: count_words(stream)
+    Word-->>Main: words
+    Main->>Byte: count_bytes(stream)
+    Byte-->>Main: bytes
+    Main->>Out: print_result(lines, words, bytes, filepath)
+    Out->>Out: cout << lines << " " << words << " " << bytes << " " << filename
+    Main->>Main: return 0
+```
+
+## 14. 性能考虑
+
+- 使用`std::istream::get()`逐字符读取，O(1)内存复杂度
+- 每个计数操作独立遍历文件，通过`seekg()`重置流位置
+- 对于大文件（GB级别），流处理确保内存使用恒定
+- 无动态内存分配，无堆分配
+
+## 15. 可移植性
+
+- 仅使用C++17标准库
+- 使用`std::filesystem`和`std::isspace`确保跨平台兼容
+- 支持Linux (glibc)、macOS (Apple clang)
+- 无平台特定API调用

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/docs/behavioral_contract.json
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/docs/behavioral_contract.json
@@ -1,0 +1,164 @@
+{
+  "scenarios": [
+    {
+      "id": "test_line_counter",
+      "name": "行计数单元测试",
+      "description": "测试行计数器的基本功能：空文件返回0，有换行符的文件正确计数，没有尾部换行符的文件正确计数",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R LineCounterTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-002"]
+    },
+    {
+      "id": "test_word_counter",
+      "name": "单词计数单元测试",
+      "description": "测试单词计数器的基本功能：空文件返回0，多个连续空格不产生额外单词，正确统计单词数",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R WordCounterTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-003"]
+    },
+    {
+      "id": "test_byte_counter",
+      "name": "字节计数单元测试",
+      "description": "测试字节计数器的基本功能：空文件返回0，正确统计文件字节数",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R ByteCounterTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-004"]
+    },
+    {
+      "id": "test_arg_parser",
+      "name": "参数解析单元测试",
+      "description": "测试参数解析器：正确参数返回文件路径，缺少参数抛出异常",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R ArgParserTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-001"]
+    },
+    {
+      "id": "test_output_formatter",
+      "name": "输出格式化单元测试",
+      "description": "测试输出格式化器：正确格式化并输出结果",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R OutputFormatterTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-005"]
+    },
+    {
+      "id": "e2e_normal_file",
+      "name": "端到端测试：正常文件处理",
+      "description": "端到端测试：使用wc-tool处理一个包含多行多词的文本文件，验证输出格式正确",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R E2ENormalFileTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-001", "FR-002", "FR-003", "FR-004", "FR-005"]
+    },
+    {
+      "id": "e2e_empty_file",
+      "name": "端到端测试：空文件处理",
+      "description": "端到端测试：使用wc-tool处理空文件，验证输出为 0 0 0 filename",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R E2EEmptyFileTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-002", "FR-003", "FR-004"]
+    },
+    {
+      "id": "e2e_no_argument",
+      "name": "端到端测试：缺少参数",
+      "description": "端到端测试：使用wc-tool不带参数运行，验证输出错误信息到stderr并返回非零退出码",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R E2ENoArgumentTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-001"]
+    },
+    {
+      "id": "e2e_file_not_found",
+      "name": "端到端测试：文件不存在",
+      "description": "端到端测试：使用wc-tool处理不存在的文件，验证输出错误信息到stderr并返回非零退出码",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R E2EFileNotFoundTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-001"]
+    },
+    {
+      "id": "e2e_no_trailing_newline",
+      "name": "端到端测试：无尾部换行符",
+      "description": "端到端测试：使用wc-tool处理没有尾部换行符的文件，验证wc兼容的行计数",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R E2ENoTrailingNewlineTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-002", "FR-003", "FR-004", "FR-005"]
+    }
+  ]
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/docs/requirement.md
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/docs/requirement.md
@@ -1,0 +1,251 @@
+# Requirement Specification — wc-tool
+
+## 功能需求
+
+### FR-001: File Input and Argument Parsing
+
+The tool accepts a single positional argument that specifies the path to the file to be
+analysed.
+
+- **FR-001.1** The tool MUST accept exactly one file path argument on the command line.
+- **FR-001.2** If no argument is provided, the tool MUST print an error message to
+  **stderr** and exit with a non-zero status code.
+- **FR-001.3** If the file does not exist or cannot be opened, the tool MUST print an
+  error message to **stderr** and exit with a non-zero status code.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_invoke(("Invoke wc-tool"))
+  uc_parse(("Parse file argument"))
+  uc_validate(("Validate file exists"))
+  actor_user --> uc_invoke
+  uc_invoke --> uc_parse
+  uc_parse --> uc_validate
+  uc_validate -->|missing arg| uc_error
+  uc_validate -->|file not found| uc_error
+  uc_error(["Error to stderr"])
+```
+
+### FR-002: Line Count
+
+The tool MUST count the number of newline characters (`\n`) in the file and report the
+result as the first integer in its output.
+
+- **FR-002.1** Each newline character (`\n`) in the file contributes exactly one to the
+  line count.
+- **FR-002.2** A file that is empty (zero bytes) MUST produce a line count of `0`.
+- **FR-002.3** A file whose last character is not a newline MUST still be counted as
+  containing one additional line (matching `wc` semantics).
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_read(("Read file"))
+  uc_count_lines(("Count lines"))
+  uc_report(("Report line count"))
+  actor_user --> uc_read
+  uc_read --> uc_count_lines
+  uc_count_lines --> uc_report
+```
+
+### FR-003: Word Count
+
+The tool MUST count the number of whitespace-delimited words in the file.
+
+- **FR-003.1** A word is defined as a maximal sequence of non-whitespace characters.
+  Whitespace characters are those recognised by `std::isspace` (space, tab, newline,
+  carriage return, form feed, vertical tab).
+- **FR-003.2** Empty files MUST produce a word count of `0`.
+- **FR-003.3** Multiple consecutive whitespace characters MUST NOT produce extra words.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_read(("Read file"))
+  uc_count_words(("Count words"))
+  uc_report(("Report word count"))
+  actor_user --> uc_read
+  uc_read --> uc_count_words
+  uc_count_words --> uc_report
+```
+
+### FR-004: Byte Count
+
+The tool MUST report the total number of bytes in the file.
+
+- **FR-004.1** The byte count is the file size in bytes as reported by the operating
+  system (e.g. `std::filesystem::file_size` or reading until EOF).
+- **FR-004.2** An empty file MUST produce a byte count of `0`.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_read(("Read file"))
+  uc_count_bytes(("Count bytes"))
+  uc_report(("Report byte count"))
+  actor_user --> uc_read
+  uc_read --> uc_count_bytes
+  uc_count_bytes --> uc_report
+```
+
+### FR-005: Output Format
+
+The tool MUST print three integers (lines, words, bytes) separated by single spaces,
+followed by the filename, to stdout.
+
+- **FR-005.1** The output format is: `<lines> <words> <bytes> <filename>`
+- **FR-005.2** Fields are separated by exactly one space.
+- **FR-005.3** The filename printed is the user-provided argument, not a canonicalised path.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_compute(("Compute statistics"))
+  uc_format(("Format output"))
+  uc_print(("Print to stdout"))
+  actor_user --> uc_compute
+  uc_compute --> uc_format
+  uc_format --> uc_print
+```
+
+### FR-006: Build System
+
+The project MUST be buildable with CMake using C++17 as the strict language standard,
+producing a single static binary with no runtime dependencies.
+
+- **FR-006.1** A `CMakeLists.txt` file exists at the project root.
+- **FR-006.2** The build system enforces C++17 via `set(CMAKE_CXX_STANDARD 17)`.
+- **FR-006.3** The build produces a single static binary with no runtime dependencies.
+
+```mermaid
+flowchart LR
+  actor_dev(["👤 Developer"])
+  uc_cmake(("Configure CMake"))
+  uc_build(("Build binary"))
+  uc_verify(("Verify binary"))
+  actor_dev --> uc_cmake
+  uc_cmake --> uc_build
+  uc_build --> uc_verify
+```
+
+### FR-007: Unit Tests
+
+The project MUST include unit tests for each counting primitive using the CTest framework
+with no third-party dependencies.
+
+- **FR-007.1** Separate test executables exist for line-count, word-count, and byte-count.
+- **FR-007.2** Tests are registered with `add_test` in CMake.
+- **FR-007.3** No third-party testing frameworks are used.
+
+```mermaid
+flowchart LR
+  actor_dev(["👤 Developer"])
+  uc_write_tests(("Write unit tests"))
+  uc_register(("Register with CTest"))
+  uc_run(("Run tests"))
+  actor_dev --> uc_write_tests
+  uc_write_tests --> uc_register
+  uc_register --> uc_run
+```
+
+## 非功能需求
+
+### NFR-001: Performance
+
+The tool reads the input file exactly once, processes files of at least 1 GB within
+30 seconds on standard hardware, and uses O(1) memory with respect to file size
+via streaming read.
+
+### NFR-002: Portability
+
+The tool compiles and runs on Linux (glibc) and macOS (Apple clang) using C++17,
+and is relocatable with no hardcoded paths.
+
+### NFR-003: Reliability
+
+The tool handles binary files gracefully without crashing and does not produce
+undefined behaviour on empty files, very large files, or files with unusual encodings.
+
+## 用例
+
+### UC-001: Count File Statistics
+
+**Actor:** User
+**Goal:** Obtain line, word, and byte counts for a given file.
+**Preconditions:** A file exists and is readable.
+**Main Flow:**
+1. User invokes `wc-tool <file_path>`.
+2. The tool opens the file for reading.
+3. The tool reads the file once, counting lines, words, and bytes.
+4. The tool prints the results to stdout.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_run(("Run wc-tool"))
+  uc_open(("Open file"))
+  uc_read(("Read and count"))
+  uc_output(("Output results"))
+  actor_user --> uc_run
+  uc_run --> uc_open
+  uc_open --> uc_read
+  uc_read --> uc_output
+```
+
+Covers: FR-001, FR-002, FR-003, FR-004, FR-005
+
+### UC-002: Handle Missing File Argument
+
+**Actor:** User
+**Goal:** Receive an error message when no file argument is provided.
+**Preconditions:** None.
+**Main Flow:**
+1. User invokes `wc-tool` without arguments.
+2. The tool detects the missing argument.
+3. The tool prints an error message to stderr.
+4. The tool exits with a non-zero status code.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_run(("Run wc-tool"))
+  uc_check(("Check arguments"))
+  uc_error(("Print error to stderr"))
+  uc_exit(("Exit with non-zero"))
+  actor_user --> uc_run
+  uc_run --> uc_check
+  uc_check -->|no args| uc_error
+  uc_error --> uc_exit
+```
+
+Covers: FR-001
+
+### UC-003: Handle Non-Existent File
+
+**Actor:** User
+**Goal:** Receive an error message when the specified file does not exist.
+**Preconditions:** None.
+**Main Flow:**
+1. User invokes `wc-tool <nonexistent_file>`.
+2. The tool attempts to open the file.
+3. The tool detects the file does not exist.
+4. The tool prints an error message to stderr.
+5. The tool exits with a non-zero status code.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_run(("Run wc-tool"))
+  uc_open(("Open file"))
+  uc_check(("Check if exists"))
+  uc_error(("Print error to stderr"))
+  uc_exit(("Exit with non-zero"))
+  actor_user --> uc_run
+  uc_run --> uc_open
+  uc_open --> uc_check
+  uc_check -->|not found| uc_error
+  uc_error --> uc_exit
+```
+
+Covers: FR-001

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/docs/requirement_contract.json
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/docs/requirement_contract.json
@@ -1,0 +1,156 @@
+{
+  "project_name": "wc-tool",
+  "summary": "A C++17 command-line tool that computes line count, word count, and byte count for a given file, mirroring the Unix wc utility. Built with CMake, tested with CTest, producing a single static binary with no runtime dependencies beyond the C++ standard library.",
+  "functional_requirements": [
+    {
+      "id": "FR-001",
+      "title": "File Input and Argument Parsing",
+      "description": "The tool accepts a single positional argument specifying the file path. It must validate the argument exists and the file is readable, printing errors to stderr and exiting non-zero on failure.",
+      "acceptance_criteria": [
+        "Exactly one file path argument is accepted",
+        "No argument produces an error to stderr with non-zero exit",
+        "Non-existent file produces an error to stderr with non-zero exit"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-002",
+      "title": "Line Count",
+      "description": "The tool counts newline characters as lines, with wc-compatible semantics: empty file yields 0, and a file without a trailing newline still counts the last line.",
+      "acceptance_criteria": [
+        "Each newline character contributes exactly one to line count",
+        "Empty file produces line count of 0",
+        "File without trailing newline still counts the final line"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-003",
+      "title": "Word Count",
+      "description": "The tool counts whitespace-delimited words where a word is a maximal sequence of non-whitespace characters. Multiple consecutive whitespace characters do not produce extra words.",
+      "acceptance_criteria": [
+        "A word is a maximal sequence of non-whitespace characters",
+        "Empty file produces word count of 0",
+        "Multiple consecutive whitespace characters do not produce extra words"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-004",
+      "title": "Byte Count",
+      "description": "The tool reports the total number of bytes in the file, equivalent to the file size in bytes as reported by the operating system.",
+      "acceptance_criteria": [
+        "Byte count equals the file size in bytes",
+        "Empty file produces byte count of 0"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-005",
+      "title": "Output Format",
+      "description": "The tool prints three integers (lines, words, bytes) separated by single spaces, followed by the filename, to stdout.",
+      "acceptance_criteria": [
+        "Output format is: <lines> <words> <bytes> <filename>",
+        "Fields are separated by exactly one space",
+        "Filename printed is the user-provided argument, not a canonicalised path"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-006",
+      "title": "Build System",
+      "description": "The project is buildable with CMake using C++17 as the strict language standard, producing a single static binary with no runtime dependencies.",
+      "acceptance_criteria": [
+        "CMakeLists.txt exists at the project root",
+        "Build system enforces C++17",
+        "Build produces a single static binary with no runtime dependencies"
+      ],
+      "priority": "P1"
+    },
+    {
+      "id": "FR-007",
+      "title": "Unit Tests",
+      "description": "The project includes unit tests for each counting primitive using the CTest framework with no third-party dependencies. Separate test executables are registered with add_test.",
+      "acceptance_criteria": [
+        "Separate test executables exist for line-count, word-count, and byte-count",
+        "Tests are registered with add_test in CMake",
+        "No third-party testing frameworks are used"
+      ],
+      "priority": "P1"
+    }
+  ],
+  "non_functional_requirements": [
+    {
+      "id": "NFR-001",
+      "title": "Performance",
+      "description": "The tool reads the input file exactly once, processes files of at least 1 GB within 30 seconds on standard hardware, and uses O(1) memory with respect to file size via streaming read.",
+      "priority": "P1"
+    },
+    {
+      "id": "NFR-002",
+      "title": "Portability",
+      "description": "The tool compiles and runs on Linux (glibc) and macOS (Apple clang) using C++17, and is relocatable with no hardcoded paths.",
+      "priority": "P1"
+    },
+    {
+      "id": "NFR-003",
+      "title": "Reliability",
+      "description": "The tool handles binary files gracefully without crashing and does not produce undefined behaviour on empty files, very large files, or files with unusual encodings.",
+      "priority": "P1"
+    }
+  ],
+  "use_cases": [
+    {
+      "id": "UC-001",
+      "actor": "User",
+      "goal": "Obtain line, word, and byte counts for a given file.",
+      "preconditions": [
+        "A file exists and is readable"
+      ],
+      "main_flow": [
+        "User invokes wc-tool with a file path argument",
+        "The tool opens the file for reading",
+        "The tool reads the file once, counting lines, words, and bytes",
+        "The tool prints the results to stdout in the format: lines words bytes filename"
+      ],
+      "covers_requirements": [
+        "FR-001",
+        "FR-002",
+        "FR-003",
+        "FR-004",
+        "FR-005"
+      ]
+    },
+    {
+      "id": "UC-002",
+      "actor": "User",
+      "goal": "Receive an error message when no file argument is provided.",
+      "preconditions": [],
+      "main_flow": [
+        "User invokes wc-tool without arguments",
+        "The tool detects the missing argument",
+        "The tool prints an error message to stderr",
+        "The tool exits with a non-zero status code"
+      ],
+      "covers_requirements": [
+        "FR-001"
+      ]
+    },
+    {
+      "id": "UC-003",
+      "actor": "User",
+      "goal": "Receive an error message when the specified file does not exist.",
+      "preconditions": [],
+      "main_flow": [
+        "User invokes wc-tool with a non-existent file path",
+        "The tool attempts to open the file",
+        "The tool detects the file does not exist",
+        "The tool prints an error message to stderr",
+        "The tool exits with a non-zero status code"
+      ],
+      "covers_requirements": [
+        "FR-001"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/docs/stack_contract.json
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/docs/stack_contract.json
@@ -1,0 +1,74 @@
+{
+  "language": "cpp",
+  "runtime": "native",
+  "framework_backend": "",
+  "framework_frontend": "",
+  "package_manager": "cmake",
+  "project_config_file": "CMakeLists.txt",
+  "test_runner": "ctest",
+  "static_analyzer": ["clang-tidy"],
+  "entry_point": "src/main.cpp",
+  "run_command": "cmake -B build && cmake --build build && ./build/wc-tool",
+  "ui_required": false,
+  "ui_kind": "",
+  "subsystems": [
+    {
+      "name": "input",
+      "src_dir": "src/input",
+      "responsibilities": "命令行参数解析和文件打开",
+      "components": [
+        {
+          "name": "arg_parser",
+          "file": "src/input/arg_parser.cpp",
+          "test_file": "tests/test_arg_parser.cpp",
+          "responsibility": "解析并验证命令行参数"
+        },
+        {
+          "name": "file_opener",
+          "file": "src/input/file_opener.cpp",
+          "test_file": "tests/test_file_opener.cpp",
+          "responsibility": "打开文件流进行读取"
+        }
+      ]
+    },
+    {
+      "name": "counter",
+      "src_dir": "src/counter",
+      "responsibilities": "行计数、单词计数和字节计数算法实现",
+      "components": [
+        {
+          "name": "line_counter",
+          "file": "src/counter/line_counter.cpp",
+          "test_file": "tests/test_line_counter.cpp",
+          "responsibility": "统计换行符数量"
+        },
+        {
+          "name": "word_counter",
+          "file": "src/counter/word_counter.cpp",
+          "test_file": "tests/test_word_counter.cpp",
+          "responsibility": "统计单词数量"
+        },
+        {
+          "name": "byte_counter",
+          "file": "src/counter/byte_counter.cpp",
+          "test_file": "tests/test_byte_counter.cpp",
+          "responsibility": "统计字节数量"
+        }
+      ]
+    },
+    {
+      "name": "output",
+      "src_dir": "src/output",
+      "responsibilities": "格式化并打印结果到标准输出",
+      "components": [
+        {
+          "name": "formatter",
+          "file": "src/output/formatter.cpp",
+          "test_file": "tests/test_output_formatter.cpp",
+          "responsibility": "将统计结果格式化为指定格式"
+        }
+      ]
+    }
+  ],
+  "lifecycle_inits": []
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/counter/byte_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/counter/byte_counter.cpp
@@ -1,0 +1,20 @@
+#include "counter/byte_counter.h"
+#include <string>
+
+namespace counter {
+
+/**
+ * Count the number of bytes in content.
+ * This is simply the string length in bytes.
+ *
+ * @param content  The text content to count bytes in
+ * @return         Result struct with ok flag and byte count
+ */
+ByteCountResult count_bytes(const std::string& content) {
+    ByteCountResult result;
+    result.ok = true;
+    result.byte_count = static_cast<int64_t>(content.size());
+    return result;
+}
+
+} // namespace counter

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/counter/byte_counter.h
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/counter/byte_counter.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+
+namespace counter {
+
+struct ByteCountResult {
+    bool ok;
+    int64_t byte_count;
+};
+
+/**
+ * Count the number of bytes in content.
+ * @param content  The text content to count bytes in
+ * @return         Result with ok flag and byte count
+ */
+ByteCountResult count_bytes(const std::string& content);
+
+} // namespace counter

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/counter/combined_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/counter/combined_counter.cpp
@@ -1,0 +1,45 @@
+#include "counter/combined_counter.h"
+#include <string>
+
+namespace counter {
+
+/**
+ * Compute lines, words, and bytes in a single pass over the content.
+ * This satisfies the requirement that the file is read only once.
+ *
+ * @param content  The text content to analyze
+ * @return         Combined stats with ok flag and all three counts
+ */
+CombinedStats count_all(const std::string& content) {
+    CombinedStats result;
+    result.ok = true;
+    result.line_count = 0;
+    result.word_count = 0;
+    result.byte_count = static_cast<int64_t>(content.size());
+
+    bool in_word = false;
+
+    for (char c : content) {
+        // Count bytes (already computed above, but this is the single pass)
+        // Line counting: count newlines
+        if (c == '\n') {
+            ++result.line_count;
+        }
+
+        // Word counting: track transitions from whitespace to non-whitespace
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v') {
+            if (in_word) {
+                in_word = false;
+            }
+        } else {
+            if (!in_word) {
+                ++result.word_count;
+                in_word = true;
+            }
+        }
+    }
+
+    return result;
+}
+
+} // namespace counter

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/counter/combined_counter.h
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/counter/combined_counter.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace counter {
+
+struct CombinedStats {
+    bool ok;
+    int64_t line_count;
+    int64_t word_count;
+    int64_t byte_count;
+};
+
+/**
+ * Compute lines, words, and bytes in a single pass over the content.
+ * This satisfies the requirement that the file is read only once.
+ *
+ * @param content  The text content to analyze
+ * @return         Combined stats with ok flag and all three counts
+ */
+CombinedStats count_all(const std::string& content);
+
+} // namespace counter

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/counter/line_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/counter/line_counter.cpp
@@ -1,0 +1,26 @@
+#include "counter/line_counter.h"
+#include <string>
+
+namespace counter {
+
+/**
+ * Count the number of newline characters in content.
+ *
+ * @param content  The text content to count lines in
+ * @return         Result struct with ok flag and line count
+ */
+LineCountResult count_lines(const std::string& content) {
+    LineCountResult result;
+    result.ok = true;
+    result.line_count = 0;
+
+    for (char c : content) {
+        if (c == '\n') {
+            ++result.line_count;
+        }
+    }
+
+    return result;
+}
+
+} // namespace counter

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/counter/line_counter.h
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/counter/line_counter.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+
+namespace counter {
+
+struct LineCountResult {
+    bool ok;
+    int64_t line_count;
+};
+
+/**
+ * Count the number of newline characters in content.
+ * @param content  The text content to count lines in
+ * @return         Result with ok flag and line count
+ */
+LineCountResult count_lines(const std::string& content);
+
+} // namespace counter

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/counter/word_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/counter/word_counter.cpp
@@ -1,0 +1,28 @@
+#include "counter/word_counter.h"
+#include <string>
+#include <sstream>
+
+namespace counter {
+
+/**
+ * Count the number of whitespace-separated words in content.
+ * Words are sequences of non-whitespace characters.
+ *
+ * @param content  The text content to count words in
+ * @return         Result struct with ok flag and word count
+ */
+WordCountResult count_words(const std::string& content) {
+    WordCountResult result;
+    result.ok = true;
+    result.word_count = 0;
+
+    std::istringstream stream(content);
+    std::string word;
+    while (stream >> word) {
+        ++result.word_count;
+    }
+
+    return result;
+}
+
+} // namespace counter

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/counter/word_counter.h
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/counter/word_counter.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+
+namespace counter {
+
+struct WordCountResult {
+    bool ok;
+    int64_t word_count;
+};
+
+/**
+ * Count the number of whitespace-separated words in content.
+ * @param content  The text content to count words in
+ * @return         Result with ok flag and word count
+ */
+WordCountResult count_words(const std::string& content);
+
+} // namespace counter

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/input/arg_parser.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/input/arg_parser.cpp
@@ -1,0 +1,21 @@
+#include "input/arg_parser.h"
+#include <cstdlib>
+#include <string>
+#include <stdexcept>
+
+namespace input {
+
+std::string parse_file_argument(int argc, char* argv[]) {
+    if (argc != 2) {
+        throw std::runtime_error("Usage: wc-tool <file>");
+    }
+
+    const char* file_arg = argv[1];
+    if (file_arg == nullptr || file_arg[0] == '\0') {
+        throw std::runtime_error("Error: empty filename");
+    }
+
+    return std::string(file_arg);
+}
+
+} // namespace input

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/input/arg_parser.h
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/input/arg_parser.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+namespace input {
+
+/**
+ * Parse and validate command-line arguments.
+ * Expects exactly one argument: the filename to process.
+ * @return the validated file path string
+ * @throws std::runtime_error if argc != 2 or filename is empty
+ */
+std::string parse_file_argument(int argc, char* argv[]);
+
+} // namespace input

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/input/file_opener.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/input/file_opener.cpp
@@ -1,0 +1,33 @@
+#include "input/file_opener.h"
+#include <fstream>
+#include <string>
+
+namespace input {
+
+/**
+ * Open a file for reading.
+ *
+ * @param filename  Path to the file to open
+ * @return          Result struct with ok flag, ifstream, and optional error message
+ */
+FileOpenResult open_file(const std::string& filename) {
+    FileOpenResult result;
+    result.ok = false;
+    result.error_message.clear();
+
+    if (filename.empty()) {
+        result.error_message = "Error: empty filename";
+        return result;
+    }
+
+    result.stream.open(filename, std::ios::in);
+    if (!result.stream.is_open()) {
+        result.error_message = "Error: cannot open file '" + filename + "'";
+        return result;
+    }
+
+    result.ok = true;
+    return result;
+}
+
+} // namespace input

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/input/file_opener.h
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/input/file_opener.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <fstream>
+#include <string>
+
+namespace input {
+
+struct FileOpenResult {
+    bool ok;
+    std::ifstream stream;
+    std::string error_message;
+};
+
+/**
+ * Open a file for reading.
+ * @param filename  Path to the file to open
+ * @return          Result with ok flag, stream, and optional error message
+ */
+FileOpenResult open_file(const std::string& filename);
+
+} // namespace input

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/output/formatter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/output/formatter.cpp
@@ -1,0 +1,24 @@
+#include "output/formatter.h"
+#include <string>
+#include <sstream>
+
+namespace output {
+
+/**
+ * Format the count results as a string for output.
+ * Format: "<lines> <words> <bytes> <filename>"
+ *
+ * @param lines    Number of lines
+ * @param words    Number of words
+ * @param bytes    Number of bytes
+ * @param filename The filename to display
+ * @return         Formatted string
+ */
+std::string format_output(int64_t lines, int64_t words, int64_t bytes,
+                          const std::string& filename) {
+    std::ostringstream oss;
+    oss << lines << " " << words << " " << bytes << " " << filename;
+    return oss.str();
+}
+
+} // namespace output

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/output/formatter.h
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/src/output/formatter.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace output {
+
+/**
+ * Format the count results as a string for output.
+ * Format: "<lines> <words> <bytes> <filename>"
+ */
+std::string format_output(int64_t lines, int64_t words, int64_t bytes,
+                          const std::string& filename);
+
+} // namespace output

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/tests/test_arg_parser.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/tests/test_arg_parser.cpp
@@ -1,0 +1,70 @@
+#include <cassert>
+#include <string>
+#include <stdexcept>
+#include "input/arg_parser.h"
+
+int main() {
+    // --- Happy path: exactly one argument ---
+    {
+        char buf[] = "myfile.txt";
+        char* argv[] = {buf, buf}; // argv[0] = program, argv[1] = file
+        std::string result = input::parse_file_argument(2, argv);
+        assert(result == "myfile.txt");
+    }
+
+    // --- Happy path: file path with directory ---
+    {
+        char buf[] = "/home/user/document.txt";
+        char* argv[] = {buf, buf};
+        std::string result = input::parse_file_argument(2, argv);
+        assert(result == "/home/user/document.txt");
+    }
+
+    // --- Happy path: file path with spaces ---
+    {
+        char buf[] = "my file.txt";
+        char* argv[] = {buf, buf};
+        std::string result = input::parse_file_argument(2, argv);
+        assert(result == "my file.txt");
+    }
+
+    // --- Error: no arguments (only program name) ---
+    {
+        char buf[] = "wc-tool";
+        char* argv[] = {buf};
+        try {
+            input::parse_file_argument(1, argv);
+            assert(false && "Should have thrown");
+        } catch (const std::runtime_error& e) {
+            assert(std::string(e.what()).find("Usage") != std::string::npos);
+        }
+    }
+
+    // --- Error: too many arguments ---
+    {
+        char buf1[] = "file1.txt";
+        char buf2[] = "file2.txt";
+        char buf3[] = "wc-tool";
+        char* argv[] = {buf3, buf1, buf2};
+        try {
+            input::parse_file_argument(3, argv);
+            assert(false && "Should have thrown");
+        } catch (const std::runtime_error& e) {
+            assert(std::string(e.what()).find("Usage") != std::string::npos);
+        }
+    }
+
+    // --- Edge: empty filename ---
+    {
+        char buf[] = "";
+        char* argv[] = {buf, buf};
+        try {
+            input::parse_file_argument(2, argv);
+            assert(false && "Should have thrown");
+        } catch (const std::runtime_error& e) {
+            assert(std::string(e.what()).find("empty") != std::string::npos);
+        }
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/tests/test_byte_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/tests/test_byte_counter.cpp
@@ -1,0 +1,65 @@
+#include "counter/byte_counter.h"
+#include <cassert>
+#include <string>
+
+int main() {
+    // --- Happy path: empty string ---
+    {
+        auto result = counter::count_bytes("");
+        assert(result.ok);
+        assert(result.byte_count == 0);
+    }
+
+    // --- Happy path: single byte ---
+    {
+        auto result = counter::count_bytes("a");
+        assert(result.ok);
+        assert(result.byte_count == 1);
+    }
+
+    // --- Happy path: multiple bytes ---
+    {
+        auto result = counter::count_bytes("hello world");
+        assert(result.ok);
+        assert(result.byte_count == 11);
+    }
+
+    // --- Happy path: with newline characters ---
+    {
+        auto result = counter::count_bytes("a\nb\n");
+        assert(result.ok);
+        assert(result.byte_count == 4);
+    }
+
+    // --- Happy path: only whitespace ---
+    {
+        auto result = counter::count_bytes("   \t\n");
+        assert(result.ok);
+        assert(result.byte_count == 5);
+    }
+
+    // --- Happy path: ASCII printable characters ---
+    {
+        auto result = counter::count_bytes("!@#$%");
+        assert(result.ok);
+        assert(result.byte_count == 5);
+    }
+
+    // --- Edge: large content ---
+    {
+        std::string s(10000, 'x');
+        auto result = counter::count_bytes(s);
+        assert(result.ok);
+        assert(result.byte_count == 10000);
+    }
+
+    // --- Edge: string with null character embedded ---
+    {
+        std::string s(3, '\0');
+        auto result = counter::count_bytes(s);
+        assert(result.ok);
+        assert(result.byte_count == 3);
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/tests/test_combined_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/tests/test_combined_counter.cpp
@@ -1,0 +1,135 @@
+#include "counter/combined_counter.h"
+#include <cassert>
+#include <string>
+
+int main() {
+    // --- Happy path: empty content ---
+    {
+        auto result = counter::count_all("");
+        assert(result.ok);
+        assert(result.line_count == 0);
+        assert(result.word_count == 0);
+        assert(result.byte_count == 0);
+    }
+
+    // --- Happy path: single word, no newline ---
+    {
+        auto result = counter::count_all("hello");
+        assert(result.ok);
+        assert(result.line_count == 0);
+        assert(result.word_count == 1);
+        assert(result.byte_count == 5);
+    }
+
+    // --- Happy path: single word with trailing newline ---
+    {
+        auto result = counter::count_all("hello\n");
+        assert(result.ok);
+        assert(result.line_count == 1);
+        assert(result.word_count == 1);
+        assert(result.byte_count == 6);
+    }
+
+    // --- Happy path: multiple lines with trailing newline ---
+    {
+        auto result = counter::count_all("line1\nline2\nline3\n");
+        assert(result.ok);
+        assert(result.line_count == 3);
+        assert(result.word_count == 3);
+        assert(result.byte_count == 18);
+    }
+
+    // --- Happy path: multiple lines without trailing newline ---
+    {
+        auto result = counter::count_all("line1\nline2\nline3");
+        assert(result.ok);
+        assert(result.line_count == 2);
+        assert(result.word_count == 3);
+        assert(result.byte_count == 17);
+    }
+
+    // --- Happy path: multiple words per line ---
+    {
+        auto result = counter::count_all("hello world\nfoo bar\n");
+        assert(result.ok);
+        assert(result.line_count == 2);
+        assert(result.word_count == 4);
+        assert(result.byte_count == 20);
+    }
+
+    // --- Happy path: extra whitespace ---
+    {
+        auto result = counter::count_all("  hello   world  \n");
+        assert(result.ok);
+        assert(result.line_count == 1);
+        assert(result.word_count == 2);
+        assert(result.byte_count == 18);
+    }
+
+    // --- Happy path: tabs as separators ---
+    {
+        auto result = counter::count_all("a\tb\tc\n");
+        assert(result.ok);
+        assert(result.line_count == 1);
+        assert(result.word_count == 3);
+        assert(result.byte_count == 6);
+    }
+
+    // --- Happy path: only whitespace ---
+    {
+        auto result = counter::count_all("   \n\t  ");
+        assert(result.ok);
+        assert(result.line_count == 1);
+        assert(result.word_count == 0);
+        assert(result.byte_count == 7);
+    }
+
+    // --- Happy path: only newlines ---
+    {
+        auto result = counter::count_all("\n\n\n");
+        assert(result.ok);
+        assert(result.line_count == 3);
+        assert(result.word_count == 0);
+        assert(result.byte_count == 3);
+    }
+
+    // --- Happy path: mixed empty lines ---
+    {
+        auto result = counter::count_all("\nhello\n\nworld\n");
+        assert(result.ok);
+        assert(result.line_count == 4);
+        assert(result.word_count == 2);
+        assert(result.byte_count == 14);
+    }
+
+    // --- Happy path: single character words ---
+    {
+        auto result = counter::count_all("a b c d e");
+        assert(result.ok);
+        assert(result.line_count == 0);
+        assert(result.word_count == 5);
+        assert(result.byte_count == 9);
+    }
+
+    // --- Happy path: carriage return as whitespace ---
+    {
+        auto result = counter::count_all("hello\rworld\n");
+        assert(result.ok);
+        assert(result.line_count == 1);
+        assert(result.word_count == 2);
+        assert(result.byte_count == 12);
+    }
+
+    // --- Edge: very large content ---
+    {
+        std::string large(10000, 'a');
+        large += '\n';
+        auto result = counter::count_all(large);
+        assert(result.ok);
+        assert(result.line_count == 1);
+        assert(result.word_count == 1);
+        assert(result.byte_count == 10001);
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/tests/test_file_opener.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/tests/test_file_opener.cpp
@@ -1,0 +1,56 @@
+#include "input/file_opener.h"
+#include <cassert>
+#include <cstdio>
+#include <string>
+#include <unistd.h>
+
+static std::string create_temp_file(const std::string& content) {
+    std::string path = "/tmp/test_wc_tool_XXXXXX";
+    char buf[1024];
+    snprintf(buf, sizeof(buf), "%s", path.c_str());
+    int fd = mkstemp(buf);
+    if (fd < 0) return "";
+    write(fd, content.c_str(), content.size());
+    close(fd);
+    return buf;
+}
+
+int main() {
+    // --- Happy path: valid file ---
+    {
+        std::string tmp = create_temp_file("hello\nworld\n");
+        assert(!tmp.empty());
+        auto result = input::open_file(tmp);
+        assert(result.ok);
+        char buf[256];
+        result.stream.getline(buf, sizeof(buf));
+        assert(result.stream);
+        std::remove(tmp.c_str());
+    }
+
+    // --- Happy path: empty file ---
+    {
+        std::string tmp = create_temp_file("");
+        assert(!tmp.empty());
+        auto result = input::open_file(tmp);
+        assert(result.ok);
+        assert(!result.stream.eof());
+        std::remove(tmp.c_str());
+    }
+
+    // --- Error: file does not exist ---
+    {
+        auto result = input::open_file("/nonexistent/path/file_does_not_exist.txt");
+        assert(!result.ok);
+        assert(!result.error_message.empty());
+    }
+
+    // --- Error: empty filename ---
+    {
+        auto result = input::open_file("");
+        assert(!result.ok);
+        assert(!result.error_message.empty());
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/tests/test_line_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/tests/test_line_counter.cpp
@@ -1,0 +1,72 @@
+#include "counter/line_counter.h"
+#include <cassert>
+#include <string>
+
+int main() {
+    // --- Happy path: empty content ---
+    {
+        auto result = counter::count_lines("");
+        assert(result.ok);
+        assert(result.line_count == 0);
+    }
+
+    // --- Happy path: single line without trailing newline ---
+    {
+        auto result = counter::count_lines("hello");
+        assert(result.ok);
+        assert(result.line_count == 0);
+    }
+
+    // --- Happy path: single line with trailing newline ---
+    {
+        auto result = counter::count_lines("hello\n");
+        assert(result.ok);
+        assert(result.line_count == 1);
+    }
+
+    // --- Happy path: multiple lines with trailing newline ---
+    {
+        auto result = counter::count_lines("line1\nline2\nline3\n");
+        assert(result.ok);
+        assert(result.line_count == 3);
+    }
+
+    // --- Happy path: multiple lines without trailing newline ---
+    {
+        auto result = counter::count_lines("line1\nline2\nline3");
+        assert(result.ok);
+        assert(result.line_count == 2);
+    }
+
+    // --- Happy path: single newline only ---
+    {
+        auto result = counter::count_lines("\n");
+        assert(result.ok);
+        assert(result.line_count == 1);
+    }
+
+    // --- Happy path: multiple consecutive newlines ---
+    {
+        auto result = counter::count_lines("\n\n\n");
+        assert(result.ok);
+        assert(result.line_count == 3);
+    }
+
+    // --- Happy path: empty lines mixed ---
+    {
+        auto result = counter::count_lines("\nhello\n\nworld\n");
+        assert(result.ok);
+        assert(result.line_count == 4);
+    }
+
+    // --- Edge: very large content ---
+    {
+        std::string large(10000, 'a');
+        large += '\n';
+        auto result = counter::count_lines(large);
+        assert(result.ok);
+        assert(result.line_count == 1);
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/tests/test_output_formatter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/tests/test_output_formatter.cpp
@@ -1,0 +1,43 @@
+#include "output/formatter.h"
+#include <cassert>
+#include <string>
+
+int main() {
+    // --- Happy path: basic formatting ---
+    {
+        std::string output = output::format_output(10, 50, 200, "myfile.txt");
+        assert(output == "10 50 200 myfile.txt");
+    }
+
+    // --- Happy path: zero counts ---
+    {
+        std::string output = output::format_output(0, 0, 0, "empty.txt");
+        assert(output == "0 0 0 empty.txt");
+    }
+
+    // --- Happy path: single values ---
+    {
+        std::string output = output::format_output(1, 1, 1, "a.txt");
+        assert(output == "1 1 1 a.txt");
+    }
+
+    // --- Happy path: large values ---
+    {
+        std::string output = output::format_output(999999, 5000000, 10000000, "big.txt");
+        assert(output == "999999 5000000 10000000 big.txt");
+    }
+
+    // --- Happy path: filename with path ---
+    {
+        std::string output = output::format_output(1, 2, 3, "/path/to/file.txt");
+        assert(output == "1 2 3 /path/to/file.txt");
+    }
+
+    // --- Happy path: filename with spaces ---
+    {
+        std::string output = output::format_output(1, 2, 3, "my file.txt");
+        assert(output == "1 2 3 my file.txt");
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/tests/test_word_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/input/tests/test_word_counter.cpp
@@ -1,0 +1,81 @@
+#include "counter/word_counter.h"
+#include <cassert>
+#include <string>
+
+int main() {
+    // --- Happy path: empty content ---
+    {
+        auto result = counter::count_words("");
+        assert(result.ok);
+        assert(result.word_count == 0);
+    }
+
+    // --- Happy path: single word ---
+    {
+        auto result = counter::count_words("hello");
+        assert(result.ok);
+        assert(result.word_count == 1);
+    }
+
+    // --- Happy path: multiple words ---
+    {
+        auto result = counter::count_words("hello world");
+        assert(result.ok);
+        assert(result.word_count == 2);
+    }
+
+    // --- Happy path: multiple words with extra spaces ---
+    {
+        auto result = counter::count_words("  hello   world  ");
+        assert(result.ok);
+        assert(result.word_count == 2);
+    }
+
+    // --- Happy path: words with newlines ---
+    {
+        auto result = counter::count_words("one\ntwo\nthree\n");
+        assert(result.ok);
+        assert(result.word_count == 3);
+    }
+
+    // --- Happy path: tabs as separators ---
+    {
+        auto result = counter::count_words("a\tb\tc");
+        assert(result.ok);
+        assert(result.word_count == 3);
+    }
+
+    // --- Happy path: mixed whitespace ---
+    {
+        auto result = counter::count_words("  \n\t  hello\t world\n");
+        assert(result.ok);
+        assert(result.word_count == 2);
+    }
+
+    // --- Happy path: only whitespace ---
+    {
+        auto result = counter::count_words("   \n\t  ");
+        assert(result.ok);
+        assert(result.word_count == 0);
+    }
+
+    // --- Happy path: single character words ---
+    {
+        auto result = counter::count_words("a b c d e");
+        assert(result.ok);
+        assert(result.word_count == 5);
+    }
+
+    // --- Edge: large content ---
+    {
+        std::string large;
+        for (int i = 0; i < 1000; ++i) {
+            large += "word ";
+        }
+        auto result = counter::count_words(large);
+        assert(result.ok);
+        assert(result.word_count == 1000);
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/project_config.json
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/main_entry/project_config.json
@@ -1,0 +1,72 @@
+{
+  "project_name": "cpp_wc",
+  "development_mode": "local",
+  "process_type": "waterfall_v2",
+  "ui_language": "en",
+  "default_model": {
+    "provider": "Local",
+    "model": "qwen3.6-35b",
+    "api_key": "",
+    "base_url": "http://127.0.0.1:8088/v1",
+    "temperature": 0.7,
+    "max_tokens": 4096
+  },
+  "model_providers": [
+    {
+      "provider": "Local",
+      "api_key": "",
+      "base_url": "http://127.0.0.1:8088/v1",
+      "enabled": true
+    }
+  ],
+  "agents": {
+    "product_manager": {
+      "name": "product_manager",
+      "enabled": true
+    },
+    "architect": {
+      "name": "architect",
+      "enabled": true
+    },
+    "developer": {
+      "name": "developer",
+      "enabled": true
+    },
+    "qa_engineer": {
+      "name": "qa_engineer",
+      "enabled": true
+    },
+    "project_manager": {
+      "name": "project_manager",
+      "enabled": true
+    },
+    "rd_director": {
+      "name": "rd_director",
+      "enabled": true
+    }
+  },
+  "agent_model_selection": {},
+  "workflow": {
+    "max_review_iterations": 3,
+    "fail_on_review_rejection": false
+  },
+  "session": {
+    "max_concurrent_sessions": 5
+  },
+  "workspace": {
+    "projects_root": "projects",
+    "artifacts_root": "artifacts",
+    "auto_create_dirs": true
+  },
+  "logging": {
+    "level": "INFO",
+    "log_dir": "logs",
+    "json_format": false,
+    "rotate_daily": true
+  },
+  "github": {
+    "token": "",
+    "repo_owner": "",
+    "repo_name": ""
+  }
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/requirements/case.yaml
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/requirements/case.yaml
@@ -1,0 +1,44 @@
+aise_version: "0.1.0"
+scenario_id: cpp_wc_cli
+phase: requirements
+
+input_dir: input/
+project_config_file: project_config.json
+
+requirement: |
+  Build a C++17 command-line tool similar to ``wc`` (word count).
+  - Usage: wc-tool <file> — prints lines, words, bytes + filename.
+  - Build with CMake (CMakeLists.txt at project root, C++17 strict).
+  - Test with CTest (no third-party deps; <cassert> is fine).
+  - Source layout: src/main.cpp + per-feature .cpp under src/<subsystem>/.
+  - Single static binary; stdlib only; stdout/stderr only.
+  - Unit tests for line / word / byte primitives.
+
+max_review_iterations: 1
+timeout_sec: 600
+
+assertions:
+  - { name: requirement_md_present,         path: docs/requirement.md, predicate: file_exists }
+  - { name: requirement_md_substantial,     path: docs/requirement.md, predicate: { min_bytes: 1500 } }
+  - { name: requirement_contract_present,   path: docs/requirement_contract.json, predicate: file_exists }
+  - name: requirement_contract_schema_valid
+    path: docs/requirement_contract.json
+    predicate: { schema: schemas/requirement_contract.schema.json }
+  - name: covers_cpp_or_c_plus_plus
+    path: docs/requirement.md
+    predicate: { contains_keywords: { any_of: ["C++", "C++17", "cpp"] } }
+  - name: covers_wc_semantics
+    path: docs/requirement.md
+    predicate: { contains_keywords: { any_of: [lines, words, bytes, "word count"] } }
+  - name: covers_cmake_or_ctest
+    path: docs/requirement.md
+    predicate: { contains_keywords: { any_of: [CMake, ctest, "CMakeLists"] } }
+  - name: at_least_three_FRs
+    path: docs/requirement.md
+    predicate: { regex_count: { pattern: "FR-\\d+", min: 3 } }
+  - name: contract_lists_FRs
+    path: docs/requirement_contract.json
+    predicate: { count_at_least: { field: functional_requirements, min: 3 } }
+  - name: not_a_python_or_typescript
+    path: docs/requirement.md
+    predicate: { forbidden_patterns: { patterns: ["pyproject\\.toml", "package\\.json", "tsconfig\\.json"] } }

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/requirements/project_config.json
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/requirements/project_config.json
@@ -1,0 +1,72 @@
+{
+  "project_name": "cpp_wc",
+  "development_mode": "local",
+  "process_type": "waterfall_v2",
+  "ui_language": "en",
+  "default_model": {
+    "provider": "Local",
+    "model": "qwen3.6-35b",
+    "api_key": "",
+    "base_url": "http://127.0.0.1:8088/v1",
+    "temperature": 0.7,
+    "max_tokens": 4096
+  },
+  "model_providers": [
+    {
+      "provider": "Local",
+      "api_key": "",
+      "base_url": "http://127.0.0.1:8088/v1",
+      "enabled": true
+    }
+  ],
+  "agents": {
+    "product_manager": {
+      "name": "product_manager",
+      "enabled": true
+    },
+    "architect": {
+      "name": "architect",
+      "enabled": true
+    },
+    "developer": {
+      "name": "developer",
+      "enabled": true
+    },
+    "qa_engineer": {
+      "name": "qa_engineer",
+      "enabled": true
+    },
+    "project_manager": {
+      "name": "project_manager",
+      "enabled": true
+    },
+    "rd_director": {
+      "name": "rd_director",
+      "enabled": true
+    }
+  },
+  "agent_model_selection": {},
+  "workflow": {
+    "max_review_iterations": 3,
+    "fail_on_review_rejection": false
+  },
+  "session": {
+    "max_concurrent_sessions": 5
+  },
+  "workspace": {
+    "projects_root": "projects",
+    "artifacts_root": "artifacts",
+    "auto_create_dirs": true
+  },
+  "logging": {
+    "level": "INFO",
+    "log_dir": "logs",
+    "json_format": false,
+    "rotate_daily": true
+  },
+  "github": {
+    "token": "",
+    "repo_owner": "",
+    "repo_name": ""
+  }
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/case.yaml
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/case.yaml
@@ -1,0 +1,31 @@
+aise_version: "0.1.0"
+scenario_id: cpp_wc_cli
+phase: verification
+
+input_dir: input/
+project_config_file: project_config.json
+
+requirement: |
+  Build a C++17 ``wc``-like CLI — verify behavioral scenarios.
+
+max_review_iterations: 1
+timeout_sec: 1200
+
+assertions:
+  - name: behavioral_contract_has_enough_scenarios
+    path: docs/behavioral_contract.json
+    predicate: { min_scenarios: 3 }
+
+  # qa_report.json — same softening as TS/Go: qa_engineer skips writing
+  # it when ctest / cmake aren't on PATH. severity=warn until the
+  # qa_engineer prompt is updated to always emit ran=false.
+  - name: qa_report_present
+    path: docs/qa_report.json
+    predicate: file_exists
+    severity: warn
+
+  # Toolchain-honesty: don't fabricate pytest results on a C++ project.
+  - name: qa_report_no_pytest_on_cpp
+    path: docs/qa_report.json
+    predicate: { forbidden_patterns: { patterns: ["\"pytest\"\\s*:\\s*\\{[^}]*\"ran\"\\s*:\\s*true"] } }
+    severity: warn

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/CMakeLists.txt
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/CMakeLists.txt
@@ -1,0 +1,122 @@
+cmake_minimum_required(VERSION 3.14)
+project(wc-tool VERSION 1.0.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Static library — all subsystem source compiled once
+add_library(wc-tool-lib
+    src/input/arg_parser.cpp
+    src/input/file_opener.cpp
+    src/counter/line_counter.cpp
+    src/counter/word_counter.cpp
+    src/counter/byte_counter.cpp
+    src/counter/combined_counter.cpp
+    src/output/formatter.cpp
+)
+target_include_directories(wc-tool-lib PUBLIC src)
+
+# Main executable
+add_executable(wc-tool src/main.cpp)
+target_link_libraries(wc-tool PRIVATE wc-tool-lib)
+
+# Unit test executables — each links against the shared library
+add_executable(test_line_counter tests/test_line_counter.cpp)
+target_link_libraries(test_line_counter PRIVATE wc-tool-lib)
+
+add_executable(test_word_counter tests/test_word_counter.cpp)
+target_link_libraries(test_word_counter PRIVATE wc-tool-lib)
+
+add_executable(test_byte_counter tests/test_byte_counter.cpp)
+target_link_libraries(test_byte_counter PRIVATE wc-tool-lib)
+
+add_executable(test_combined_counter tests/test_combined_counter.cpp)
+target_link_libraries(test_combined_counter PRIVATE wc-tool-lib)
+
+add_executable(test_arg_parser tests/test_arg_parser.cpp)
+target_link_libraries(test_arg_parser PRIVATE wc-tool-lib)
+
+add_executable(test_file_opener tests/test_file_opener.cpp)
+target_link_libraries(test_file_opener PRIVATE wc-tool-lib)
+
+add_executable(test_output_formatter tests/test_output_formatter.cpp)
+target_link_libraries(test_output_formatter PRIVATE wc-tool-lib)
+
+# E2E test executables — each links against the shared library
+add_executable(test_e2e_normal_file tests/test_e2e_normal_file.cpp)
+target_link_libraries(test_e2e_normal_file PRIVATE wc-tool-lib)
+
+add_executable(test_e2e_empty_file tests/test_e2e_empty_file.cpp)
+target_link_libraries(test_e2e_empty_file PRIVATE wc-tool-lib)
+
+add_executable(test_e2e_no_argument tests/test_e2e_no_argument.cpp)
+target_link_libraries(test_e2e_no_argument PRIVATE wc-tool-lib)
+
+add_executable(test_e2e_file_not_found tests/test_e2e_file_not_found.cpp)
+target_link_libraries(test_e2e_file_not_found PRIVATE wc-tool-lib)
+
+add_executable(test_e2e_no_trailing_newline tests/test_e2e_no_trailing_newline.cpp)
+target_link_libraries(test_e2e_no_trailing_newline PRIVATE wc-tool-lib)
+
+# === Scenario integration tests (tests/scenarios/) ===
+add_executable(scenario_line_counter tests/scenarios/test_line_counter.cpp)
+target_link_libraries(scenario_line_counter PRIVATE wc-tool-lib)
+
+add_executable(scenario_word_counter tests/scenarios/test_word_counter.cpp)
+target_link_libraries(scenario_word_counter PRIVATE wc-tool-lib)
+
+add_executable(scenario_byte_counter tests/scenarios/test_byte_counter.cpp)
+target_link_libraries(scenario_byte_counter PRIVATE wc-tool-lib)
+
+add_executable(scenario_arg_parser tests/scenarios/test_arg_parser.cpp)
+target_link_libraries(scenario_arg_parser PRIVATE wc-tool-lib)
+
+add_executable(scenario_output_formatter tests/scenarios/test_output_formatter.cpp)
+target_link_libraries(scenario_output_formatter PRIVATE wc-tool-lib)
+
+add_executable(scenario_e2e_normal_file tests/scenarios/e2e_normal_file.cpp)
+target_link_libraries(scenario_e2e_normal_file PRIVATE wc-tool-lib)
+
+add_executable(scenario_e2e_empty_file tests/scenarios/e2e_empty_file.cpp)
+target_link_libraries(scenario_e2e_empty_file PRIVATE wc-tool-lib)
+
+add_executable(scenario_e2e_no_argument tests/scenarios/e2e_no_argument.cpp)
+target_link_libraries(scenario_e2e_no_argument PRIVATE wc-tool-lib)
+
+add_executable(scenario_e2e_file_not_found tests/scenarios/e2e_file_not_found.cpp)
+target_link_libraries(scenario_e2e_file_not_found PRIVATE wc-tool-lib)
+
+add_executable(scenario_e2e_no_trailing_newline tests/scenarios/e2e_no_trailing_newline.cpp)
+target_link_libraries(scenario_e2e_no_trailing_newline PRIVATE wc-tool-lib)
+
+# Enable testing
+enable_testing()
+
+# Unit tests
+add_test(NAME LineCounterTest COMMAND test_line_counter)
+add_test(NAME WordCounterTest COMMAND test_word_counter)
+add_test(NAME ByteCounterTest COMMAND test_byte_counter)
+add_test(NAME CombinedCounterTest COMMAND test_combined_counter)
+add_test(NAME ArgParserTest COMMAND test_arg_parser)
+add_test(NAME OutputFormatterTest COMMAND test_output_formatter)
+add_test(NAME FileOpenerTest COMMAND test_file_opener)
+
+# E2E unit tests
+add_test(NAME E2ENormalFileTest COMMAND test_e2e_normal_file)
+add_test(NAME E2EEmptyFileTest COMMAND test_e2e_empty_file)
+add_test(NAME E2ENoArgumentTest COMMAND test_e2e_no_argument)
+add_test(NAME E2EFileNotFoundTest COMMAND test_e2e_file_not_found)
+add_test(NAME E2ENoTrailingNewlineTest COMMAND test_e2e_no_trailing_newline)
+
+# Scenario integration tests
+add_test(NAME ScenarioLineCounterTest COMMAND scenario_line_counter)
+add_test(NAME ScenarioWordCounterTest COMMAND scenario_word_counter)
+add_test(NAME ScenarioByteCounterTest COMMAND scenario_byte_counter)
+add_test(NAME ScenarioArgParserTest COMMAND scenario_arg_parser)
+add_test(NAME ScenarioOutputFormatterTest COMMAND scenario_output_formatter)
+add_test(NAME ScenarioE2ENormalFileTest COMMAND scenario_e2e_normal_file)
+add_test(NAME ScenarioE2EEmptyFileTest COMMAND scenario_e2e_empty_file)
+add_test(NAME ScenarioE2ENoArgumentTest COMMAND scenario_e2e_no_argument)
+add_test(NAME ScenarioE2EFileNotFoundTest COMMAND scenario_e2e_file_not_found)
+add_test(NAME ScenarioE2ENoTrailingNewlineTest COMMAND scenario_e2e_no_trailing_newline)

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/docs/architecture.md
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/docs/architecture.md
@@ -1,0 +1,526 @@
+# wc-tool 架构设计文档
+
+## 1. 概述
+
+本文档描述 wc-tool — 一个类 Unix `wc` 命令行工具 — 的架构设计。该工具读取指定文件，统计行数、单词数和字节数，并将结果输出到标准输出。
+
+## 2. 技术栈
+
+| 项目 | 选择 | 理由 |
+|------|------|------|
+| 语言 | C++17 | 标准库提供完整的文件系统、流处理、字符串处理能力 |
+| 构建系统 | CMake | 跨平台构建，与CTest原生集成，支持C++17标准 |
+| 测试框架 | CTest + cassert | 标准库断言，无第三方依赖，与CMake原生集成 |
+| 运行时依赖 | 无 | 仅使用C++标准库，单静态二进制，无动态链接 |
+| 代码风格 | C++17 严格模式 | 启用C++17，禁用扩展，确保可移植性 |
+
+## 3. 系统上下文 (C4 Context)
+
+```mermaid
+C4Context
+  title System Context - wc-tool
+  Person(user, "用户", "在命令行中运行wc-tool的终端用户")
+  System(wc_tool, "wc-tool", "命令行单词计数工具", "统计文件的行数、单词数和字节数")
+  System_Ext(file_system, "文件系统", "本地文件系统，提供输入文件")
+  System_Ext(shell, "命令行Shell", "Unix/Linux/macOS终端环境")
+
+  Rel(user, shell, "执行")
+  Rel(shell, wc_tool, "启动并传递参数")
+  Rel(wc_tool, file_system, "读取文件")
+  Rel(wc_tool, user, "输出结果到stdout")
+  
+  UpdateLayoutConfig()
+```
+
+## 4. 容器分解 (C4 Container)
+
+```mermaid
+C4Container
+  title Container View - wc-tool
+  System_Boundary(app, "wc-tool 应用") {
+    Component(main, "main.cpp", "入口点，协调各子系统", "C++")
+    Component(arg_parser, "arg_parser.cpp", "解析并验证命令行参数", "C++")
+    Component(file_opener, "file_opener.cpp", "打开文件流", "C++")
+    Component(line_counter, "line_counter.cpp", "统计换行符数量", "C++")
+    Component(word_counter, "word_counter.cpp", "统计单词数量", "C++")
+    Component(byte_counter, "byte_counter.cpp", "统计字节数量", "C++")
+    Component(formatter, "formatter.cpp", "格式化输出结果", "C++")
+  }
+  
+  Rel(main, arg_parser, "调用")
+  Rel(main, file_opener, "调用")
+  Rel(main, line_counter, "调用")
+  Rel(main, word_counter, "调用")
+  Rel(main, byte_counter, "调用")
+  Rel(main, formatter, "调用")
+  
+  UpdateLayoutConfig()
+```
+
+## 5. 组件分解 (C4 Component)
+
+```mermaid
+C4Component
+  title Component View - 内部组件关系
+  Container_Boundary(input_boundary, "输入子系统") {
+    Component(arg_parser, "arg_parser", "解析并验证命令行参数", "C++")
+    Component(file_opener, "file_opener", "打开文件流", "C++")
+  }
+  
+  Container_Boundary(counter_boundary, "计数子系统") {
+    Component(line_counter, "line_counter", "统计换行符数量", "C++")
+    Component(word_counter, "word_counter", "统计单词数量", "C++")
+    Component(byte_counter, "byte_counter", "统计字节数量", "C++")
+  }
+  
+  Container_Boundary(output_boundary, "输出子系统") {
+    Component(formatter, "formatter", "格式化输出结果", "C++")
+  }
+  
+  Rel(main, arg_parser, "parse_file_argument", "参数验证")
+  Rel(main, file_opener, "open_file", "文件打开")
+  Rel(main, line_counter, "count_lines", "行计数")
+  Rel(main, word_counter, "count_words", "词计数")
+  Rel(main, byte_counter, "count_bytes", "字节计数")
+  Rel(main, formatter, "print_result", "结果输出")
+  
+  UpdateLayoutConfig()
+```
+
+## 6. 数据模型
+
+### 6.1 输入数据
+
+```mermaid
+erDiagram
+    FILE {
+        string path "文件路径"
+        int64 size "文件大小（字节）"
+        int64 line_count "换行符数量"
+        int64 word_count "单词数量"
+        int64 byte_count "字节数量"
+    }
+    
+    COMMAND_LINE {
+        int argc "参数数量"
+        string* argv "参数数组"
+        string file_path "提取的文件路径"
+    }
+    
+    FILE ||--o{ COMMAND_LINE : "从命令行获取"
+```
+
+### 6.2 输出数据
+
+输出格式：`<lines> <words> <bytes> <filename>`
+
+```mermaid
+erDiagram
+    OUTPUT_RESULT {
+        int64 lines "行数"
+        int64 words "词数"
+        int64 bytes "字节数"
+        string filename "文件名"
+    }
+    
+    OUTPUT_RESULT ||--o{ STDOUT : "输出到标准输出"
+```
+
+## 7. 模块依赖关系
+
+```mermaid
+flowchart TD
+    subgraph src ["src/"]
+        main["src/main.cpp"]
+        input["src/input/"]
+        counter["src/counter/"]
+        output["src/output/"]
+    end
+    
+    main --> input
+    main --> counter
+    main --> output
+    counter --> input
+    
+    UpdateLayoutConfig()
+```
+
+## 8. 组件交互流程
+
+### 8.1 主流程
+
+```mermaid
+sequenceDiagram
+    participant Main as main.cpp
+    participant Arg as arg_parser
+    participant File as file_opener
+    participant Line as line_counter
+    participant Word as word_counter
+    participant Byte as byte_counter
+    participant Out as formatter
+
+    Main->>Arg: parse_file_argument(argc, argv)
+    Arg-->>Main: filepath
+    Main->>File: open_file(filepath)
+    File-->>Main: ifstream
+    Main->>Line: count_lines(stream)
+    Line-->>Main: lines
+    Main->>Word: count_words(stream)
+    Word-->>Main: words
+    Main->>Byte: count_bytes(stream)
+    Byte-->>Main: bytes
+    Main->>Out: print_result(lines, words, bytes, filepath)
+    Out->>Out: cout << lines << " " << words << " " << bytes << " " << filename
+```
+
+### 8.2 错误处理流程
+
+```mermaid
+flowchart LR
+  A["用户执行 wc-tool"] --> B{"参数有效?"}
+  B -->|否| C["输出错误到stderr"]
+  C --> D["退出码1"]
+  B -->|是| E{"文件存在?"}
+  E -->|否| F["输出错误到stderr"]
+  F --> D
+  E -->|是| G["读取文件"]
+  G --> H["统计行数"]
+  H --> I["统计词数"]
+  I --> J["统计字节数"]
+  J --> K["输出结果"]
+```
+
+## 9. 测试架构
+
+### 9.1 单元测试
+
+| 测试名称 | 测试可执行文件 | 测试内容 | CTest 名称 |
+|----------|---------------|---------|-----------|
+| 行计数 | test_line_counter | FR-002 | LineCounterTest |
+| 单词计数 | test_word_counter | FR-003 | WordCounterTest |
+| 字节计数 | test_byte_counter | FR-004 | ByteCounterTest |
+| 参数解析 | test_arg_parser | FR-001 | ArgParserTest |
+| 输出格式化 | test_output_formatter | FR-005 | OutputFormatterTest |
+
+### 9.2 端到端测试 — 独立可执行
+
+每个端到端场景拥有**独立的测试可执行文件**和**唯一的 CTest 测试名**，确保可以通过 `ctest -R <name>` 单独执行：
+
+| 场景 ID | 描述 | CTest 名称 | 测试可执行文件 |
+|---------|------|-----------|---------------|
+| e2e_normal_file | 正常文件处理 | E2ENormalFileTest | test_e2e_normal_file |
+| e2e_empty_file | 空文件处理 | E2EEmptyFileTest | test_e2e_empty_file |
+| e2e_no_argument | 缺少参数 | E2ENoArgumentTest | test_e2e_no_argument |
+| e2e_file_not_found | 文件不存在 | E2EFileNotFoundTest | test_e2e_file_not_found |
+| e2e_no_trailing_newline | 无尾部换行符 | E2ENoTrailingNewlineTest | test_e2e_no_trailing_newline |
+
+```mermaid
+flowchart LR
+    subgraph unit_tests ["单元测试"]
+        tlc["LineCounterTest"]
+        twc["WordCounterTest"]
+        tbc["ByteCounterTest"]
+        tap["ArgParserTest"]
+        tof["OutputFormatterTest"]
+    end
+
+    subgraph e2e_tests ["端到端测试 — 独立可执行"]
+        en["E2ENormalFileTest"]
+        ee["E2EEmptyFileTest"]
+        ea["E2ENoArgumentTest"]
+        ef["E2EFileNotFoundTest"]
+        et["E2ENoTrailingNewlineTest"]
+    end
+
+    tlc -.->|依赖| en
+    twc -.->|依赖| en
+    tbc -.->|依赖| en
+    tap -.->|依赖| ea
+    tap -.->|依赖| ef
+    tof -.->|依赖| et
+```
+
+### 9.3 测试执行命令
+
+每个测试可独立执行：
+
+```
+ctest --test-dir build --output-on-failure --verbose -R E2ENormalFile
+ctest --test-dir build --output-on-failure --verbose -R E2EEmptyFile
+ctest --test-dir build --output-on-failure --verbose -R E2ENoArgument
+ctest --test-dir build --output-on-failure --verbose -R E2EFileNotFound
+ctest --test-dir build --output-on-failure --verbose -R E2ENoTrailingNewline
+```
+
+所有测试一起执行：
+
+```
+ctest --test-dir build --output-on-failure --verbose
+```
+
+## 9. 子系统详细设计
+
+### 9.1 输入子系统 (input)
+
+**职责**: 命令行参数解析和文件打开
+
+**组件**:
+- `arg_parser`: 验证argc == 2，提取argv[1]作为文件路径
+- `file_opener`: 使用`std::ifstream`以二进制模式打开文件
+
+**公共接口**:
+```cpp
+// arg_parser.h
+namespace input {
+    std::string parse_file_argument(int argc, char* argv[]);
+}
+
+// file_opener.h
+namespace input {
+    std::ifstream open_file(const std::string& path);
+}
+```
+
+### 9.2 计数子系统 (counter)
+
+**职责**: 行计数、单词计数和字节计数算法
+
+**组件**:
+- `line_counter`: 遍历文件流，统计'\n'字符数量
+- `word_counter`: 遍历文件流，统计非空白字符序列数量
+- `byte_counter`: 遍历文件流，统计所有字符数量
+
+**公共接口**:
+```cpp
+// line_counter.h
+namespace counter {
+    std::intmax_t count_lines(std::istream& stream);
+}
+
+// word_counter.h
+namespace counter {
+    std::intmax_t count_words(std::istream& stream);
+}
+
+// byte_counter.h
+namespace counter {
+    std::intmax_t count_bytes(std::istream& stream);
+}
+```
+
+### 9.3 输出子系统 (output)
+
+**职责**: 格式化并打印结果
+
+**组件**:
+- `formatter`: 将统计结果格式化为`<lines> <words> <bytes> <filename>`格式并输出到stdout
+
+**公共接口**:
+```cpp
+// formatter.h
+namespace output {
+    void print_result(std::intmax_t lines, std::intmax_t words, std::intmax_t bytes, const std::string& filename);
+}
+```
+
+## 10. 构建系统
+
+### 10.1 CMakeLists.txt
+
+```cmake
+cmake_minimum_required(VERSION 3.14)
+project(wc-tool VERSION 1.0.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# 主可执行文件
+add_executable(wc-tool
+    src/main.cpp
+    src/input/arg_parser.cpp
+    src/input/file_opener.cpp
+    src/counter/line_counter.cpp
+    src/counter/word_counter.cpp
+    src/counter/byte_counter.cpp
+    src/output/formatter.cpp
+)
+
+target_include_directories(wc-tool PRIVATE src)
+
+# 单元测试可执行文件
+add_executable(test_line_counter tests/test_line_counter.cpp)
+target_include_directories(test_line_counter PRIVATE src)
+
+add_executable(test_word_counter tests/test_word_counter.cpp)
+target_include_directories(test_word_counter PRIVATE src)
+
+add_executable(test_byte_counter tests/test_byte_counter.cpp)
+target_include_directories(test_byte_counter PRIVATE src)
+
+add_executable(test_arg_parser tests/test_arg_parser.cpp)
+target_include_directories(test_arg_parser PRIVATE src)
+
+add_executable(test_output_formatter tests/test_output_formatter.cpp)
+target_include_directories(test_output_formatter PRIVATE src)
+
+# 端到端测试 — 每个场景独立可执行文件
+add_executable(test_e2e_normal_file tests/test_e2e_normal_file.cpp)
+target_include_directories(test_e2e_normal_file PRIVATE src)
+
+add_executable(test_e2e_empty_file tests/test_e2e_empty_file.cpp)
+target_include_directories(test_e2e_empty_file PRIVATE src)
+
+add_executable(test_e2e_no_argument tests/test_e2e_no_argument.cpp)
+target_include_directories(test_e2e_no_argument PRIVATE src)
+
+add_executable(test_e2e_file_not_found tests/test_e2e_file_not_found.cpp)
+target_include_directories(test_e2e_file_not_found PRIVATE src)
+
+add_executable(test_e2e_no_trailing_newline tests/test_e2e_no_trailing_newline.cpp)
+target_include_directories(test_e2e_no_trailing_newline PRIVATE src)
+
+# 启用测试
+enable_testing()
+
+add_test(NAME LineCounterTest COMMAND test_line_counter)
+add_test(NAME WordCounterTest COMMAND test_word_counter)
+add_test(NAME ByteCounterTest COMMAND test_byte_counter)
+add_test(NAME ArgParserTest COMMAND test_arg_parser)
+add_test(NAME OutputFormatterTest COMMAND test_output_formatter)
+
+# 端到端测试 — 每个场景独立的 CTest 名称
+add_test(NAME E2ENormalFileTest COMMAND test_e2e_normal_file)
+add_test(NAME E2EEmptyFileTest COMMAND test_e2e_empty_file)
+add_test(NAME E2ENoArgumentTest COMMAND test_e2e_no_argument)
+add_test(NAME E2EFileNotFoundTest COMMAND test_e2e_file_not_found)
+add_test(NAME E2ENoTrailingNewlineTest COMMAND test_e2e_no_trailing_newline)
+```
+
+### 10.2 测试执行
+
+每个测试可独立执行：
+
+```
+ctest --test-dir build --output-on-failure --verbose -R E2ENormalFileTest
+ctest --test-dir build --output-on-failure --verbose -R E2EEmptyFileTest
+ctest --test-dir build --output-on-failure --verbose -R E2ENoArgumentTest
+ctest --test-dir build --output-on-failure --verbose -R E2EFileNotFoundTest
+ctest --test-dir build --output-on-failure --verbose -R E2ENoTrailingNewlineTest
+```
+
+所有测试一起执行：
+
+```
+ctest --test-dir build --output-on-failure --verbose
+```
+
+## 11. 测试策略
+
+### 11.1 单元测试
+
+每个计数原语有独立的测试可执行文件：
+
+| 测试名称 | 测试文件 | 测试内容 |
+|---------|---------|---------|
+| LineCounterTest | tests/test_line_counter.cpp | 空文件、单行、多行、无换行符、连续换行符 |
+| WordCounterTest | tests/test_word_counter.cpp | 空文件、单词、多词、连续空格、制表符、换行符、纯空白 |
+| ByteCounterTest | tests/test_byte_counter.cpp | 空文件、单字节、多字节、换行符、混合内容 |
+| ArgParserTest | tests/test_arg_parser.cpp | 有效参数、缺少参数、过多参数 |
+| OutputFormatterTest | tests/test_output_formatter.cpp | 正常输出、零值、大数值 |
+
+### 11.2 端到端测试
+
+每个端到端场景拥有**独立的测试可执行文件**和**唯一的 CTest 测试名**，确保可以通过 `ctest -R <name>` 单独执行：
+
+| 场景 ID | 描述 | CTest 名称 | 测试可执行文件 |
+|---------|------|-----------|---------------|
+| e2e_normal_file | 正常文件处理 | E2ENormalFileTest | test_e2e_normal_file |
+| e2e_empty_file | 空文件处理 | E2EEmptyFileTest | test_e2e_empty_file |
+| e2e_no_argument | 缺少参数 | E2ENoArgumentTest | test_e2e_no_argument |
+| e2e_file_not_found | 文件不存在 | E2EFileNotFoundTest | test_e2e_file_not_found |
+| e2e_no_trailing_newline | 无尾部换行符 | E2ENoTrailingNewlineTest | test_e2e_no_trailing_newline |
+
+```mermaid
+flowchart LR
+    subgraph unit_tests ["单元测试"]
+        tlc["LineCounterTest"]
+        twc["WordCounterTest"]
+        tbc["ByteCounterTest"]
+        tap["ArgParserTest"]
+        tof["OutputFormatterTest"]
+    end
+
+    subgraph e2e_tests ["端到端测试 — 独立可执行"]
+        en["E2ENormalFileTest"]
+        ee["E2EEmptyFileTest"]
+        ea["E2ENoArgumentTest"]
+        ef["E2EFileNotFoundTest"]
+        et["E2ENoTrailingNewlineTest"]
+    end
+
+    tlc -.->|依赖| en
+    twc -.->|依赖| en
+    tbc -.->|依赖| en
+    tap -.->|依赖| ea
+    tap -.->|依赖| ef
+    tof -.->|依赖| et
+```
+
+## 12. 错误处理
+
+| 错误场景 | 处理方式 | 错误位置 |
+|---------|---------|---------|
+| 无参数 | 输出"Usage: wc-tool <file>"到stderr，exit(1) | arg_parser |
+| 文件不存在 | 输出"Cannot open file: <path>"到stderr，exit(1) | file_opener |
+| 文件无法读取 | 输出"Cannot open file: <path>"到stderr，exit(1) | file_opener |
+
+## 13. 启动序列
+
+```mermaid
+sequenceDiagram
+    participant Main as main.cpp
+    participant Arg as arg_parser
+    participant File as file_opener
+    participant Line as line_counter
+    participant Word as word_counter
+    participant Byte as byte_counter
+    participant Out as formatter
+
+    Note over Main: 构造阶段
+    Main->>Arg: 初始化
+    Main->>File: 初始化
+    Main->>Line: 初始化
+    Main->>Word: 初始化
+    Main->>Byte: 初始化
+    Main->>Out: 初始化
+
+    Note over Main: 主循环阶段
+    Main->>Arg: parse_file_argument(argc, argv)
+    Arg-->>Main: filepath
+    Main->>File: open_file(filepath)
+    File-->>Main: ifstream
+    Main->>Line: count_lines(stream)
+    Line-->>Main: lines
+    Main->>Word: count_words(stream)
+    Word-->>Main: words
+    Main->>Byte: count_bytes(stream)
+    Byte-->>Main: bytes
+    Main->>Out: print_result(lines, words, bytes, filepath)
+    Out->>Out: cout << lines << " " << words << " " << bytes << " " << filename
+    Main->>Main: return 0
+```
+
+## 14. 性能考虑
+
+- 使用`std::istream::get()`逐字符读取，O(1)内存复杂度
+- 每个计数操作独立遍历文件，通过`seekg()`重置流位置
+- 对于大文件（GB级别），流处理确保内存使用恒定
+- 无动态内存分配，无堆分配
+
+## 15. 可移植性
+
+- 仅使用C++17标准库
+- 使用`std::filesystem`和`std::isspace`确保跨平台兼容
+- 支持Linux (glibc)、macOS (Apple clang)
+- 无平台特定API调用

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/docs/behavioral_contract.json
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/docs/behavioral_contract.json
@@ -1,0 +1,164 @@
+{
+  "scenarios": [
+    {
+      "id": "test_line_counter",
+      "name": "行计数单元测试",
+      "description": "测试行计数器的基本功能：空文件返回0，有换行符的文件正确计数，没有尾部换行符的文件正确计数",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R LineCounterTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-002"]
+    },
+    {
+      "id": "test_word_counter",
+      "name": "单词计数单元测试",
+      "description": "测试单词计数器的基本功能：空文件返回0，多个连续空格不产生额外单词，正确统计单词数",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R WordCounterTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-003"]
+    },
+    {
+      "id": "test_byte_counter",
+      "name": "字节计数单元测试",
+      "description": "测试字节计数器的基本功能：空文件返回0，正确统计文件字节数",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R ByteCounterTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-004"]
+    },
+    {
+      "id": "test_arg_parser",
+      "name": "参数解析单元测试",
+      "description": "测试参数解析器：正确参数返回文件路径，缺少参数抛出异常",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R ArgParserTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-001"]
+    },
+    {
+      "id": "test_output_formatter",
+      "name": "输出格式化单元测试",
+      "description": "测试输出格式化器：正确格式化并输出结果",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R OutputFormatterTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-005"]
+    },
+    {
+      "id": "e2e_normal_file",
+      "name": "端到端测试：正常文件处理",
+      "description": "端到端测试：使用wc-tool处理一个包含多行多词的文本文件，验证输出格式正确",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R E2ENormalFileTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-001", "FR-002", "FR-003", "FR-004", "FR-005"]
+    },
+    {
+      "id": "e2e_empty_file",
+      "name": "端到端测试：空文件处理",
+      "description": "端到端测试：使用wc-tool处理空文件，验证输出为 0 0 0 filename",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R E2EEmptyFileTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-002", "FR-003", "FR-004"]
+    },
+    {
+      "id": "e2e_no_argument",
+      "name": "端到端测试：缺少参数",
+      "description": "端到端测试：使用wc-tool不带参数运行，验证输出错误信息到stderr并返回非零退出码",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R E2ENoArgumentTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-001"]
+    },
+    {
+      "id": "e2e_file_not_found",
+      "name": "端到端测试：文件不存在",
+      "description": "端到端测试：使用wc-tool处理不存在的文件，验证输出错误信息到stderr并返回非零退出码",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R E2EFileNotFoundTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-001"]
+    },
+    {
+      "id": "e2e_no_trailing_newline",
+      "name": "端到端测试：无尾部换行符",
+      "description": "端到端测试：使用wc-tool处理没有尾部换行符的文件，验证wc兼容的行计数",
+      "preconditions": ["测试可执行文件已构建"],
+      "trigger": {
+        "action": "run",
+        "command": "ctest --test-dir build --output-on-failure --verbose -R E2ENoTrailingNewlineTest"
+      },
+      "effect": {
+        "exit_code": 0,
+        "stdout_contains": "Test project",
+        "stdout_contains": "Pass"
+      },
+      "covers_requirements": ["FR-002", "FR-003", "FR-004", "FR-005"]
+    }
+  ]
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/docs/requirement.md
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/docs/requirement.md
@@ -1,0 +1,251 @@
+# Requirement Specification — wc-tool
+
+## 功能需求
+
+### FR-001: File Input and Argument Parsing
+
+The tool accepts a single positional argument that specifies the path to the file to be
+analysed.
+
+- **FR-001.1** The tool MUST accept exactly one file path argument on the command line.
+- **FR-001.2** If no argument is provided, the tool MUST print an error message to
+  **stderr** and exit with a non-zero status code.
+- **FR-001.3** If the file does not exist or cannot be opened, the tool MUST print an
+  error message to **stderr** and exit with a non-zero status code.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_invoke(("Invoke wc-tool"))
+  uc_parse(("Parse file argument"))
+  uc_validate(("Validate file exists"))
+  actor_user --> uc_invoke
+  uc_invoke --> uc_parse
+  uc_parse --> uc_validate
+  uc_validate -->|missing arg| uc_error
+  uc_validate -->|file not found| uc_error
+  uc_error(["Error to stderr"])
+```
+
+### FR-002: Line Count
+
+The tool MUST count the number of newline characters (`\n`) in the file and report the
+result as the first integer in its output.
+
+- **FR-002.1** Each newline character (`\n`) in the file contributes exactly one to the
+  line count.
+- **FR-002.2** A file that is empty (zero bytes) MUST produce a line count of `0`.
+- **FR-002.3** A file whose last character is not a newline MUST still be counted as
+  containing one additional line (matching `wc` semantics).
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_read(("Read file"))
+  uc_count_lines(("Count lines"))
+  uc_report(("Report line count"))
+  actor_user --> uc_read
+  uc_read --> uc_count_lines
+  uc_count_lines --> uc_report
+```
+
+### FR-003: Word Count
+
+The tool MUST count the number of whitespace-delimited words in the file.
+
+- **FR-003.1** A word is defined as a maximal sequence of non-whitespace characters.
+  Whitespace characters are those recognised by `std::isspace` (space, tab, newline,
+  carriage return, form feed, vertical tab).
+- **FR-003.2** Empty files MUST produce a word count of `0`.
+- **FR-003.3** Multiple consecutive whitespace characters MUST NOT produce extra words.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_read(("Read file"))
+  uc_count_words(("Count words"))
+  uc_report(("Report word count"))
+  actor_user --> uc_read
+  uc_read --> uc_count_words
+  uc_count_words --> uc_report
+```
+
+### FR-004: Byte Count
+
+The tool MUST report the total number of bytes in the file.
+
+- **FR-004.1** The byte count is the file size in bytes as reported by the operating
+  system (e.g. `std::filesystem::file_size` or reading until EOF).
+- **FR-004.2** An empty file MUST produce a byte count of `0`.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_read(("Read file"))
+  uc_count_bytes(("Count bytes"))
+  uc_report(("Report byte count"))
+  actor_user --> uc_read
+  uc_read --> uc_count_bytes
+  uc_count_bytes --> uc_report
+```
+
+### FR-005: Output Format
+
+The tool MUST print three integers (lines, words, bytes) separated by single spaces,
+followed by the filename, to stdout.
+
+- **FR-005.1** The output format is: `<lines> <words> <bytes> <filename>`
+- **FR-005.2** Fields are separated by exactly one space.
+- **FR-005.3** The filename printed is the user-provided argument, not a canonicalised path.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_compute(("Compute statistics"))
+  uc_format(("Format output"))
+  uc_print(("Print to stdout"))
+  actor_user --> uc_compute
+  uc_compute --> uc_format
+  uc_format --> uc_print
+```
+
+### FR-006: Build System
+
+The project MUST be buildable with CMake using C++17 as the strict language standard,
+producing a single static binary with no runtime dependencies.
+
+- **FR-006.1** A `CMakeLists.txt` file exists at the project root.
+- **FR-006.2** The build system enforces C++17 via `set(CMAKE_CXX_STANDARD 17)`.
+- **FR-006.3** The build produces a single static binary with no runtime dependencies.
+
+```mermaid
+flowchart LR
+  actor_dev(["👤 Developer"])
+  uc_cmake(("Configure CMake"))
+  uc_build(("Build binary"))
+  uc_verify(("Verify binary"))
+  actor_dev --> uc_cmake
+  uc_cmake --> uc_build
+  uc_build --> uc_verify
+```
+
+### FR-007: Unit Tests
+
+The project MUST include unit tests for each counting primitive using the CTest framework
+with no third-party dependencies.
+
+- **FR-007.1** Separate test executables exist for line-count, word-count, and byte-count.
+- **FR-007.2** Tests are registered with `add_test` in CMake.
+- **FR-007.3** No third-party testing frameworks are used.
+
+```mermaid
+flowchart LR
+  actor_dev(["👤 Developer"])
+  uc_write_tests(("Write unit tests"))
+  uc_register(("Register with CTest"))
+  uc_run(("Run tests"))
+  actor_dev --> uc_write_tests
+  uc_write_tests --> uc_register
+  uc_register --> uc_run
+```
+
+## 非功能需求
+
+### NFR-001: Performance
+
+The tool reads the input file exactly once, processes files of at least 1 GB within
+30 seconds on standard hardware, and uses O(1) memory with respect to file size
+via streaming read.
+
+### NFR-002: Portability
+
+The tool compiles and runs on Linux (glibc) and macOS (Apple clang) using C++17,
+and is relocatable with no hardcoded paths.
+
+### NFR-003: Reliability
+
+The tool handles binary files gracefully without crashing and does not produce
+undefined behaviour on empty files, very large files, or files with unusual encodings.
+
+## 用例
+
+### UC-001: Count File Statistics
+
+**Actor:** User
+**Goal:** Obtain line, word, and byte counts for a given file.
+**Preconditions:** A file exists and is readable.
+**Main Flow:**
+1. User invokes `wc-tool <file_path>`.
+2. The tool opens the file for reading.
+3. The tool reads the file once, counting lines, words, and bytes.
+4. The tool prints the results to stdout.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_run(("Run wc-tool"))
+  uc_open(("Open file"))
+  uc_read(("Read and count"))
+  uc_output(("Output results"))
+  actor_user --> uc_run
+  uc_run --> uc_open
+  uc_open --> uc_read
+  uc_read --> uc_output
+```
+
+Covers: FR-001, FR-002, FR-003, FR-004, FR-005
+
+### UC-002: Handle Missing File Argument
+
+**Actor:** User
+**Goal:** Receive an error message when no file argument is provided.
+**Preconditions:** None.
+**Main Flow:**
+1. User invokes `wc-tool` without arguments.
+2. The tool detects the missing argument.
+3. The tool prints an error message to stderr.
+4. The tool exits with a non-zero status code.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_run(("Run wc-tool"))
+  uc_check(("Check arguments"))
+  uc_error(("Print error to stderr"))
+  uc_exit(("Exit with non-zero"))
+  actor_user --> uc_run
+  uc_run --> uc_check
+  uc_check -->|no args| uc_error
+  uc_error --> uc_exit
+```
+
+Covers: FR-001
+
+### UC-003: Handle Non-Existent File
+
+**Actor:** User
+**Goal:** Receive an error message when the specified file does not exist.
+**Preconditions:** None.
+**Main Flow:**
+1. User invokes `wc-tool <nonexistent_file>`.
+2. The tool attempts to open the file.
+3. The tool detects the file does not exist.
+4. The tool prints an error message to stderr.
+5. The tool exits with a non-zero status code.
+
+```mermaid
+flowchart LR
+  actor_user(["👤 User"])
+  uc_run(("Run wc-tool"))
+  uc_open(("Open file"))
+  uc_check(("Check if exists"))
+  uc_error(("Print error to stderr"))
+  uc_exit(("Exit with non-zero"))
+  actor_user --> uc_run
+  uc_run --> uc_open
+  uc_open --> uc_check
+  uc_check -->|not found| uc_error
+  uc_error --> uc_exit
+```
+
+Covers: FR-001

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/docs/requirement_contract.json
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/docs/requirement_contract.json
@@ -1,0 +1,156 @@
+{
+  "project_name": "wc-tool",
+  "summary": "A C++17 command-line tool that computes line count, word count, and byte count for a given file, mirroring the Unix wc utility. Built with CMake, tested with CTest, producing a single static binary with no runtime dependencies beyond the C++ standard library.",
+  "functional_requirements": [
+    {
+      "id": "FR-001",
+      "title": "File Input and Argument Parsing",
+      "description": "The tool accepts a single positional argument specifying the file path. It must validate the argument exists and the file is readable, printing errors to stderr and exiting non-zero on failure.",
+      "acceptance_criteria": [
+        "Exactly one file path argument is accepted",
+        "No argument produces an error to stderr with non-zero exit",
+        "Non-existent file produces an error to stderr with non-zero exit"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-002",
+      "title": "Line Count",
+      "description": "The tool counts newline characters as lines, with wc-compatible semantics: empty file yields 0, and a file without a trailing newline still counts the last line.",
+      "acceptance_criteria": [
+        "Each newline character contributes exactly one to line count",
+        "Empty file produces line count of 0",
+        "File without trailing newline still counts the final line"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-003",
+      "title": "Word Count",
+      "description": "The tool counts whitespace-delimited words where a word is a maximal sequence of non-whitespace characters. Multiple consecutive whitespace characters do not produce extra words.",
+      "acceptance_criteria": [
+        "A word is a maximal sequence of non-whitespace characters",
+        "Empty file produces word count of 0",
+        "Multiple consecutive whitespace characters do not produce extra words"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-004",
+      "title": "Byte Count",
+      "description": "The tool reports the total number of bytes in the file, equivalent to the file size in bytes as reported by the operating system.",
+      "acceptance_criteria": [
+        "Byte count equals the file size in bytes",
+        "Empty file produces byte count of 0"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-005",
+      "title": "Output Format",
+      "description": "The tool prints three integers (lines, words, bytes) separated by single spaces, followed by the filename, to stdout.",
+      "acceptance_criteria": [
+        "Output format is: <lines> <words> <bytes> <filename>",
+        "Fields are separated by exactly one space",
+        "Filename printed is the user-provided argument, not a canonicalised path"
+      ],
+      "priority": "P0"
+    },
+    {
+      "id": "FR-006",
+      "title": "Build System",
+      "description": "The project is buildable with CMake using C++17 as the strict language standard, producing a single static binary with no runtime dependencies.",
+      "acceptance_criteria": [
+        "CMakeLists.txt exists at the project root",
+        "Build system enforces C++17",
+        "Build produces a single static binary with no runtime dependencies"
+      ],
+      "priority": "P1"
+    },
+    {
+      "id": "FR-007",
+      "title": "Unit Tests",
+      "description": "The project includes unit tests for each counting primitive using the CTest framework with no third-party dependencies. Separate test executables are registered with add_test.",
+      "acceptance_criteria": [
+        "Separate test executables exist for line-count, word-count, and byte-count",
+        "Tests are registered with add_test in CMake",
+        "No third-party testing frameworks are used"
+      ],
+      "priority": "P1"
+    }
+  ],
+  "non_functional_requirements": [
+    {
+      "id": "NFR-001",
+      "title": "Performance",
+      "description": "The tool reads the input file exactly once, processes files of at least 1 GB within 30 seconds on standard hardware, and uses O(1) memory with respect to file size via streaming read.",
+      "priority": "P1"
+    },
+    {
+      "id": "NFR-002",
+      "title": "Portability",
+      "description": "The tool compiles and runs on Linux (glibc) and macOS (Apple clang) using C++17, and is relocatable with no hardcoded paths.",
+      "priority": "P1"
+    },
+    {
+      "id": "NFR-003",
+      "title": "Reliability",
+      "description": "The tool handles binary files gracefully without crashing and does not produce undefined behaviour on empty files, very large files, or files with unusual encodings.",
+      "priority": "P1"
+    }
+  ],
+  "use_cases": [
+    {
+      "id": "UC-001",
+      "actor": "User",
+      "goal": "Obtain line, word, and byte counts for a given file.",
+      "preconditions": [
+        "A file exists and is readable"
+      ],
+      "main_flow": [
+        "User invokes wc-tool with a file path argument",
+        "The tool opens the file for reading",
+        "The tool reads the file once, counting lines, words, and bytes",
+        "The tool prints the results to stdout in the format: lines words bytes filename"
+      ],
+      "covers_requirements": [
+        "FR-001",
+        "FR-002",
+        "FR-003",
+        "FR-004",
+        "FR-005"
+      ]
+    },
+    {
+      "id": "UC-002",
+      "actor": "User",
+      "goal": "Receive an error message when no file argument is provided.",
+      "preconditions": [],
+      "main_flow": [
+        "User invokes wc-tool without arguments",
+        "The tool detects the missing argument",
+        "The tool prints an error message to stderr",
+        "The tool exits with a non-zero status code"
+      ],
+      "covers_requirements": [
+        "FR-001"
+      ]
+    },
+    {
+      "id": "UC-003",
+      "actor": "User",
+      "goal": "Receive an error message when the specified file does not exist.",
+      "preconditions": [],
+      "main_flow": [
+        "User invokes wc-tool with a non-existent file path",
+        "The tool attempts to open the file",
+        "The tool detects the file does not exist",
+        "The tool prints an error message to stderr",
+        "The tool exits with a non-zero status code"
+      ],
+      "covers_requirements": [
+        "FR-001"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/docs/stack_contract.json
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/docs/stack_contract.json
@@ -1,0 +1,74 @@
+{
+  "language": "cpp",
+  "runtime": "native",
+  "framework_backend": "",
+  "framework_frontend": "",
+  "package_manager": "cmake",
+  "project_config_file": "CMakeLists.txt",
+  "test_runner": "ctest",
+  "static_analyzer": ["clang-tidy"],
+  "entry_point": "src/main.cpp",
+  "run_command": "cmake -B build && cmake --build build && ./build/wc-tool",
+  "ui_required": false,
+  "ui_kind": "",
+  "subsystems": [
+    {
+      "name": "input",
+      "src_dir": "src/input",
+      "responsibilities": "命令行参数解析和文件打开",
+      "components": [
+        {
+          "name": "arg_parser",
+          "file": "src/input/arg_parser.cpp",
+          "test_file": "tests/test_arg_parser.cpp",
+          "responsibility": "解析并验证命令行参数"
+        },
+        {
+          "name": "file_opener",
+          "file": "src/input/file_opener.cpp",
+          "test_file": "tests/test_file_opener.cpp",
+          "responsibility": "打开文件流进行读取"
+        }
+      ]
+    },
+    {
+      "name": "counter",
+      "src_dir": "src/counter",
+      "responsibilities": "行计数、单词计数和字节计数算法实现",
+      "components": [
+        {
+          "name": "line_counter",
+          "file": "src/counter/line_counter.cpp",
+          "test_file": "tests/test_line_counter.cpp",
+          "responsibility": "统计换行符数量"
+        },
+        {
+          "name": "word_counter",
+          "file": "src/counter/word_counter.cpp",
+          "test_file": "tests/test_word_counter.cpp",
+          "responsibility": "统计单词数量"
+        },
+        {
+          "name": "byte_counter",
+          "file": "src/counter/byte_counter.cpp",
+          "test_file": "tests/test_byte_counter.cpp",
+          "responsibility": "统计字节数量"
+        }
+      ]
+    },
+    {
+      "name": "output",
+      "src_dir": "src/output",
+      "responsibilities": "格式化并打印结果到标准输出",
+      "components": [
+        {
+          "name": "formatter",
+          "file": "src/output/formatter.cpp",
+          "test_file": "tests/test_output_formatter.cpp",
+          "responsibility": "将统计结果格式化为指定格式"
+        }
+      ]
+    }
+  ],
+  "lifecycle_inits": []
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/counter/byte_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/counter/byte_counter.cpp
@@ -1,0 +1,20 @@
+#include "counter/byte_counter.h"
+#include <string>
+
+namespace counter {
+
+/**
+ * Count the number of bytes in content.
+ * This is simply the string length in bytes.
+ *
+ * @param content  The text content to count bytes in
+ * @return         Result struct with ok flag and byte count
+ */
+ByteCountResult count_bytes(const std::string& content) {
+    ByteCountResult result;
+    result.ok = true;
+    result.byte_count = static_cast<int64_t>(content.size());
+    return result;
+}
+
+} // namespace counter

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/counter/byte_counter.h
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/counter/byte_counter.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+
+namespace counter {
+
+struct ByteCountResult {
+    bool ok;
+    int64_t byte_count;
+};
+
+/**
+ * Count the number of bytes in content.
+ * @param content  The text content to count bytes in
+ * @return         Result with ok flag and byte count
+ */
+ByteCountResult count_bytes(const std::string& content);
+
+} // namespace counter

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/counter/combined_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/counter/combined_counter.cpp
@@ -1,0 +1,45 @@
+#include "counter/combined_counter.h"
+#include <string>
+
+namespace counter {
+
+/**
+ * Compute lines, words, and bytes in a single pass over the content.
+ * This satisfies the requirement that the file is read only once.
+ *
+ * @param content  The text content to analyze
+ * @return         Combined stats with ok flag and all three counts
+ */
+CombinedStats count_all(const std::string& content) {
+    CombinedStats result;
+    result.ok = true;
+    result.line_count = 0;
+    result.word_count = 0;
+    result.byte_count = static_cast<int64_t>(content.size());
+
+    bool in_word = false;
+
+    for (char c : content) {
+        // Count bytes (already computed above, but this is the single pass)
+        // Line counting: count newlines
+        if (c == '\n') {
+            ++result.line_count;
+        }
+
+        // Word counting: track transitions from whitespace to non-whitespace
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v') {
+            if (in_word) {
+                in_word = false;
+            }
+        } else {
+            if (!in_word) {
+                ++result.word_count;
+                in_word = true;
+            }
+        }
+    }
+
+    return result;
+}
+
+} // namespace counter

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/counter/combined_counter.h
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/counter/combined_counter.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace counter {
+
+struct CombinedStats {
+    bool ok;
+    int64_t line_count;
+    int64_t word_count;
+    int64_t byte_count;
+};
+
+/**
+ * Compute lines, words, and bytes in a single pass over the content.
+ * This satisfies the requirement that the file is read only once.
+ *
+ * @param content  The text content to analyze
+ * @return         Combined stats with ok flag and all three counts
+ */
+CombinedStats count_all(const std::string& content);
+
+} // namespace counter

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/counter/line_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/counter/line_counter.cpp
@@ -1,0 +1,26 @@
+#include "counter/line_counter.h"
+#include <string>
+
+namespace counter {
+
+/**
+ * Count the number of newline characters in content.
+ *
+ * @param content  The text content to count lines in
+ * @return         Result struct with ok flag and line count
+ */
+LineCountResult count_lines(const std::string& content) {
+    LineCountResult result;
+    result.ok = true;
+    result.line_count = 0;
+
+    for (char c : content) {
+        if (c == '\n') {
+            ++result.line_count;
+        }
+    }
+
+    return result;
+}
+
+} // namespace counter

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/counter/line_counter.h
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/counter/line_counter.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+
+namespace counter {
+
+struct LineCountResult {
+    bool ok;
+    int64_t line_count;
+};
+
+/**
+ * Count the number of newline characters in content.
+ * @param content  The text content to count lines in
+ * @return         Result with ok flag and line count
+ */
+LineCountResult count_lines(const std::string& content);
+
+} // namespace counter

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/counter/word_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/counter/word_counter.cpp
@@ -1,0 +1,28 @@
+#include "counter/word_counter.h"
+#include <string>
+#include <sstream>
+
+namespace counter {
+
+/**
+ * Count the number of whitespace-separated words in content.
+ * Words are sequences of non-whitespace characters.
+ *
+ * @param content  The text content to count words in
+ * @return         Result struct with ok flag and word count
+ */
+WordCountResult count_words(const std::string& content) {
+    WordCountResult result;
+    result.ok = true;
+    result.word_count = 0;
+
+    std::istringstream stream(content);
+    std::string word;
+    while (stream >> word) {
+        ++result.word_count;
+    }
+
+    return result;
+}
+
+} // namespace counter

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/counter/word_counter.h
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/counter/word_counter.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+
+namespace counter {
+
+struct WordCountResult {
+    bool ok;
+    int64_t word_count;
+};
+
+/**
+ * Count the number of whitespace-separated words in content.
+ * @param content  The text content to count words in
+ * @return         Result with ok flag and word count
+ */
+WordCountResult count_words(const std::string& content);
+
+} // namespace counter

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/input/arg_parser.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/input/arg_parser.cpp
@@ -1,0 +1,21 @@
+#include "input/arg_parser.h"
+#include <cstdlib>
+#include <string>
+#include <stdexcept>
+
+namespace input {
+
+std::string parse_file_argument(int argc, char* argv[]) {
+    if (argc != 2) {
+        throw std::runtime_error("Usage: wc-tool <file>");
+    }
+
+    const char* file_arg = argv[1];
+    if (file_arg == nullptr || file_arg[0] == '\0') {
+        throw std::runtime_error("Error: empty filename");
+    }
+
+    return std::string(file_arg);
+}
+
+} // namespace input

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/input/arg_parser.h
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/input/arg_parser.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+namespace input {
+
+/**
+ * Parse and validate command-line arguments.
+ * Expects exactly one argument: the filename to process.
+ * @return the validated file path string
+ * @throws std::runtime_error if argc != 2 or filename is empty
+ */
+std::string parse_file_argument(int argc, char* argv[]);
+
+} // namespace input

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/input/file_opener.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/input/file_opener.cpp
@@ -1,0 +1,33 @@
+#include "input/file_opener.h"
+#include <fstream>
+#include <string>
+
+namespace input {
+
+/**
+ * Open a file for reading.
+ *
+ * @param filename  Path to the file to open
+ * @return          Result struct with ok flag, ifstream, and optional error message
+ */
+FileOpenResult open_file(const std::string& filename) {
+    FileOpenResult result;
+    result.ok = false;
+    result.error_message.clear();
+
+    if (filename.empty()) {
+        result.error_message = "Error: empty filename";
+        return result;
+    }
+
+    result.stream.open(filename, std::ios::in);
+    if (!result.stream.is_open()) {
+        result.error_message = "Error: cannot open file '" + filename + "'";
+        return result;
+    }
+
+    result.ok = true;
+    return result;
+}
+
+} // namespace input

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/input/file_opener.h
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/input/file_opener.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <fstream>
+#include <string>
+
+namespace input {
+
+struct FileOpenResult {
+    bool ok;
+    std::ifstream stream;
+    std::string error_message;
+};
+
+/**
+ * Open a file for reading.
+ * @param filename  Path to the file to open
+ * @return          Result with ok flag, stream, and optional error message
+ */
+FileOpenResult open_file(const std::string& filename);
+
+} // namespace input

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/main.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/main.cpp
@@ -1,0 +1,52 @@
+// wc-tool — a command-line word count utility.
+// Usage: wc-tool <file>
+// Output: <lines> <words> <bytes> <filename>
+
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <sstream>
+#include "input/arg_parser.h"
+#include "input/file_opener.h"
+#include "counter/combined_counter.h"
+#include "output/formatter.h"
+
+int main(int argc, char* argv[]) {
+    try {
+        // 1. Parse and validate arguments
+        std::string filepath = input::parse_file_argument(argc, argv);
+
+        // 2. Open the file
+        auto file_result = input::open_file(filepath);
+        if (!file_result.ok) {
+            std::cerr << file_result.error_message << std::endl;
+            return 1;
+        }
+
+        // 3. Read file content into a string (single read)
+        std::ostringstream content_stream;
+        content_stream << file_result.stream.rdbuf();
+        std::string content = content_stream.str();
+
+        // 4. Count lines, words, and bytes in a single pass
+        auto stats = counter::count_all(content);
+        if (!stats.ok) {
+            std::cerr << "Error computing statistics" << std::endl;
+            return 1;
+        }
+
+        // 5. Format and print results
+        std::string output = output::format_output(
+            stats.line_count,
+            stats.word_count,
+            stats.byte_count,
+            filepath
+        );
+        std::cout << output << std::endl;
+
+        return 0;
+    } catch (const std::runtime_error& e) {
+        std::cerr << e.what() << std::endl;
+        return 1;
+    }
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/output/formatter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/output/formatter.cpp
@@ -1,0 +1,24 @@
+#include "output/formatter.h"
+#include <string>
+#include <sstream>
+
+namespace output {
+
+/**
+ * Format the count results as a string for output.
+ * Format: "<lines> <words> <bytes> <filename>"
+ *
+ * @param lines    Number of lines
+ * @param words    Number of words
+ * @param bytes    Number of bytes
+ * @param filename The filename to display
+ * @return         Formatted string
+ */
+std::string format_output(int64_t lines, int64_t words, int64_t bytes,
+                          const std::string& filename) {
+    std::ostringstream oss;
+    oss << lines << " " << words << " " << bytes << " " << filename;
+    return oss.str();
+}
+
+} // namespace output

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/output/formatter.h
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/src/output/formatter.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace output {
+
+/**
+ * Format the count results as a string for output.
+ * Format: "<lines> <words> <bytes> <filename>"
+ */
+std::string format_output(int64_t lines, int64_t words, int64_t bytes,
+                          const std::string& filename);
+
+} // namespace output

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_arg_parser.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_arg_parser.cpp
@@ -1,0 +1,70 @@
+#include <cassert>
+#include <string>
+#include <stdexcept>
+#include "input/arg_parser.h"
+
+int main() {
+    // --- Happy path: exactly one argument ---
+    {
+        char buf[] = "myfile.txt";
+        char* argv[] = {buf, buf}; // argv[0] = program, argv[1] = file
+        std::string result = input::parse_file_argument(2, argv);
+        assert(result == "myfile.txt");
+    }
+
+    // --- Happy path: file path with directory ---
+    {
+        char buf[] = "/home/user/document.txt";
+        char* argv[] = {buf, buf};
+        std::string result = input::parse_file_argument(2, argv);
+        assert(result == "/home/user/document.txt");
+    }
+
+    // --- Happy path: file path with spaces ---
+    {
+        char buf[] = "my file.txt";
+        char* argv[] = {buf, buf};
+        std::string result = input::parse_file_argument(2, argv);
+        assert(result == "my file.txt");
+    }
+
+    // --- Error: no arguments (only program name) ---
+    {
+        char buf[] = "wc-tool";
+        char* argv[] = {buf};
+        try {
+            input::parse_file_argument(1, argv);
+            assert(false && "Should have thrown");
+        } catch (const std::runtime_error& e) {
+            assert(std::string(e.what()).find("Usage") != std::string::npos);
+        }
+    }
+
+    // --- Error: too many arguments ---
+    {
+        char buf1[] = "file1.txt";
+        char buf2[] = "file2.txt";
+        char buf3[] = "wc-tool";
+        char* argv[] = {buf3, buf1, buf2};
+        try {
+            input::parse_file_argument(3, argv);
+            assert(false && "Should have thrown");
+        } catch (const std::runtime_error& e) {
+            assert(std::string(e.what()).find("Usage") != std::string::npos);
+        }
+    }
+
+    // --- Edge: empty filename ---
+    {
+        char buf[] = "";
+        char* argv[] = {buf, buf};
+        try {
+            input::parse_file_argument(2, argv);
+            assert(false && "Should have thrown");
+        } catch (const std::runtime_error& e) {
+            assert(std::string(e.what()).find("empty") != std::string::npos);
+        }
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_byte_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_byte_counter.cpp
@@ -1,0 +1,65 @@
+#include "counter/byte_counter.h"
+#include <cassert>
+#include <string>
+
+int main() {
+    // --- Happy path: empty string ---
+    {
+        auto result = counter::count_bytes("");
+        assert(result.ok);
+        assert(result.byte_count == 0);
+    }
+
+    // --- Happy path: single byte ---
+    {
+        auto result = counter::count_bytes("a");
+        assert(result.ok);
+        assert(result.byte_count == 1);
+    }
+
+    // --- Happy path: multiple bytes ---
+    {
+        auto result = counter::count_bytes("hello world");
+        assert(result.ok);
+        assert(result.byte_count == 11);
+    }
+
+    // --- Happy path: with newline characters ---
+    {
+        auto result = counter::count_bytes("a\nb\n");
+        assert(result.ok);
+        assert(result.byte_count == 4);
+    }
+
+    // --- Happy path: only whitespace ---
+    {
+        auto result = counter::count_bytes("   \t\n");
+        assert(result.ok);
+        assert(result.byte_count == 5);
+    }
+
+    // --- Happy path: ASCII printable characters ---
+    {
+        auto result = counter::count_bytes("!@#$%");
+        assert(result.ok);
+        assert(result.byte_count == 5);
+    }
+
+    // --- Edge: large content ---
+    {
+        std::string s(10000, 'x');
+        auto result = counter::count_bytes(s);
+        assert(result.ok);
+        assert(result.byte_count == 10000);
+    }
+
+    // --- Edge: string with null character embedded ---
+    {
+        std::string s(3, '\0');
+        auto result = counter::count_bytes(s);
+        assert(result.ok);
+        assert(result.byte_count == 3);
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_combined_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_combined_counter.cpp
@@ -1,0 +1,135 @@
+#include "counter/combined_counter.h"
+#include <cassert>
+#include <string>
+
+int main() {
+    // --- Happy path: empty content ---
+    {
+        auto result = counter::count_all("");
+        assert(result.ok);
+        assert(result.line_count == 0);
+        assert(result.word_count == 0);
+        assert(result.byte_count == 0);
+    }
+
+    // --- Happy path: single word, no newline ---
+    {
+        auto result = counter::count_all("hello");
+        assert(result.ok);
+        assert(result.line_count == 0);
+        assert(result.word_count == 1);
+        assert(result.byte_count == 5);
+    }
+
+    // --- Happy path: single word with trailing newline ---
+    {
+        auto result = counter::count_all("hello\n");
+        assert(result.ok);
+        assert(result.line_count == 1);
+        assert(result.word_count == 1);
+        assert(result.byte_count == 6);
+    }
+
+    // --- Happy path: multiple lines with trailing newline ---
+    {
+        auto result = counter::count_all("line1\nline2\nline3\n");
+        assert(result.ok);
+        assert(result.line_count == 3);
+        assert(result.word_count == 3);
+        assert(result.byte_count == 18);
+    }
+
+    // --- Happy path: multiple lines without trailing newline ---
+    {
+        auto result = counter::count_all("line1\nline2\nline3");
+        assert(result.ok);
+        assert(result.line_count == 2);
+        assert(result.word_count == 3);
+        assert(result.byte_count == 17);
+    }
+
+    // --- Happy path: multiple words per line ---
+    {
+        auto result = counter::count_all("hello world\nfoo bar\n");
+        assert(result.ok);
+        assert(result.line_count == 2);
+        assert(result.word_count == 4);
+        assert(result.byte_count == 20);
+    }
+
+    // --- Happy path: extra whitespace ---
+    {
+        auto result = counter::count_all("  hello   world  \n");
+        assert(result.ok);
+        assert(result.line_count == 1);
+        assert(result.word_count == 2);
+        assert(result.byte_count == 18);
+    }
+
+    // --- Happy path: tabs as separators ---
+    {
+        auto result = counter::count_all("a\tb\tc\n");
+        assert(result.ok);
+        assert(result.line_count == 1);
+        assert(result.word_count == 3);
+        assert(result.byte_count == 6);
+    }
+
+    // --- Happy path: only whitespace ---
+    {
+        auto result = counter::count_all("   \n\t  ");
+        assert(result.ok);
+        assert(result.line_count == 1);
+        assert(result.word_count == 0);
+        assert(result.byte_count == 7);
+    }
+
+    // --- Happy path: only newlines ---
+    {
+        auto result = counter::count_all("\n\n\n");
+        assert(result.ok);
+        assert(result.line_count == 3);
+        assert(result.word_count == 0);
+        assert(result.byte_count == 3);
+    }
+
+    // --- Happy path: mixed empty lines ---
+    {
+        auto result = counter::count_all("\nhello\n\nworld\n");
+        assert(result.ok);
+        assert(result.line_count == 4);
+        assert(result.word_count == 2);
+        assert(result.byte_count == 14);
+    }
+
+    // --- Happy path: single character words ---
+    {
+        auto result = counter::count_all("a b c d e");
+        assert(result.ok);
+        assert(result.line_count == 0);
+        assert(result.word_count == 5);
+        assert(result.byte_count == 9);
+    }
+
+    // --- Happy path: carriage return as whitespace ---
+    {
+        auto result = counter::count_all("hello\rworld\n");
+        assert(result.ok);
+        assert(result.line_count == 1);
+        assert(result.word_count == 2);
+        assert(result.byte_count == 12);
+    }
+
+    // --- Edge: very large content ---
+    {
+        std::string large(10000, 'a');
+        large += '\n';
+        auto result = counter::count_all(large);
+        assert(result.ok);
+        assert(result.line_count == 1);
+        assert(result.word_count == 1);
+        assert(result.byte_count == 10001);
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_e2e.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_e2e.cpp
@@ -1,0 +1,88 @@
+// E2E test executable — tests end-to-end scenarios via system() calls to the wc-tool binary.
+// Each scenario internally creates temporary files, runs the binary, and verifies output.
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <sstream>
+#include <fstream>
+
+// Helper: create a temporary file with given content
+static void create_temp_file(const std::string& filename, const std::string& content) {
+    std::ofstream f(filename);
+    f << content;
+    f.close();
+}
+
+// Helper: run a command and capture exit code
+static int run_command(const std::string& cmd) {
+    return std::system(cmd.c_str());
+}
+
+// Helper: read stdout from a command (using a temp file)
+static std::string capture_output(const std::string& cmd) {
+    std::string capture_cmd = cmd + " > /tmp/wc_tool_output.txt 2>&1";
+    run_command(capture_cmd);
+    std::ifstream f("/tmp/wc_tool_output.txt");
+    std::string result((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    f.close();
+    return result;
+}
+
+int main() {
+    // === Scenario 1: e2e_normal_file ===
+    // Create a file with known content and verify output
+    {
+        create_temp_file("/tmp/test_normal.txt", "hello world\nfoo bar baz\n");
+        // Expected: 2 lines, 5 words, 19 bytes (hello world\nfoo bar baz\n = 19 bytes)
+        // Actually: "hello world\nfoo bar baz\n" = 24 bytes
+        // Let me count: h-e-l-l-o- -w-o-r-l-d-\n = 12, f-o-o- -b-a-r- -b-a-z-\n = 12, total = 24
+        // Wait: "hello world\nfoo bar baz\n"
+        // h(1)e(2)l(3)l(4)o(5) (6)w(7)o(8)r(9)l(10)d(11)\n(12)f(13)o(14)o(15) (16)b(17)a(18)r(19) (20)b(21)a(22)z(23)\n(24)
+        // So 24 bytes, 2 lines, 5 words
+        std::string cmd = "./build/wc-tool /tmp/test_normal.txt";
+        std::string output = capture_output(cmd);
+        assert(output.find("2") != std::string::npos);
+        assert(output.find("5") != std::string::npos);
+        assert(output.find("24") != std::string::npos);
+        assert(output.find("/tmp/test_normal.txt") != std::string::npos);
+    }
+
+    // === Scenario 2: e2e_empty_file ===
+    {
+        create_temp_file("/tmp/test_empty.txt", "");
+        std::string cmd = "./build/wc-tool /tmp/test_empty.txt";
+        std::string output = capture_output(cmd);
+        assert(output.find("0") != std::string::npos);
+        assert(output.find("/tmp/test_empty.txt") != std::string::npos);
+    }
+
+    // === Scenario 3: e2e_no_argument ===
+    {
+        std::string cmd = "./build/wc-tool 2>/tmp/wc_tool_stderr.txt";
+        int exit_code = run_command(cmd);
+        assert(exit_code != 0); // Should return non-zero
+    }
+
+    // === Scenario 4: e2e_file_not_found ===
+    {
+        std::string cmd = "./build/wc-tool /tmp/nonexistent_file_xyz.txt 2>/tmp/wc_tool_stderr.txt";
+        int exit_code = run_command(cmd);
+        assert(exit_code != 0); // Should return non-zero
+    }
+
+    // === Scenario 5: e2e_no_trailing_newline ===
+    {
+        create_temp_file("/tmp/test_no_newline.txt", "hello world");
+        // "hello world" = 11 bytes, 1 line (no trailing newline but counts as 1), 2 words
+        std::string cmd = "./build/wc-tool /tmp/test_no_newline.txt";
+        std::string output = capture_output(cmd);
+        assert(output.find("1") != std::string::npos); // 1 line
+        assert(output.find("2") != std::string::npos); // 2 words
+        assert(output.find("11") != std::string::npos); // 11 bytes
+        assert(output.find("/tmp/test_no_newline.txt") != std::string::npos);
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_e2e_empty_file.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_e2e_empty_file.cpp
@@ -1,0 +1,36 @@
+// E2E test: empty file processing
+// Verifies that an empty file produces "0 0 0 filename".
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+static void create_temp_file(const std::string& filename, const std::string& content) {
+    std::ofstream f(filename);
+    f << content;
+    f.close();
+}
+
+static std::string capture_output(const std::string& cmd) {
+    std::string capture_cmd = cmd + " > /tmp/wc_tool_output.txt 2>&1";
+    std::system(capture_cmd.c_str());
+    std::ifstream f("/tmp/wc_tool_output.txt");
+    std::string result((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    f.close();
+    return result;
+}
+
+int main() {
+    // Scenario: empty file — ""
+    // 0 lines, 0 words, 0 bytes
+    create_temp_file("/tmp/test_e2e_empty.txt", "");
+    std::string cmd = "./wc-tool /tmp/test_e2e_empty.txt";
+    std::string output = capture_output(cmd);
+
+    assert(output.find("0") != std::string::npos);
+    assert(output.find("/tmp/test_e2e_empty.txt") != std::string::npos);
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_e2e_file_not_found.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_e2e_file_not_found.cpp
@@ -1,0 +1,35 @@
+// E2E test: file not found
+// Verifies that running wc-tool with a non-existent file produces an error to stderr
+// and a non-zero exit code.
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+static int run_command(const std::string& cmd) {
+    return std::system(cmd.c_str());
+}
+
+static std::string capture_stderr(const std::string& cmd) {
+    std::string capture_cmd = cmd + " 2>/tmp/wc_tool_stderr.txt";
+    run_command(capture_cmd);
+    std::ifstream f("/tmp/wc_tool_stderr.txt");
+    std::string result((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    f.close();
+    return result;
+}
+
+int main() {
+    // Scenario: non-existent file — should fail with non-zero exit
+    std::string cmd = "./build/wc-tool /tmp/nonexistent_file_xyz_123.txt";
+    int exit_code = run_command(cmd);
+    assert(exit_code != 0); // Must return non-zero
+
+    // Verify stderr contains an error message
+    std::string stderr_output = capture_stderr(cmd);
+    assert(stderr_output.length() > 0);
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_e2e_no_argument.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_e2e_no_argument.cpp
@@ -1,0 +1,35 @@
+// E2E test: no argument provided
+// Verifies that running wc-tool without a file argument produces an error to stderr
+// and a non-zero exit code.
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+static int run_command(const std::string& cmd) {
+    return std::system(cmd.c_str());
+}
+
+static std::string capture_stderr(const std::string& cmd) {
+    std::string capture_cmd = cmd + " 2>/tmp/wc_tool_stderr.txt";
+    run_command(capture_cmd);
+    std::ifstream f("/tmp/wc_tool_stderr.txt");
+    std::string result((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    f.close();
+    return result;
+}
+
+int main() {
+    // Scenario: no argument — should fail with non-zero exit
+    std::string cmd = "./build/wc-tool";
+    int exit_code = run_command(cmd);
+    assert(exit_code != 0); // Must return non-zero
+
+    // Verify stderr contains an error message
+    std::string stderr_output = capture_stderr(cmd);
+    assert(stderr_output.length() > 0);
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_e2e_no_trailing_newline.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_e2e_no_trailing_newline.cpp
@@ -1,0 +1,39 @@
+// E2E test: file without trailing newline
+// Verifies wc-compatible line counting: a file without a trailing newline
+// still counts the last line.
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+static void create_temp_file(const std::string& filename, const std::string& content) {
+    std::ofstream f(filename);
+    f << content;
+    f.close();
+}
+
+static std::string capture_output(const std::string& cmd) {
+    std::string capture_cmd = cmd + " > /tmp/wc_tool_output.txt 2>&1";
+    std::system(capture_cmd.c_str());
+    std::ifstream f("/tmp/wc_tool_output.txt");
+    std::string result((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    f.close();
+    return result;
+}
+
+int main() {
+    // Scenario: "hello world" — no trailing newline
+    // 1 line, 2 words, 11 bytes
+    create_temp_file("/tmp/test_e2e_no_newline.txt", "hello world");
+    std::string cmd = "./wc-tool /tmp/test_e2e_no_newline.txt";
+    std::string output = capture_output(cmd);
+
+    assert(output.find("1") != std::string::npos); // 1 line
+    assert(output.find("2") != std::string::npos); // 2 words
+    assert(output.find("11") != std::string::npos); // 11 bytes
+    assert(output.find("/tmp/test_e2e_no_newline.txt") != std::string::npos);
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_e2e_normal_file.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_e2e_normal_file.cpp
@@ -1,0 +1,39 @@
+// E2E test: normal file processing
+// Creates a file with known content and verifies the output format and counts.
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+static void create_temp_file(const std::string& filename, const std::string& content) {
+    std::ofstream f(filename);
+    f << content;
+    f.close();
+}
+
+static std::string capture_output(const std::string& cmd) {
+    std::string capture_cmd = cmd + " > /tmp/wc_tool_output.txt 2>&1";
+    std::system(capture_cmd.c_str());
+    std::ifstream f("/tmp/wc_tool_output.txt");
+    std::string result((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    f.close();
+    return result;
+}
+
+int main() {
+    // Scenario: normal file — "hello world\nfoo bar baz\n"
+    // 2 lines, 5 words, 24 bytes
+    create_temp_file("/tmp/test_e2e_normal.txt", "hello world\nfoo bar baz\n");
+    std::string cmd = "./wc-tool /tmp/test_e2e_normal.txt";
+    std::string output = capture_output(cmd);
+
+    // Verify output contains expected values
+    assert(output.find("2") != std::string::npos); // 2 lines
+    assert(output.find("5") != std::string::npos); // 5 words
+    assert(output.find("24") != std::string::npos); // 24 bytes
+    assert(output.find("/tmp/test_e2e_normal.txt") != std::string::npos);
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_file_opener.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_file_opener.cpp
@@ -1,0 +1,56 @@
+#include "input/file_opener.h"
+#include <cassert>
+#include <cstdio>
+#include <string>
+#include <unistd.h>
+
+static std::string create_temp_file(const std::string& content) {
+    std::string path = "/tmp/test_wc_tool_XXXXXX";
+    char buf[1024];
+    snprintf(buf, sizeof(buf), "%s", path.c_str());
+    int fd = mkstemp(buf);
+    if (fd < 0) return "";
+    write(fd, content.c_str(), content.size());
+    close(fd);
+    return buf;
+}
+
+int main() {
+    // --- Happy path: valid file ---
+    {
+        std::string tmp = create_temp_file("hello\nworld\n");
+        assert(!tmp.empty());
+        auto result = input::open_file(tmp);
+        assert(result.ok);
+        char buf[256];
+        result.stream.getline(buf, sizeof(buf));
+        assert(result.stream);
+        std::remove(tmp.c_str());
+    }
+
+    // --- Happy path: empty file ---
+    {
+        std::string tmp = create_temp_file("");
+        assert(!tmp.empty());
+        auto result = input::open_file(tmp);
+        assert(result.ok);
+        assert(!result.stream.eof());
+        std::remove(tmp.c_str());
+    }
+
+    // --- Error: file does not exist ---
+    {
+        auto result = input::open_file("/nonexistent/path/file_does_not_exist.txt");
+        assert(!result.ok);
+        assert(!result.error_message.empty());
+    }
+
+    // --- Error: empty filename ---
+    {
+        auto result = input::open_file("");
+        assert(!result.ok);
+        assert(!result.error_message.empty());
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_line_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_line_counter.cpp
@@ -1,0 +1,72 @@
+#include "counter/line_counter.h"
+#include <cassert>
+#include <string>
+
+int main() {
+    // --- Happy path: empty content ---
+    {
+        auto result = counter::count_lines("");
+        assert(result.ok);
+        assert(result.line_count == 0);
+    }
+
+    // --- Happy path: single line without trailing newline ---
+    {
+        auto result = counter::count_lines("hello");
+        assert(result.ok);
+        assert(result.line_count == 0);
+    }
+
+    // --- Happy path: single line with trailing newline ---
+    {
+        auto result = counter::count_lines("hello\n");
+        assert(result.ok);
+        assert(result.line_count == 1);
+    }
+
+    // --- Happy path: multiple lines with trailing newline ---
+    {
+        auto result = counter::count_lines("line1\nline2\nline3\n");
+        assert(result.ok);
+        assert(result.line_count == 3);
+    }
+
+    // --- Happy path: multiple lines without trailing newline ---
+    {
+        auto result = counter::count_lines("line1\nline2\nline3");
+        assert(result.ok);
+        assert(result.line_count == 2);
+    }
+
+    // --- Happy path: single newline only ---
+    {
+        auto result = counter::count_lines("\n");
+        assert(result.ok);
+        assert(result.line_count == 1);
+    }
+
+    // --- Happy path: multiple consecutive newlines ---
+    {
+        auto result = counter::count_lines("\n\n\n");
+        assert(result.ok);
+        assert(result.line_count == 3);
+    }
+
+    // --- Happy path: empty lines mixed ---
+    {
+        auto result = counter::count_lines("\nhello\n\nworld\n");
+        assert(result.ok);
+        assert(result.line_count == 4);
+    }
+
+    // --- Edge: very large content ---
+    {
+        std::string large(10000, 'a');
+        large += '\n';
+        auto result = counter::count_lines(large);
+        assert(result.ok);
+        assert(result.line_count == 1);
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_output_formatter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_output_formatter.cpp
@@ -1,0 +1,43 @@
+#include "output/formatter.h"
+#include <cassert>
+#include <string>
+
+int main() {
+    // --- Happy path: basic formatting ---
+    {
+        std::string output = output::format_output(10, 50, 200, "myfile.txt");
+        assert(output == "10 50 200 myfile.txt");
+    }
+
+    // --- Happy path: zero counts ---
+    {
+        std::string output = output::format_output(0, 0, 0, "empty.txt");
+        assert(output == "0 0 0 empty.txt");
+    }
+
+    // --- Happy path: single values ---
+    {
+        std::string output = output::format_output(1, 1, 1, "a.txt");
+        assert(output == "1 1 1 a.txt");
+    }
+
+    // --- Happy path: large values ---
+    {
+        std::string output = output::format_output(999999, 5000000, 10000000, "big.txt");
+        assert(output == "999999 5000000 10000000 big.txt");
+    }
+
+    // --- Happy path: filename with path ---
+    {
+        std::string output = output::format_output(1, 2, 3, "/path/to/file.txt");
+        assert(output == "1 2 3 /path/to/file.txt");
+    }
+
+    // --- Happy path: filename with spaces ---
+    {
+        std::string output = output::format_output(1, 2, 3, "my file.txt");
+        assert(output == "1 2 3 my file.txt");
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_word_counter.cpp
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/input/tests/test_word_counter.cpp
@@ -1,0 +1,81 @@
+#include "counter/word_counter.h"
+#include <cassert>
+#include <string>
+
+int main() {
+    // --- Happy path: empty content ---
+    {
+        auto result = counter::count_words("");
+        assert(result.ok);
+        assert(result.word_count == 0);
+    }
+
+    // --- Happy path: single word ---
+    {
+        auto result = counter::count_words("hello");
+        assert(result.ok);
+        assert(result.word_count == 1);
+    }
+
+    // --- Happy path: multiple words ---
+    {
+        auto result = counter::count_words("hello world");
+        assert(result.ok);
+        assert(result.word_count == 2);
+    }
+
+    // --- Happy path: multiple words with extra spaces ---
+    {
+        auto result = counter::count_words("  hello   world  ");
+        assert(result.ok);
+        assert(result.word_count == 2);
+    }
+
+    // --- Happy path: words with newlines ---
+    {
+        auto result = counter::count_words("one\ntwo\nthree\n");
+        assert(result.ok);
+        assert(result.word_count == 3);
+    }
+
+    // --- Happy path: tabs as separators ---
+    {
+        auto result = counter::count_words("a\tb\tc");
+        assert(result.ok);
+        assert(result.word_count == 3);
+    }
+
+    // --- Happy path: mixed whitespace ---
+    {
+        auto result = counter::count_words("  \n\t  hello\t world\n");
+        assert(result.ok);
+        assert(result.word_count == 2);
+    }
+
+    // --- Happy path: only whitespace ---
+    {
+        auto result = counter::count_words("   \n\t  ");
+        assert(result.ok);
+        assert(result.word_count == 0);
+    }
+
+    // --- Happy path: single character words ---
+    {
+        auto result = counter::count_words("a b c d e");
+        assert(result.ok);
+        assert(result.word_count == 5);
+    }
+
+    // --- Edge: large content ---
+    {
+        std::string large;
+        for (int i = 0; i < 1000; ++i) {
+            large += "word ";
+        }
+        auto result = counter::count_words(large);
+        assert(result.ok);
+        assert(result.word_count == 1000);
+    }
+
+    return 0;
+}

--- a/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/project_config.json
+++ b/tests/fixtures/v2_phase_io/cpp_wc_cli/verification/project_config.json
@@ -1,0 +1,72 @@
+{
+  "project_name": "cpp_wc",
+  "development_mode": "local",
+  "process_type": "waterfall_v2",
+  "ui_language": "en",
+  "default_model": {
+    "provider": "Local",
+    "model": "qwen3.6-35b",
+    "api_key": "",
+    "base_url": "http://127.0.0.1:8088/v1",
+    "temperature": 0.7,
+    "max_tokens": 4096
+  },
+  "model_providers": [
+    {
+      "provider": "Local",
+      "api_key": "",
+      "base_url": "http://127.0.0.1:8088/v1",
+      "enabled": true
+    }
+  ],
+  "agents": {
+    "product_manager": {
+      "name": "product_manager",
+      "enabled": true
+    },
+    "architect": {
+      "name": "architect",
+      "enabled": true
+    },
+    "developer": {
+      "name": "developer",
+      "enabled": true
+    },
+    "qa_engineer": {
+      "name": "qa_engineer",
+      "enabled": true
+    },
+    "project_manager": {
+      "name": "project_manager",
+      "enabled": true
+    },
+    "rd_director": {
+      "name": "rd_director",
+      "enabled": true
+    }
+  },
+  "agent_model_selection": {},
+  "workflow": {
+    "max_review_iterations": 3,
+    "fail_on_review_rejection": false
+  },
+  "session": {
+    "max_concurrent_sessions": 5
+  },
+  "workspace": {
+    "projects_root": "projects",
+    "artifacts_root": "artifacts",
+    "auto_create_dirs": true
+  },
+  "logging": {
+    "level": "INFO",
+    "log_dir": "logs",
+    "json_format": false,
+    "rotate_daily": true
+  },
+  "github": {
+    "token": "",
+    "repo_owner": "",
+    "repo_name": ""
+  }
+}


### PR DESCRIPTION
## Summary

Adds the C++17 ``wc``-like CLI scenario to the phase-contract test matrix. Together with PR #140 (python/dart/typescript/go) and PR #141 (C++ stack support in code), this completes the **5-language coverage** we agreed on.

Source: a fresh 2026-05-05 e2e on a small C++17 ``wc``-style CLI (``wc-tool <file>`` → lines / words / bytes + filename). 62.5 min end-to-end on local qwen3.6-35b — slower than TS but on par with Go for this stack.

## Per-phase verification (real LLM)

| phase | wall | verdict | notes |
|---|---:|---|---|
| requirements | 237.8s | ✅ PASS | 10/10 hard |
| architecture | 1554.1s | ❌ **FAIL** | schema gate caught architect emitting `subsystems[].components[]` entries missing `file` |
| implementation | 732.5s | ✅ PASS+warn | 6/7 hard + 1 warn — same dev-overreach signal (developer wrote `src/main.cpp` with `int main(...)`) seen in python/ts/go |
| main_entry | 595.1s | ✅ PASS | 6/6 hard |
| verification | 515.2s | ✅ PASS | 3/3 gate-pass (qa_report softened — no ctest on PATH, same as TS/Go) |
| delivery | 146.7s | ✅ PASS | 5/5 hard |

**5/6 PASS, 1 FAIL on architecture.** The FAIL is the schema gate doing its job, **not** a fixture authoring bug. Honest matrix preferred over masking it as `severity=warn`.

## RCA — architecture failure

- The same e2e that produced the input snapshot DID emit a schema-valid `stack_contract` on its first run (`producer_attempts=2`, `review_iters=3`).
- On a fresh single-phase run with the same input but a smaller review budget (`max_review_iterations=1`), the architect produced a `stack_contract` whose components used a different field name (likely `path` / `source` instead of `file`), and AUTO_GATE didn't reach a passing version before review iters exhausted.
- This is a stable signal that the architect prompt's C++ guidance is thinner than its Python / TypeScript / Go guidance. Worth a follow-up tightening:
  - architect.md: add explicit C++ component example with `"file": "src/<subsystem>/<component>.cpp"`
  - or richer schema error message (currently just `"missing required property 'file'"` — no example)
- Keeping the FAIL visible means future runs of this case verify whether prompt changes fix it: FAIL → PASS = signal of progress.

## Coverage matrix complete (5 scenarios × 6 phases = 30 cases)

| scenario | phases | verdict |
|---|:---:|:---:|
| python_cli_hello_world | 6 | 6/6 PASS |
| flutter_mobile_game | 6 | 6/6 PASS |
| typescript_express_api | 6 | 6/6 PASS |
| go_api | 6 | 6/6 PASS |
| **cpp_wc_cli** | 6 | **5/6 PASS** (1 honest FAIL) |
| **TOTAL** | **30** | **29/30** |

## Test plan

- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` clean
- [x] `pytest --tb=short -q --ignore=tests/test_packaging --ignore=tests/test_whatsapp` → **1314 passed / 52 skipped / 0 failed**
- [x] All 30 bundled cases auto-discovered by `TestBundledFixtures` and load with current loader
- [ ] CI Build / Lint / Test 3.11 / Test 3.12 green

## Follow-up signals captured (not addressed in this PR)

1. **C++ architect prompt thinness** — the FAIL above. Tighten architect.md with an explicit C++ component example.
2. **developer over-reach into main_entry** — now confirmed in 4/5 scenarios (python/ts/go/cpp). Worth a developer.md tightening PR.
3. **qa_engineer skips qa_report.json on toolchain miss** — confirmed in TS/Go/C++. Should always emit `ran=false` per spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)