### PR TITLE
perf(waterfall_v2): scheduling optimizations A1 + A2 + A3 + B3

### DIFF
--- a/src/aise/processes/waterfall_v2.process.md
+++ b/src/aise/processes/waterfall_v2.process.md
@@ -41,7 +41,7 @@ phases:
           - { schema: schemas/requirement_contract.schema.json }
     review:
       consensus: ALL_PASS
-      revise_budget: 3
+      revise_budget: 2
       on_revise_exhausted: continue_with_marker
       reviewer_questions:
         architect: |
@@ -131,7 +131,7 @@ phases:
           - { min_bytes: 100 }
     review:
       consensus: ALL_PASS
-      revise_budget: 3
+      revise_budget: 2
       on_revise_exhausted: continue_with_marker
       reviewer_questions:
         qa_engineer: |
@@ -153,7 +153,7 @@ phases:
           - contains_all_lifecycle_inits
     review:
       consensus: ALL_PASS
-      revise_budget: 3
+      revise_budget: 2
       on_revise_exhausted: continue_with_marker
       reviewer_questions:
         qa_engineer: |
@@ -201,7 +201,7 @@ phases:
           - { schema: schemas/qa_report.schema.json }
     review:
       consensus: ALL_PASS
-      revise_budget: 3
+      revise_budget: 2
       on_revise_exhausted: continue_with_marker
       reviewer_questions:
         project_manager: |
@@ -224,7 +224,7 @@ phases:
           - { prior_phases_summarized: 5 }
     review:
       consensus: ALL_PASS
-      revise_budget: 3
+      revise_budget: 1
       on_revise_exhausted: continue_with_marker
       reviewer_questions:
         rd_director: |

--- a/src/aise/runtime/phase_executor.py
+++ b/src/aise/runtime/phase_executor.py
@@ -56,6 +56,7 @@ deliberately a pure state machine that returns a PhaseResult.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass, field
 from enum import Enum
@@ -130,6 +131,55 @@ class PhaseResult:
 
 
 _PRODUCER_AUTO_GATE_RETRIES = 3
+
+
+# -- Fan-out parallelism cap ---------------------------------------------
+#
+# A3 (2026-05-05): the spec's static ``max_workers: 3`` was chosen for
+# small Python CLIs and serialized 22-Dart-component fan-outs into 7+
+# batches. We widen at runtime based on task count, capped here.
+# Above ~8 we hit local-vLLM queue saturation (no real parallelism left)
+# and on a cloud LLM with prompt caching the marginal speedup vs queue
+# pressure flattens around the same number.
+_MAX_FANOUT_PARALLELISM = 8
+
+
+def _file_fingerprint(path: Path) -> str:
+    """Cheap content fingerprint used by the AUTO_GATE incremental
+    cache (B3). Returns ``"missing"`` for non-existent files (treated
+    as a distinct cache key from any present-file fingerprint), and
+    ``size:hex(sha256)`` otherwise. Reading the file twice in the same
+    AUTO_GATE pass is fine — it's small (architect docs / contract
+    JSON / per-component source); the cache only helps across
+    *retries*, not within one pass.
+    """
+    if not path.is_file():
+        return "missing"
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return "missing"
+    return f"{len(data)}:{hashlib.sha256(data).hexdigest()[:32]}"
+
+
+def _adaptive_max_workers(task_count: int) -> int:
+    """Return a sensible per-stage worker count for ``task_count`` tasks.
+
+    The mapping is intentionally coarse — 3 buckets:
+
+    - ≤ 4 tasks: 2 workers (small project; saturating 3+ wastes setup)
+    - 5–15 tasks: 4 workers (medium; balance of throughput vs LLM queue)
+    - 16+ tasks: 8 workers (large project; full parallelism cap)
+
+    Callers (``_run_fanout``) treat this as a *floor* combined with the
+    spec's static ``max_workers``; the larger of the two wins, so a
+    spec author can still pin a higher value if their stack supports it.
+    """
+    if task_count <= 4:
+        return 2
+    if task_count <= 15:
+        return 4
+    return _MAX_FANOUT_PARALLELISM
 
 
 # -- Inline JSON contract examples ---------------------------------------
@@ -367,6 +417,11 @@ class PhaseExecutor:
     stack_contract: dict[str, Any] | None = None
     behavioral_contract: dict[str, Any] | None = None
     requirement_contract: dict[str, Any] | None = None
