### PR TITLE
fix(prompts+spec): close 2 prompt defects surfaced by phase-test matrix

### DIFF
--- a/src/aise/agents/architect.md
+++ b/src/aise/agents/architect.md
@@ -128,6 +128,27 @@ own — if you don't lay down the skeleton, nobody will.
     parent's `src_dir`. The runtime validates this — a flat layout
     where components point at sibling top-level paths fails the
     check and triggers an architect re-dispatch.
+  - **The JSON key is literally `"file"` regardless of language.**
+    Do not rename it to `"path"` / `"source"` / `"header"` /
+    `"src"` / `"location"` even when the language has multiple
+    file kinds. The schema's `required: ["name", "file"]` rejects
+    aliases. Concrete examples:
+
+    | Language | Component example |
+    | --- | --- |
+    | Python | `{"name": "router", "file": "src/api/router.py"}` |
+    | TypeScript | `{"name": "echo_handler", "file": "src/routes/echo_handler.ts"}` |
+    | Go | `{"name": "echo_handler", "file": "internal/handlers/echo_handler.go"}` |
+    | Rust | `{"name": "router", "file": "src/api/router.rs"}` |
+    | Dart / Flutter | `{"name": "battle_engine", "file": "lib/gameplay/battle_engine.dart"}` |
+    | C++ | `{"name": "line_counter", "file": "src/counter/line_counter.cpp"}` |
+
+    For C++ specifically: `"file"` references the primary `.cpp`.
+    A matching `.h` is implied (the developer phase will write it
+    as a sibling deliverable); do NOT add a separate `"header"`
+    JSON field. Listed C++ component files MUST end in `.cpp`,
+    `.cc`, or `.cxx` — never `.h` / `.hpp` (those are not
+    standalone components).
   - Soft cap: aim for ≤ 10 subsystems for typical projects. If you
     exceed it, you are likely flat-listing components again.
   - **`lifecycle_inits[]` is REQUIRED** (use `[]` explicitly when no

--- a/src/aise/agents/qa_engineer.md
+++ b/src/aise/agents/qa_engineer.md
@@ -127,10 +127,30 @@ test file: read the architecture doc and the project config file
 7. **UI validation — REQUIRED only when step 3 marked the project
    UI-required.** Skip this step entirely for headless-only projects.
    See the "UI Validation Step" section below for the exact procedure.
-8. **Write `docs/qa_report.json` (REQUIRED).** Phase 6 reads this
-   file verbatim to build the delivery report; if it's missing or
-   malformed Phase 6 will dispatch you again. See the
-   "Required Output Artifact" section below for the exact schema.
+8. **STOPPING RULE — write `docs/qa_report.json` BEFORE you reply.**
+   This artifact is now AUTO_GATE-enforced (waterfall_v2.process.md
+   verification phase deliverable, schema:
+   schemas/qa_report.schema.json). Phase 5 will not pass without it,
+   regardless of whether the test runner was available. Concretely,
+   immediately before your final reply do:
+
+   - `read_file('docs/qa_report.json')` to confirm it exists and
+     parses as JSON. If it doesn't, `write_file` it now using the
+     schema in the "Required Output Artifact" section below.
+   - The report is REQUIRED in BOTH branches:
+     - **Toolchain present + tests ran**: fill `<runner>.ran=true`
+       with real `passed`/`failed`/`skipped` counts.
+     - **Toolchain missing**: set `<runner>.ran=false` with a
+       one-sentence `reason` (e.g. `"vitest not on PATH"`,
+       `"go test not on PATH"`, `"ctest not on PATH"`) and OMIT
+       the count fields. Do NOT skip writing the file — empty /
+       missing report is treated as a delivery-blocking bug.
+
+   Phase-test matrix on 2026-05-05 saw qa_engineer skip this file on
+   TS / Go / C++ runs whenever the matching binary wasn't on PATH.
+   That branch is exactly the one this stopping rule covers — write
+   `ran=false` rather than skipping.
+
 9. Respond with a brief summary: which integration scenarios you
    cover, the final test result (pass/fail counts), AND — if
    UI-required — the UI-validation verdict (PASS / FAIL with reason).

--- a/src/aise/processes/waterfall_v2.process.md
+++ b/src/aise/processes/waterfall_v2.process.md
@@ -187,6 +187,18 @@ phases:
         acceptance:
           - file_exists
           - { min_bytes: 200 }
+      # qa_report.json gate: phase 6 (delivery) reads this verbatim.
+      # Promoted from "REQUIRED prose in qa_engineer.md" to a hard
+      # AUTO_GATE deliverable on 2026-05-05 because TS / Go / C++
+      # phase-test runs showed qa_engineer occasionally skipped
+      # writing it when the toolchain was missing (the prose said
+      # "ran=false" was required, but a soft prose rule wasn't
+      # enough — see PR description for the matrix).
+      - kind: document
+        path: docs/qa_report.json
+        acceptance:
+          - file_exists
+          - { schema: schemas/qa_report.schema.json }
     review:
       consensus: ALL_PASS
       revise_budget: 3

--- a/src/aise/schemas/qa_report.schema.json
+++ b/src/aise/schemas/qa_report.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "qa_report",
+  "title": "QA report (qa_engineer output, phase 5)",
+  "description": "Structural shape for docs/qa_report.json. The actual prose contract lives in src/aise/agents/qa_engineer.md; this schema only enforces the keys the delivery phase reads to compose docs/delivery_report.md. Permissive on optional sub-fields so a missing toolchain branch (ran=false with omitted counts) still validates.",
+  "type": "object",
+  "required": [
+    "phase",
+    "toolchain_check"
+  ],
+  "properties": {
+    "phase": {
+      "type": "string",
+      "minLength": 1
+    },
+    "completed_at": {
+      "type": "string"
+    },
+    "toolchain_check": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": true
+    },
+    "pytest": {
+      "type": "object",
+      "required": ["ran"],
+      "properties": {
+        "command": { "type": "string" },
+        "ran": { "type": "boolean" },
+        "reason": { "type": "string" },
+        "passed": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 },
+        "skipped": { "type": "integer", "minimum": 0 },
+        "failed_tests": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": true
+    },
+    "ui_validation": {
+      "type": "object",
+      "properties": {
+        "required": { "type": "boolean" },
+        "verdict": { "type": "string" },
+        "reason": { "type": "string" },
+        "pixel_smoke": {
+          "type": "object",
+          "properties": {
+            "non_bg_samples": { "type": "integer", "minimum": 0 },
+            "threshold": { "type": "integer", "minimum": 0 },
+            "frame_path": { "type": "string" },
+            "verdict": { "type": "string" }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "product_bugs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    },
+    "integration_tests": {
+      "type": "object",
+      "properties": {
+        "file": { "type": "string" },
+        "scenario_count": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/tests/test_runtime/test_phase_executor.py
+++ b/tests/test_runtime/test_phase_executor.py
@@ -324,6 +324,31 @@ class TestScenarioParallelFanout:
                 p = tmp_path / rel.lstrip("/")
                 p.parent.mkdir(parents=True, exist_ok=True)
                 p.write_text("# valid\n" + "x" * 250, encoding="utf-8")
+            # docs/qa_report.json is a phase-level ``document`` deliverable,
+            # not part of the per-scenario fanout's ``expected``. The
+            # real qa_engineer writes it on its own initiative
+            # (qa_engineer.md STOPPING RULE); the test mock does the same
+            # so AUTO_GATE's schema check passes.
+            qa_report = tmp_path / "docs" / "qa_report.json"
+            if not qa_report.exists():
+                qa_report.parent.mkdir(parents=True, exist_ok=True)
+                qa_report.write_text(
+                    json.dumps(
+                        {
+                            "phase": "qa",
+                            "toolchain_check": {"pytest": "present"},
+                            "pytest": {
+                                "command": "pytest",
+                                "ran": True,
+                                "passed": 1,
+                                "failed": 0,
+                                "skipped": 0,
+                                "failed_tests": [],
+                            },
+                        }
+                    ),
+                    encoding="utf-8",
+                )
             return "ok"
 
         executor = PhaseExecutor(

--- a/tests/test_runtime/test_predicates.py
+++ b/tests/test_runtime/test_predicates.py
@@ -273,6 +273,122 @@ class TestSchemaPredicate:
         assert r.passed, r.detail
 
 
+# -- qa_report.schema.json (added 2026-05-05) ---------------------------
+
+
+class TestQaReportSchema:
+    """Validates docs/qa_report.json against the bundled schema. The
+    schema was promoted from prose-only to AUTO_GATE-enforced after
+    the 2026-05-05 phase-test matrix found qa_engineer skipping the
+    report on toolchain-missing branches."""
+
+    def test_minimal_valid_report_passes(self, tmp_path: Path):
+        # Smallest legal qa_report — toolchain present, no UI, ran=true.
+        report = {
+            "phase": "qa",
+            "completed_at": "2026-05-05T00:00:00Z",
+            "toolchain_check": {"pytest": "present"},
+            "pytest": {
+                "command": "python -m pytest -q",
+                "ran": True,
+                "passed": 12,
+                "failed": 0,
+                "skipped": 0,
+                "failed_tests": [],
+            },
+        }
+        (tmp_path / "qa_report.json").write_text(json.dumps(report), encoding="utf-8")
+        r = evaluate_predicate(
+            _pred("schema", "schemas/qa_report.schema.json"),
+            _ctx(tmp_path, "qa_report.json"),
+        )
+        assert r.passed, r.detail
+
+    def test_runner_missing_branch_passes(self, tmp_path: Path):
+        # The exact branch the prompt MUST cover but historically
+        # didn't: toolchain missing → ran=false → counts omitted.
+        # The schema accepts this without inventing pass/fail numbers.
+        report = {
+            "phase": "qa",
+            "toolchain_check": {"vitest": "missing", "npx": "missing"},
+            "pytest": {
+                "command": "npx vitest run",
+                "ran": False,
+                "reason": "vitest not on PATH",
+            },
+        }
+        (tmp_path / "qa_report.json").write_text(json.dumps(report), encoding="utf-8")
+        r = evaluate_predicate(
+            _pred("schema", "schemas/qa_report.schema.json"),
+            _ctx(tmp_path, "qa_report.json"),
+        )
+        assert r.passed, r.detail
+
+    def test_ui_validation_branch_passes(self, tmp_path: Path):
+        # Flutter / pygame projects: ui_validation block populated.
+        report = {
+            "phase": "qa",
+            "toolchain_check": {"flutter": "missing"},
+            "pytest": {"command": "flutter test", "ran": False, "reason": "flutter missing"},
+            "ui_validation": {
+                "required": True,
+                "verdict": "SKIPPED_HEADLESS_ONLY",
+                "reason": "no display server",
+                "pixel_smoke": {
+                    "non_bg_samples": 0,
+                    "threshold": 1000,
+                    "frame_path": "artifacts/smoke_frame_0.png",
+                    "verdict": "SKIPPED",
+                },
+            },
+        }
+        (tmp_path / "qa_report.json").write_text(json.dumps(report), encoding="utf-8")
+        r = evaluate_predicate(
+            _pred("schema", "schemas/qa_report.schema.json"),
+            _ctx(tmp_path, "qa_report.json"),
+        )
+        assert r.passed, r.detail
+
+    def test_missing_phase_field_fails(self, tmp_path: Path):
+        # ``phase`` is required at the top level — schema must reject.
+        report = {"toolchain_check": {"pytest": "present"}}
+        (tmp_path / "qa_report.json").write_text(json.dumps(report), encoding="utf-8")
+        r = evaluate_predicate(
+            _pred("schema", "schemas/qa_report.schema.json"),
+            _ctx(tmp_path, "qa_report.json"),
+        )
+        assert not r.passed
+        assert "phase" in r.detail
+
+    def test_missing_toolchain_check_fails(self, tmp_path: Path):
+        # toolchain_check is required: phase 6 reads it to decide
+        # whether reported pass/fail counts can be trusted.
+        report = {"phase": "qa"}
+        (tmp_path / "qa_report.json").write_text(json.dumps(report), encoding="utf-8")
+        r = evaluate_predicate(
+            _pred("schema", "schemas/qa_report.schema.json"),
+            _ctx(tmp_path, "qa_report.json"),
+        )
+        assert not r.passed
+        assert "toolchain_check" in r.detail
+
+    def test_pytest_missing_ran_field_fails(self, tmp_path: Path):
+        # When the ``pytest`` object is present, ``ran`` is required
+        # so phase 6 can branch on it.
+        report = {
+            "phase": "qa",
+            "toolchain_check": {"pytest": "present"},
+            "pytest": {"command": "pytest"},
+        }
+        (tmp_path / "qa_report.json").write_text(json.dumps(report), encoding="utf-8")
+        r = evaluate_predicate(
+            _pred("schema", "schemas/qa_report.schema.json"),
+            _ctx(tmp_path, "qa_report.json"),
+        )
+        assert not r.passed
+        assert "ran" in r.detail
+
+
 # -- language_supported ---------------------------------------------------
 
 

--- a/tests/test_runtime/test_waterfall_v2_driver.py
+++ b/tests/test_runtime/test_waterfall_v2_driver.py
@@ -76,6 +76,27 @@ def _passing_produce(tmp_path: Path):
         (tmp_path / "tests" / "scenarios").mkdir(parents=True, exist_ok=True)
         for sid in (f"s{i}" for i in range(5)):
             (tmp_path / "tests" / "scenarios" / f"{sid}.py").write_text("# scenario\n" + "x" * 250, encoding="utf-8")
+        # Phase 5 also requires docs/qa_report.json (promoted to an
+        # AUTO_GATE deliverable on 2026-05-05). Schema validates against
+        # schemas/qa_report.schema.json — minimal valid shape below.
+        (docs / "qa_report.json").write_text(
+            json.dumps(
+                {
+                    "phase": "qa",
+                    "completed_at": "2026-05-05T00:00:00Z",
+                    "toolchain_check": {"pytest": "present"},
+                    "pytest": {
+                        "command": "python -m pytest -q",
+                        "ran": True,
+                        "passed": 5,
+                        "failed": 0,
+                        "skipped": 0,
+                        "failed_tests": [],
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
 
         # Phase 6 delivery
         (docs / "delivery_report.md").write_text(

--- a/tests/test_runtime/test_waterfall_v2_e2e.py
+++ b/tests/test_runtime/test_waterfall_v2_e2e.py
@@ -57,6 +57,14 @@ class MockLLM:
                 p = self.project_root / path.lstrip("/")
                 p.parent.mkdir(parents=True, exist_ok=True)
                 p.write_text(f"# qa stub for {path}\n" + "x" * 250, encoding="utf-8")
+            # docs/qa_report.json is now an AUTO_GATE-enforced
+            # deliverable (waterfall_v2.process.md verification phase
+            # promoted it from prose-only on 2026-05-05). It is NOT in
+            # ``expected`` for fanout dispatches — it's a phase-level
+            # ``kind: document`` deliverable, so the real qa_engineer
+            # writes it on its own initiative per qa_engineer.md's
+            # STOPPING RULE. The mock does the same.
+            self._write_qa_report()
         elif role == "project_manager":
             self._write_phase_6()
         return f"{role} produced"
@@ -125,6 +133,31 @@ class MockLLM:
             "## 验收结论\nshipped.\n## 已知 issue\nnone.\n## 下一步建议\niter.\n"
             "Built per docs/requirement.md and docs/architecture.md.\n"
             "Stack: docs/stack_contract.json. Behavior: docs/behavioral_contract.json.\n" + "x" * 1500,
+            encoding="utf-8",
+        )
+
+    def _write_qa_report(self) -> None:
+        """Write a minimal valid docs/qa_report.json. Verification phase
+        AUTO_GATE-enforces this artifact (schema check) since
+        2026-05-05; without it the phase halts."""
+        docs = self.project_root / "docs"
+        docs.mkdir(parents=True, exist_ok=True)
+        (docs / "qa_report.json").write_text(
+            json.dumps(
+                {
+                    "phase": "qa",
+                    "completed_at": "2026-05-05T00:00:00Z",
+                    "toolchain_check": {"pytest": "present"},
+                    "pytest": {
+                        "command": "python -m pytest -q",
+                        "ran": True,
+                        "passed": 1,
+                        "failed": 0,
+                        "skipped": 0,
+                        "failed_tests": [],
+                    },
+                }
+            ),
             encoding="utf-8",
         )
 

--- a/tests/test_runtime/test_waterfall_v2_loader.py
+++ b/tests/test_runtime/test_waterfall_v2_loader.py
@@ -156,6 +156,33 @@ class TestLoadBundledWaterfallV2:
         ((stage,)) = ver.fanout.stages
         assert stage.mode_when_runner_unavailable == "write_only"
 
+    def test_verification_has_qa_report_deliverable(self):
+        """Regression: 2026-05-05 phase-test matrix found qa_engineer
+        skipping docs/qa_report.json on TS / Go / C++ runs because the
+        artifact was REQUIRED only in qa_engineer.md prose, not in
+        the process spec. The fix promoted it to an AUTO_GATE
+        deliverable with file_exists + schema acceptance. This test
+        guards against silent removal."""
+        spec = load_waterfall_v2(default_waterfall_v2_path())
+        ver = spec.phase_by_id("verification")
+        assert ver is not None
+        qa_report_dlv = [d for d in ver.deliverables if d.kind == "document" and d.path == "docs/qa_report.json"]
+        assert qa_report_dlv, (
+            "verification phase must declare docs/qa_report.json as a "
+            "document deliverable; otherwise qa_engineer can skip writing it "
+            "and phase 6 (delivery) reads garbage"
+        )
+        kinds = [a.kind for a in qa_report_dlv[0].acceptance]
+        assert "file_exists" in kinds
+        assert "schema" in kinds, (
+            "qa_report.json deliverable must carry a schema-validation "
+            "predicate so toolchain-missing branches that fabricate counts "
+            "still get caught at AUTO_GATE"
+        )
+        # The schema arg points at the bundled JSON-Schema file.
+        schema_arg = [a for a in qa_report_dlv[0].acceptance if a.kind == "schema"][0].arg
+        assert schema_arg == "schemas/qa_report.schema.json"
+
     def test_acceptance_predicates_parsed(self):
         spec = load_waterfall_v2(default_waterfall_v2_path())
         req = spec.phase_by_id("requirements")


### PR DESCRIPTION
Two independent prompt-level defects surfaced by the 2026-05-05 phase-test matrix runs (PRs #140 / #142). Both are stable across runs and across scenarios — fixing at the source rather than softening case assertions.

> **Note**: a third signal (developer over-reaching to write `src/main.py` during phase 3) was also captured but **reverted from this PR** after validation showed prompt-only fixes don't move the LLM, and that the impact is P2 (token waste + flow noise — phase 4 overwrites the file). Will land separately as a runtime hard constraint (ACL phase-aware + AUTO_GATE reverse-scan).

## Signal 1 — architect drops `file` field on C++ stack contracts

- **Where seen**: `cpp_wc_cli × architecture` (the 1/30 hard FAIL in PR #142). AUTO_GATE schema rejected `$.subsystems[*].components[*]: missing required property 'file'`.
- **Root cause**: `architect.md`'s component example shows a Python path. On C++ contexts the LLM "helps" by renaming the JSON key to `path` / `source` / `header` because C++ has multi-file components. Schema is strict on the key name.
- **Fix**: `architect.md` cross-language reminder + per-language component examples for python / typescript / go / rust / dart / **cpp**. Pins that for C++ `"file"` is the `.cpp`; the matching `.h` is implied (sibling deliverable, not a separate JSON field).
- **Validated** 2026-05-05 (post-prompt change): `cpp_wc_cli × architecture` FAIL → **PASS** in 1898s.

## Signal 3 — qa_engineer skips qa_report.json on toolchain miss

- **Where seen**: 3/5 scenarios (typescript / go / cpp) — verification small-loops captured `qa_report.json missing` because the local test runner wasn't on PATH.
- **Root cause**: `qa_report.json` was REQUIRED only in `qa_engineer.md` prose. Process spec didn't list it as a deliverable, so AUTO_GATE never gated on it.
- **Fix**: promote `qa_report.json` from prose-only to a hard AUTO_GATE deliverable.
  - **New** `src/aise/schemas/qa_report.schema.json`
  - **`waterfall_v2.process.md`** verification phase now declares `{kind: document, path: docs/qa_report.json, acceptance: [file_exists, {schema: schemas/qa_report.schema.json}]}`
  - **`qa_engineer.md` step 8** rewritten as a STOPPING RULE covering both branches (toolchain present → counts; toolchain missing → `ran=false` + reason)
- **Validated** 2026-05-05 (post-prompt change): `typescript_express_api × verification` — `qa_report.json` **present** (2445 B), `qa_report_present` hard PASS (was previously file-missing).

## Tests added / updated

- `tests/test_runtime/test_predicates.py::TestQaReportSchema` — 6 cases (minimal-valid / `ran=false` branch / ui_validation branch / 3 negative branches)
- `tests/test_runtime/test_waterfall_v2_loader.py::test_verification_has_qa_report_deliverable` — guards against silent removal of the spec change
- Updates to fake produce_fn / MockLLM helpers in `test_phase_executor.py`, `test_waterfall_v2_driver.py`, `test_waterfall_v2_e2e.py` so they write a minimal valid `qa_report.json`

## Test plan

- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` clean
- [x] `pytest --tb=short -q --ignore=tests/test_packaging --ignore=tests/test_whatsapp` → **1321 passed / 52 skipped / 0 failed** (was 1314 → +7 new tests)
- [x] End-to-end re-runs confirmed Signal 1 and Signal 3 fixes move the LLM (see "Validated" lines above)
- [ ] CI Build / Lint / Test 3.11 / Test 3.12 green

## Follow-up: Signal 2 (developer phase 3 → main)

Tracking separately as a runtime hard constraint:
1. ACL phase-awareness: in phase 3 dispatches, restrict `developer` writes to the per-task deliverable list only — refuse `src/main.{py,ts,cpp,...}` even if the per-extension glob would normally allow it.
2. AUTO_GATE reverse scan: after phase 3 completes, reject if any source file outside the dispatch's `expected_artifacts` set landed.

Both are runtime-enforced, so they work regardless of LLM compliance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)