+    # B3 (2026-05-05): per-(path, kind, file_fp, contracts_fp) cache of
+    # previously-PASSED DeliverableReports. Skips re-running the predicate
+    # sweep on retries when nothing relevant has changed. Reset implicitly
+    # whenever a new PhaseExecutor is built (one per phase invocation).
+    _gate_cache: dict[tuple, DeliverableReport] = field(default_factory=dict)
 
     # -- Phase prompt builder (caller can override per-phase via DI) -----
     # Default builder lazily resolves to ``_default_build_phase_prompt``
@@ -556,11 +611,19 @@ class PhaseExecutor:
             group_by = None
             if stage.group_by == "subsystem":
                 group_by = lambda payload: payload.subsystem  # noqa: E731
+            # Adaptive max_workers: scale with task count (perf opt A3,
+            # 2026-05-05). The spec's static value is a floor; we widen
+            # it up to ``_MAX_FANOUT_PARALLELISM`` when fan-out is fat
+            # (e.g. 22-component Flutter project would otherwise sit at
+            # 3-wide and serialize 7 batches). For small projects the
+            # static value still wins because there aren't enough tasks
+            # to fill more workers anyway.
+            adaptive_workers = max(stage.concurrency.max_workers, _adaptive_max_workers(len(tasks)))
             stage_specs.append(
                 StageSpec(
                     id=stage.id,
                     tasks=tasks,
-                    max_workers=stage.concurrency.max_workers,
+                    max_workers=adaptive_workers,
                     depends_on=stage.depends_on,
                     group_by=group_by,
                 )
@@ -598,10 +661,30 @@ class PhaseExecutor:
         # stack_contract.json / behavioral_contract.json).
         self._refresh_contracts_from_disk()
 
+        # B3 (2026-05-05): incremental cache. Re-checking deliverables
+        # whose file content + contracts haven't changed across
+        # producer attempts is wasted IO + CPU. We hash (sha256) the
+        # deliverable file plus a fingerprint of the loaded contracts
+        # and skip the per-deliverable predicate sweep when the same
+        # tuple was just verified PASS. Cache is per-PhaseExecutor so
+        # a fresh phase execution starts clean.
+        contracts_fp = self._contracts_fingerprint()
+
         reports: list[DeliverableReport] = []
         for deliverable in phase.deliverables:
             paths = self._resolve_deliverable_paths(deliverable)
             for p in paths:
+                file_fp = _file_fingerprint(p)
+                cache_key = (str(p), deliverable.kind, file_fp, contracts_fp)
+                cached = self._gate_cache.get(cache_key)
+                if cached is not None and cached.passed:
+                    # Re-evaluating a passing predicate set on identical
+                    # input is deterministic — safe to reuse. We do NOT
+                    # cache failing reports (the failure detail string
+                    # contains paths that may surface differently across
+                    # attempts; safer to re-run them).
+                    reports.append(cached)
+                    continue
                 ctx = PredicateContext(
                     project_root=self.project_root,
                     deliverable_path=p,
@@ -609,8 +692,25 @@ class PhaseExecutor:
                     behavioral_contract=self.behavioral_contract,
                     requirement_contract=self.requirement_contract,
                 )
-                reports.append(evaluate_deliverable(deliverable, ctx))
+                report = evaluate_deliverable(deliverable, ctx)
+                if report.passed:
+                    self._gate_cache[cache_key] = report
+                reports.append(report)
         return tuple(reports)
+
+    def _contracts_fingerprint(self) -> str:
+        """Cheap content-hash of the 3 loaded contracts. When any
+        contract changes between producer attempts, every deliverable's
+        cache entry is invalidated — even if the deliverable file
+        itself is unchanged — because the predicate evaluator reads
+        the contracts via PredicateContext."""
+        h = hashlib.sha256()
+        for c in (self.stack_contract, self.behavioral_contract, self.requirement_contract):
+            h.update(b"\x00")
+            if c is not None:
+                # sort_keys to make this deterministic across dict ordering
+                h.update(json.dumps(c, sort_keys=True, ensure_ascii=False).encode("utf-8"))
+        return h.hexdigest()
 
     def _refresh_contracts_from_disk(self) -> None:
         """Re-read docs/{stack,behavioral,requirement}_contract.json so

--- a/src/aise/runtime/reviewer.py
+++ b/src/aise/runtime/reviewer.py
@@ -216,12 +216,21 @@ def run_review_round(
     """Dispatch each reviewer, parse their verdicts, return the
     aggregated ConsensusResult.
 
-    Reviewers run sequentially (cheap relative to producer work, and
-    sequential keeps trace order deterministic). Use the ``decision``
-    helper module if you want to fan reviewers in parallel later.
+    A1 (2026-05-05): when there are 2+ reviewers (currently only the
+    architecture phase is dual-reviewer with developer + qa_engineer)
+    we dispatch them concurrently via a small thread pool. Each
+    reviewer is fully independent — they read the same deliverable
+    paths and respond with their own PASS/REVISE/REJECT verdict — so
+    parallelizing has zero quality impact and saves ~50% of the
+    review-round wall on the only phase that has multiple reviewers.
+
+    Single-reviewer phases (the other 5 phases) skip the pool and run
+    inline; the trace order is deterministic for either path because
+    we emit ``feedbacks`` in ``reviewer_roles`` order regardless of
+    completion order.
     """
-    feedbacks: list[ReviewerFeedback] = []
-    for role in reviewer_roles:
+
+    def _run_single(role: str) -> ReviewerFeedback:
         question = reviewer_questions.get(role, "Review the deliverables and verdict PASS / REVISE / REJECT.")
         prompt = build_reviewer_prompt(deliverable_paths, question, project_root=ctx.project_root)
         try:
@@ -229,24 +238,35 @@ def run_review_round(
         except Exception as exc:
             # A reviewer infra failure is a soft REVISE — don't halt
             # the run on a transient model error.
-            feedbacks.append(
-                ReviewerFeedback(
-                    reviewer_role=role,
-                    verdict="REVISE",
-                    feedback_text=f"reviewer dispatch raised {type(exc).__name__}: {exc}",
-                    raw_response="",
-                )
-            )
-            continue
-        verdict, feedback_text = parse_verdict(raw)
-        feedbacks.append(
-            ReviewerFeedback(
+            return ReviewerFeedback(
                 reviewer_role=role,
-                verdict=verdict,
-                feedback_text=feedback_text,
-                raw_response=raw,
+                verdict="REVISE",
+                feedback_text=f"reviewer dispatch raised {type(exc).__name__}: {exc}",
+                raw_response="",
             )
+        verdict, feedback_text = parse_verdict(raw)
+        return ReviewerFeedback(
+            reviewer_role=role,
+            verdict=verdict,
+            feedback_text=feedback_text,
+            raw_response=raw,
         )
+
+    if len(reviewer_roles) <= 1:
+        feedbacks = [_run_single(role) for role in reviewer_roles]
+    else:
+        from concurrent.futures import ThreadPoolExecutor
+
+        # Cap pool size at 4 — currently only architecture has 2
+        # reviewers but headroom is cheap and bounds the per-round
+        # parallelism if we ever add 3+ reviewers to a phase.
+        with ThreadPoolExecutor(max_workers=min(4, len(reviewer_roles))) as pool:
+            # Preserve reviewer_roles order in the output regardless of
+            # which thread finishes first — both ConsensusResult and
+            # downstream prepend_reviewer_feedback rely on stable order.
+            futures = [pool.submit(_run_single, role) for role in reviewer_roles]
+            feedbacks = [f.result() for f in futures]
+
     consensus_pass = all(f.is_pass for f in feedbacks) and len(feedbacks) > 0
     return ConsensusResult(
         feedbacks=tuple(feedbacks),

--- a/tests/test_runtime/test_waterfall_v2_loader.py
+++ b/tests/test_runtime/test_waterfall_v2_loader.py
@@ -125,11 +125,26 @@ class TestLoadBundledWaterfallV2:
         assert dlv is not None
         assert dlv.reviewer == ("rd_director",)
 
-    def test_review_budget_3_everywhere(self):
+    def test_review_budget_tiered_by_phase(self):
+        # revise_budget tiered on 2026-05-05 (perf optimization A2): phase 2
+        # architecture keeps 3 (framing decisions warrant deeper review);
+        # phase 6 delivery drops to 1 (summary phase, extra rounds rarely
+        # change anything); other phases drop to 2 — observed across the
+        # 5-scenario matrix that iter 3 produces near-zero new fixes.
+        expected = {
+            "requirements": 2,
+            "architecture": 3,
+            "implementation": 2,
+            "main_entry": 2,
+            "verification": 2,
+            "delivery": 1,
+        }
         spec = load_waterfall_v2(default_waterfall_v2_path())
         for ph in spec.phases:
             assert ph.review is not None, ph.id
-            assert ph.review.revise_budget == 3, ph.id
+            assert ph.review.revise_budget == expected[ph.id], (
+                f"{ph.id}: revise_budget={ph.review.revise_budget}, expected {expected[ph.id]}"
+            )
             assert ph.review.consensus == "ALL_PASS", ph.id
             assert ph.review.on_revise_exhausted == "continue_with_marker", ph.id
 


### PR DESCRIPTION
Four orthogonal scheduling optimizations from the post-PR-#143 RCA, validated against the 5-scenario phase-test matrix. **B2 (per-phase summary deliverables) was implemented, validated, and reverted** as a NET REGRESSION — see below for the data + mechanism. **B1** (speculative skeleton) deferred to a follow-up.

## A1 — Dual-reviewer parallelism (validated, kept)

Architecture is the only phase with 2 reviewers (developer + qa). They previously ran sequentially in `run_review_round`. Both see the same artifact and respond independently. Now they fan out via `ThreadPoolExecutor`. Single-reviewer phases bypass the pool. Reviewer feedback list order is preserved by role order regardless of completion order.

**Validation**: cpp_wc_cli × architecture went from 1554s (PR #142 pre-fix FAIL) → 1898s (PR #143 PASS) → **611s (-68% vs PR #143)**. A1 + A2 in combination.

## A2 — Per-phase revise_budget tiering (validated, kept)

Process spec previously had `revise_budget: 3` everywhere. The matrix observed ~70% of fixes land in iter 1, ~25% in iter 2, near-zero in iter 3.

| phase | budget |
|---|---:|
| requirements | 2 |
| **architecture** | **3** (kept) |
| implementation | 2 |
| main_entry | 2 |
| verification | 2 |
| delivery | 1 |

**Validation**: python implementation went from 116.9s → **85.9s (-26%)**. Quality unchanged.

## A3 — Adaptive max_workers in fan-out (kept)

Spec's static `max_workers: 3` serialized large fan-outs (22-component Flutter → 7+ batches). New `_adaptive_max_workers(task_count)`:
- ≤ 4 tasks → 2 workers
- 5–15 tasks → 4 workers
- 16+ tasks → 8 workers (cap at `_MAX_FANOUT_PARALLELISM`)

Treated as a floor combined with the spec's static value.

## B3 — AUTO_GATE incremental cache (kept)

Producer attempts re-ran every predicate against every deliverable even when nothing changed. New `PhaseExecutor._gate_cache` keys on `(path, kind, file_fingerprint, contracts_fingerprint)` and reuses PASSED reports across retries. Failures NOT cached. Cache is per-PhaseExecutor.

## B2 — REJECTED, reverted

B2 (`architecture_summary.md` + `qa_report_summary.md` as AUTO_GATE deliverables, plus `delivery.inputs` pointing at them) was implemented, validated, and **reverted as a net regression**:

| python_cli_hello_world phase | baseline | with B2 | Δ |
|---|---:|---:|---:|
| architecture | 63.1s | 271.3s | **+330%** |
| verification | 124.1s | 261.5s | +110% |
| delivery | 18.5s | 74.6s | +303% |
| **total** | **399s** | **796s** | **+99%** |

cpp_wc_cli total: 3781s → 4100s (+8%) — delivery savings didn't cover the verification overhead.

**Mechanism**:
1. architect / qa_engineer often forget the summary file → AUTO_GATE fails → producer retries (each retry is a full re-run, 5–15 min)
2. Delivery's `inputs:` pointed at summaries that didn't exist in pre-B2 fixture snapshots → PM confused

If revisited later, B2 should be (a) opt-in via project_config, (b) delivery-only suggestion not AUTO_GATE deliverable, or (c) replaced by a runtime preprocessor that synthesises the summary deterministically (no LLM).

## Validation

Five-scenario partial re-run (python + cpp, all 6 phases) on the A1+A2+A3+B3 build (no B2):

| python | baseline | this PR | Δ |
|---|---:|---:|---:|
| total | 399s | TBD | TBD |

| cpp | baseline | this PR | Δ |
|---|---:|---:|---:|
| total | 3781s | TBD | TBD |

(Re-running python now after the revert; cpp re-run optional.)

## Test plan

- [x] `ruff check` + `format` clean
- [x] `pytest --tb=short -q --ignore=tests/test_packaging --ignore=tests/test_whatsapp` → **1321 passed / 52 skipped / 0 failed**
- [ ] Re-run python 6 phases with this revision (A1+A2+A3+B3 only) — in progress
- [ ] CI green

## Deferred

**B1** — speculative skeleton during phase 2 review (-10% to -15% on complex projects). Lands as its own follow-up after this PR validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)