### PR TITLE
feat(waterfall_v2): redefine main_entry phase as assembly proof

### DIFF
--- a/src/aise/agents/architect.md
+++ b/src/aise/agents/architect.md
@@ -208,6 +208,75 @@ own — if you don't lay down the skeleton, nobody will.
   project_7-tower's three-stacks-coexist AND 24-flat-directories
   failure modes.**
 
+- **`docs/data_dependency_contract.json` — OPTIONAL (write only when
+  the project ships data files that runtime code MUST consume).** If the
+  architecture has any of: external level/world data, asset bundles,
+  fixtures, i18n string tables, config JSON loaded at startup — declare
+  every such pipe here. Schema is `schemas/data_dependency_contract.schema.json`.
+  Minimum example:
+
+  ```json
+  {
+    "version": "1",
+    "data_dependencies": [
+      {
+        "name": "level_data",
+        "files_glob": "assets/level_*.json",
+        "consumer_module": "src/level/loader.*",
+        "min_files": 1,
+        "load_invariant": {"kind": "collection_non_empty",
+                            "expr": "loader.levels"}
+      }
+    ]
+  }
+  ```
+
+  The main_entry phase's `data_dependency_wiring_static` AUTO_GATE
+  re-runs `grep` on each `consumer_module` looking for any reference
+  to `files_glob` (literal prefix or any concrete file the glob
+  resolves to). If you declare a dependency the developer doesn't
+  wire, the gate FAILS the phase and the developer must fix the
+  loader. Do NOT declare data files that the design intends to ship
+  unread (e.g. examples in `docs/`); only declare paths whose contents
+  the runtime is expected to load.
+
+- **`docs/action_contract.json` — OPTIONAL (write only when the
+  project has user/external triggers whose handlers MUST do real
+  work).** Examples: a game's "primary attack" key, a CLI's
+  `--upgrade` flag, an HTTP endpoint POST /transfer. For each action,
+  list the symbols the handler must call so the static gate catches
+  "key wired to empty stub" assemblies. Schema is
+  `schemas/action_contract.schema.json`. Minimum example:
+
+  ```json
+  {
+    "version": "1",
+    "actions": [
+      {
+        "name": "primary_attack",
+        "trigger": {"kind": "key", "value": "Space"},
+        "expected_change": {"kind": "state_field_changes",
+                             "field": "currentScreen"},
+        "handler_must_call": ["combat.calculateBattle",
+                                "player.applyBattleResult"]
+      }
+    ]
+  }
+  ```
+
+  The main_entry phase's `action_contract_wiring_static` AUTO_GATE
+  scans the entry-point file (or `action.handler_module` when set)
+  for every symbol in `handler_must_call`, looking for a call site
+  matching `\bsymbol\s*\(`. Missing → gate FAILS. Use this when the
+  cost of a "wire ran but did nothing" bug is high (game combat,
+  payment, security-sensitive flows).
+
+  Both contracts are OPTIONAL. Projects without runtime data pipes /
+  important user actions can skip them — the main_entry static gates
+  vacuous-pass when the contract files are absent. Skipping is fine
+  for trivial CLIs and pure-library packages; producing them is
+  STRONGLY recommended for any project with a runtime-driven loop.
+
 - **Subsystem directories — MANDATORY (one directory per *subsystem*,
   NOT one directory per component).** A "subsystem" is the unit of
   decomposition the architecture document draws an outline around —

--- a/src/aise/agents/developer.md
+++ b/src/aise/agents/developer.md
@@ -176,7 +176,39 @@ iterate `docs/stack_contract.json#/lifecycle_inits[]` and invoke each
 listed `<attr>.<method>()` exactly once, in the order declared.
 Skipping this loop — or hand-picking a subset of components — is the
 single most common cause of "tests pass, screen blank" delivery
-failures. The minimal pattern (Python example):
+failures.
+
+**Assembly proof is mandatory** (added 2026-05-06; harden main_entry).
+The main_entry phase is no longer "write the entry file"; it is "prove
+the assembly is wired". On top of the lifecycle loop above, you MUST
+also satisfy:
+
+1. **Data dependency wiring** — if `docs/data_dependency_contract.json`
+   exists, every entry's `consumer_module` glob MUST resolve to a
+   source file that references the corresponding `files_glob` (literal
+   prefix or any concrete file). The static gate
+   `data_dependency_wiring_static` re-runs grep; missing references
+   FAIL the phase.
+
+2. **Action handler wiring** — if `docs/action_contract.json` exists,
+   for every action with a non-empty `handler_must_call`, the handler
+   file (action.handler_module if set, else stack_contract.entry_point)
+   MUST contain a call site for each declared symbol (matched as
+   `\bsymbol\s*\(`). The static gate
+   `action_contract_wiring_static` enforces this; an empty handler
+   stub (e.g. `case 'battle': // TODO`) FAILS the phase.
+
+3. **Integration report** — write `docs/integration_report.json`
+   with the schema `schemas/integration_report.schema.json` summarising
+   the three checks above. `verdict` MUST be `"pass"` (everything
+   wired) or `"skipped"` (with a `reason` saying why a runtime probe
+   couldn't run, e.g. no headless browser); `"fail"` is rejected by
+   AUTO_GATE. The optional integration probe at
+   `python -m aise.runtime.integration_probe <project_root>` produces
+   this file automatically — invoke it with `--no-boot` if your
+   sandbox shouldn't spawn the runtime.
+
+The minimal lifecycle pattern (Python example):
 
 ```python
 import json

--- a/src/aise/processes/waterfall_v2.process.md
+++ b/src/aise/processes/waterfall_v2.process.md
@@ -75,6 +75,23 @@ phases:
           - file_exists
           - { schema: schemas/behavioral_contract.schema.json }
           - { min_scenarios: 5 }
+      # Two assembly contracts (added 2026-05-06 to harden main_entry):
+      # - data_dependency_contract: which data/asset files MUST be consumed
+      #   by which source modules at runtime
+      # - action_contract: which user/external triggers MUST be wired to
+      #   non-trivial handlers
+      # Both are OPTIONAL on disk — projects without them keep the prior
+      # main_entry behaviour. When present, the main_entry static gates
+      # (data_dependency_wiring_static / action_contract_wiring_static)
+      # check that the assembly is actually wired.
+      - kind: contract
+        path: docs/data_dependency_contract.json
+        acceptance:
+          - { schema_optional: schemas/data_dependency_contract.schema.json }
+      - kind: contract
+        path: docs/action_contract.json
+        acceptance:
+          - { schema_optional: schemas/action_contract.schema.json }
     review:
       consensus: ALL_PASS
       revise_budget: 3
@@ -143,14 +160,36 @@ phases:
     title: Main Entry Wiring
     producer: developer
     reviewer: qa_engineer
-    inputs: [docs/stack_contract.json]
+    inputs:
+      - docs/stack_contract.json
+      - docs/data_dependency_contract.json
+      - docs/action_contract.json
     deliverables:
+      # The entry-point file carries all three assembly checks:
+      # - lifecycle_inits invoked (existing rule)
+      # - data dependencies referenced somewhere in source
+      # - action handlers wire the must-call symbols
+      # All three are vacuous-pass when their driving contract is
+      # absent, so legacy projects without data_dependency_contract /
+      # action_contract see no behaviour change.
       - kind: derived
         from: stack_contract
         rule: entry_point
         acceptance:
           - file_exists
           - contains_all_lifecycle_inits
+          - data_dependency_wiring_static
+          - action_contract_wiring_static
+      # NEW assembly self-disclosure: developer writes the integration
+      # report; AUTO_GATE validates structure + that verdict != fail.
+      # The hard gates are the three predicates above; this report is
+      # the audit-trail artefact phase 6 (delivery) reads.
+      - kind: document
+        path: docs/integration_report.json
+        acceptance:
+          - file_exists
+          - { schema: schemas/integration_report.schema.json }
+          - { json_field_one_of: { field: verdict, allowed: ["pass", "skipped"] } }
     review:
       consensus: ALL_PASS
       revise_budget: 2
@@ -159,6 +198,9 @@ phases:
         qa_engineer: |
           按 stack_contract.run_command 启动 entry_point 是否能 boot 成功？
           若沙箱无法运行该 runtime，请基于代码静态推断并说明理由。
+          额外检查：data_dependency_contract / action_contract 中的每条
+          条目是否都已在源码中真正引用/调用？docs/integration_report.json
+          的 verdict 字段必须为 "pass" 或 "skipped"（附 reason）。
 
   # --------------------------------------------------------------------
   - id: verification
@@ -199,6 +241,17 @@ phases:
         acceptance:
           - file_exists
           - { schema: schemas/qa_report.schema.json }
+          # Lint-only warning (non-blocking): scan tests/integration/**
+          # and tests/scenarios/** for files with no source-code refs;
+          # surface them in the AUTO_GATE log. The hard gate against
+          # fake integration tests is action_contract_wiring_static in
+          # the main_entry phase; this lint is a redundant signal.
+          - {
+              lint_integration_test_imports: {
+                globs: ["tests/integration/**", "tests/scenarios/**"],
+                source_globs: ["src/", "lib/"],
+              },
+            }
     review:
       consensus: ALL_PASS
       revise_budget: 2

--- a/src/aise/runtime/integration_probe.py
+++ b/src/aise/runtime/integration_probe.py
@@ -1,0 +1,527 @@
+"""Integration probe — runtime-side companion to the static main_entry
+predicates.
+
+Responsibility: take a project root, look up the stack profile, and
+return an ``integration_report.json``-shaped dict with the runtime
+``boot_check`` plus best-effort ``data_wiring_check`` /
+``action_wiring_check`` annotations. The probe is a *helper* — neither
+PhaseExecutor nor any predicate runs it automatically. The developer
+agent or qa_engineer agent invokes it via the ``aise integration_probe``
+CLI hook (``python -m aise.runtime.integration_probe <project_root>``)
+inside the main_entry phase, and writes the result into
+``docs/integration_report.json``.
+
+By design:
+* Static gates enforce correctness (and never spawn subprocesses).
+* The runtime probe is best-effort: it writes ``verdict=skipped`` with
+  a precise ``reason`` whenever the stack profile is ``web`` or
+  ``unknown`` (no headless browser shipped with the AISE sandbox), or
+  whenever a dependency (``run_command``, port, http library) is
+  unavailable.
+
+This module is intentionally pure-stdlib — no requests, no playwright,
+no docker. Subprocess + urllib + socket only.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+from urllib.error import URLError
+
+from .stack_profiles import select_profile
+
+# -- Result types --------------------------------------------------------
+
+
+@dataclass
+class BootCheck:
+    ran: bool = False
+    verdict: str = "skipped"  # pass | fail | skipped
+    exit_code: int | None = None
+    duration_s: float = 0.0
+    reason: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        # exit_code may be None — drop it from the dict in that case so
+        # the schema's `integer` type doesn't trip on null.
+        if d.get("exit_code") is None:
+            d.pop("exit_code")
+        return d
+
+
+@dataclass
+class DataWiring:
+    name: str
+    static_refs: int
+    consumer_module_resolved: str = ""
+    runtime_invariant_ok: bool | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        if d.get("runtime_invariant_ok") is None:
+            d.pop("runtime_invariant_ok")
+        return d
+
+
+@dataclass
+class ActionWiring:
+    name: str
+    handler_calls_found: int
+    handler_calls_missing: list[str] = field(default_factory=list)
+    state_changed: bool | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        if d.get("state_changed") is None:
+            d.pop("state_changed")
+        return d
+
+
+@dataclass
+class ProbeResult:
+    profile: str
+    runtime_kind: str
+    verdict: str  # pass | fail | skipped
+    boot: BootCheck
+    data_wiring: list[DataWiring]
+    action_wiring: list[ActionWiring]
+    violations: list[str]
+
+    def to_integration_report(self) -> dict[str, Any]:
+        """Materialize the integration_report.json shape consumed by
+        the schema validator + AUTO_GATE."""
+        from datetime import datetime, timezone
+
+        return {
+            "phase": "main_entry",
+            "completed_at": datetime.now(tz=timezone.utc).isoformat(),
+            "verdict": self.verdict,
+            "lifecycle_init_check": {"expected": 0, "reached": 0},
+            "data_wiring_check": [d.to_dict() for d in self.data_wiring],
+            "action_wiring_check": [a.to_dict() for a in self.action_wiring],
+            "boot_check": self.boot.to_dict(),
+            "violations": list(self.violations),
+            "_profile": self.profile,
+            "_runtime_kind": self.runtime_kind,
+        }
+
+
+# -- Static-side helpers (mirror predicates.py logic for the report) -----
+
+
+def _glob_substring_keys(glob: str) -> list[str]:
+    cut = glob
+    for ch in ("*", "?", "[", "{"):
+        idx = cut.find(ch)
+        if idx >= 0:
+            cut = cut[:idx]
+    cut = cut.rstrip("/")
+    out: list[str] = []
+    if cut:
+        out.append(cut)
+    if glob and glob not in out:
+        out.append(glob)
+    return out or [glob]
+
+
+def _expand(project_root: Path, glob: str) -> list[Path]:
+    return sorted(project_root.glob(glob.lstrip("/")))
+
+
+def _count_data_refs(project_root: Path, dep: dict[str, Any]) -> tuple[int, str]:
+    consumer_glob = dep.get("consumer_module") or ""
+    files_glob = dep.get("files_glob") or ""
+    if not consumer_glob or not files_glob:
+        return 0, ""
+    consumers = _expand(project_root, consumer_glob)
+    if not consumers:
+        return 0, consumer_glob
+    keys = list(_glob_substring_keys(files_glob))
+    for f in _expand(project_root, files_glob):
+        try:
+            keys.append(str(f.relative_to(project_root)))
+        except ValueError:
+            keys.append(str(f))
+        keys.append(f.name)
+    keys = list(dict.fromkeys(keys))
+    refs = 0
+    matched_consumer = ""
+    for c in consumers:
+        try:
+            body = c.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for k in keys:
+            if k and k in body:
+                refs += body.count(k)
+                if not matched_consumer:
+                    try:
+                        matched_consumer = str(c.relative_to(project_root))
+                    except ValueError:
+                        matched_consumer = str(c)
+    return refs, matched_consumer
+
+
+def _count_handler_calls(
+    project_root: Path,
+    action: dict[str, Any],
+    default_handler: str,
+) -> tuple[int, list[str]]:
+    must_call = action.get("handler_must_call") or []
+    if not must_call:
+        return 0, []
+    handler_rel = action.get("handler_module") or default_handler
+    if not handler_rel:
+        return 0, list(must_call)
+    handler_path = project_root / handler_rel.lstrip("/")
+    if not handler_path.is_file():
+        return 0, list(must_call)
+    try:
+        body = handler_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return 0, list(must_call)
+    found = 0
+    missing: list[str] = []
+    for sym in must_call:
+        if not isinstance(sym, str) or not sym:
+            continue
+        tail = sym.rsplit(".", 1)[-1]
+        pattern = rf"\b{re.escape(tail)}\s*\("
+        if re.search(pattern, body):
+            found += 1
+        else:
+            missing.append(sym)
+    return found, missing
+
+
+# -- Runtime boot helpers ------------------------------------------------
+
+
+def _alloc_port() -> int:
+    """Ask the OS for a free TCP port. Race-prone (someone else could
+    grab it before the spawned process binds) but the probe's boot
+    window is short enough that this is acceptable for a best-effort."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _format_cmd(
+    template: tuple[str, ...],
+    *,
+    entry_point: str,
+    run_command: str,
+    port: int,
+) -> list[str]:
+    """Substitute template placeholders. Missing placeholder raises
+    KeyError so we surface a precise error in the report."""
+    out: list[str] = []
+    for tok in template:
+        formatted = tok.format(entry_point=entry_point, run_command=run_command, port=port)
+        out.append(formatted)
+    return out
+
+
+def _run_cli_probe(
+    cmd: list[str],
+    cwd: Path,
+    timeout_s: int,
+) -> BootCheck:
+    """Spawn the cli binary, wait for exit, capture stdio. Verdict is
+    pass when exit_code is 0 and stdout is non-empty (something happened);
+    fail otherwise."""
+    started = time.monotonic()
+    try:
+        proc = subprocess.run(  # noqa: S603 — cmd is from architect's stack_contract
+            cmd,
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired:
+        return BootCheck(
+            ran=True,
+            verdict="fail",
+            exit_code=None,
+            duration_s=time.monotonic() - started,
+            reason=f"cli probe timed out after {timeout_s}s",
+        )
+    except OSError as exc:
+        return BootCheck(
+            ran=False,
+            verdict="skipped",
+            duration_s=time.monotonic() - started,
+            reason=f"spawn failed: {type(exc).__name__}: {exc}",
+        )
+    duration = time.monotonic() - started
+    if proc.returncode != 0:
+        return BootCheck(
+            ran=True,
+            verdict="fail",
+            exit_code=proc.returncode,
+            duration_s=duration,
+            reason=f"non-zero exit; stderr head: {(proc.stderr or '')[:200]!r}",
+        )
+    stdout_head = (proc.stdout or "").strip()
+    if not stdout_head:
+        return BootCheck(
+            ran=True,
+            verdict="fail",
+            exit_code=0,
+            duration_s=duration,
+            reason="exit 0 but empty stdout — no observable behaviour",
+        )
+    return BootCheck(
+        ran=True,
+        verdict="pass",
+        exit_code=0,
+        duration_s=duration,
+        reason=f"stdout head: {stdout_head[:120]!r}",
+    )
+
+
+def _run_server_probe(
+    cmd: list[str],
+    cwd: Path,
+    url: str,
+    timeout_s: int,
+) -> BootCheck:
+    """Spawn server, poll URL until 2xx (or timeout), then terminate."""
+    started = time.monotonic()
+    try:
+        proc = subprocess.Popen(  # noqa: S603 — cmd is from architect's stack_contract
+            cmd,
+            cwd=str(cwd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        return BootCheck(
+            ran=False,
+            verdict="skipped",
+            duration_s=time.monotonic() - started,
+            reason=f"spawn failed: {type(exc).__name__}: {exc}",
+        )
+    deadline = started + timeout_s
+    last_err = ""
+    try:
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                # Server exited before responding — collect output.
+                tail = (proc.stderr.read() if proc.stderr else "") or ""
+                return BootCheck(
+                    ran=True,
+                    verdict="fail",
+                    exit_code=proc.returncode,
+                    duration_s=time.monotonic() - started,
+                    reason=f"server exited early: stderr head: {tail[:200]!r}",
+                )
+            try:
+                with urllib.request.urlopen(url, timeout=2) as resp:  # noqa: S310 — local probe
+                    status = resp.status if hasattr(resp, "status") else resp.getcode()
+                    if 200 <= status < 400:
+                        return BootCheck(
+                            ran=True,
+                            verdict="pass",
+                            exit_code=None,
+                            duration_s=time.monotonic() - started,
+                            reason=f"http {status} from {url}",
+                        )
+                    last_err = f"http {status}"
+            except (URLError, OSError, ConnectionError) as exc:
+                last_err = f"{type(exc).__name__}: {exc}"
+            time.sleep(0.25)
+        return BootCheck(
+            ran=True,
+            verdict="fail",
+            exit_code=None,
+            duration_s=time.monotonic() - started,
+            reason=f"server did not respond at {url} within {timeout_s}s; last err: {last_err}",
+        )
+    finally:
+        try:
+            proc.terminate()
+            proc.wait(timeout=2)
+        except (OSError, subprocess.TimeoutExpired):
+            try:
+                proc.kill()
+            except OSError:
+                pass
+
+
+def _run_web_probe(reason_extra: str = "") -> BootCheck:
+    """Web probe is intentionally a stub. A real implementation would
+    require puppeteer/playwright, which we don't ship with the AISE
+    sandbox. The static gates (data_dependency_wiring_static and
+    action_contract_wiring_static) cover the assembly correctness; the
+    runtime probe in this profile contributes only an audit-log
+    attestation that we *tried*."""
+    base = "web runtime probe requires headless browser; not available in sandbox"
+    if reason_extra:
+        base = f"{base}; {reason_extra}"
+    return BootCheck(ran=False, verdict="skipped", reason=base)
+
+
+# -- Top-level entry point ------------------------------------------------
+
+
+def run_probe(
+    project_root: Path,
+    *,
+    stack_contract: dict[str, Any] | None = None,
+    data_dependency_contract: dict[str, Any] | None = None,
+    action_contract: dict[str, Any] | None = None,
+    enable_boot: bool = True,
+) -> ProbeResult:
+    """End-to-end probe: pick profile, run static + (optional) runtime
+    checks, return ProbeResult.
+
+    The static checks always run (they have no external dependencies);
+    the runtime boot probe runs only when ``enable_boot=True`` AND the
+    profile supports it. ``enable_boot=False`` is the safe default for
+    sandboxes / CI environments that don't want subprocess spawn.
+    """
+    profile = select_profile(project_root, stack_contract)
+
+    # Static checks first — these are always run, regardless of profile.
+    deps = (data_dependency_contract or {}).get("data_dependencies") or []
+    actions = (action_contract or {}).get("actions") or []
+    default_handler = (stack_contract or {}).get("entry_point") or ""
+
+    data_wiring: list[DataWiring] = []
+    violations: list[str] = []
+    for dep in deps:
+        if not isinstance(dep, dict):
+            continue
+        name = dep.get("name") or "?"
+        refs, consumer_resolved = _count_data_refs(project_root, dep)
+        if refs == 0:
+            violations.append(f"data_wiring.{name}: 0 source references to {dep.get('files_glob')!r}")
+        data_wiring.append(DataWiring(name=name, static_refs=refs, consumer_module_resolved=consumer_resolved))
+
+    action_wiring: list[ActionWiring] = []
+    for act in actions:
+        if not isinstance(act, dict):
+            continue
+        name = act.get("name") or "?"
+        found, missing = _count_handler_calls(project_root, act, default_handler)
+        if missing:
+            violations.append(f"action_wiring.{name}: handler missing call sites for {missing}")
+        action_wiring.append(ActionWiring(name=name, handler_calls_found=found, handler_calls_missing=missing))
+
+    # Runtime boot. Skipped when disabled or when profile doesn't support it.
+    if not enable_boot:
+        boot = BootCheck(ran=False, verdict="skipped", reason="boot probe disabled by caller")
+    elif profile.runtime_kind == "web":
+        boot = _run_web_probe()
+    elif profile.runtime_kind == "unknown":
+        boot = BootCheck(ran=False, verdict="skipped", reason="no_matching_profile")
+    elif not profile.boot_cmd:
+        boot = BootCheck(ran=False, verdict="skipped", reason="profile has no boot_cmd template")
+    else:
+        try:
+            port = _alloc_port() if "{port}" in " ".join(profile.boot_cmd) else 0
+            cmd = _format_cmd(
+                profile.boot_cmd,
+                entry_point=(stack_contract or {}).get("entry_point") or "",
+                run_command=(stack_contract or {}).get("run_command") or "",
+                port=port,
+            )
+        except KeyError as exc:
+            boot = BootCheck(ran=False, verdict="skipped", reason=f"unresolved placeholder: {exc}")
+        else:
+            if profile.runtime_kind == "cli":
+                boot = _run_cli_probe(cmd, project_root, profile.boot_timeout_s)
+            elif profile.runtime_kind == "server":
+                url = profile.observe_arg.format(port=port) if profile.observe_arg else f"http://127.0.0.1:{port}/"
+                boot = _run_server_probe(cmd, project_root, url, profile.boot_timeout_s)
+            else:
+                boot = BootCheck(ran=False, verdict="skipped", reason=f"unknown runtime_kind={profile.runtime_kind}")
+
+    # Verdict: if any static violation exists OR the boot probe reported
+    # fail, the overall verdict is fail. Skipped probes don't count
+    # against the verdict (we don't want a missing tool to block a
+    # static-clean assembly).
+    if violations or boot.verdict == "fail":
+        verdict = "fail"
+    elif data_wiring or action_wiring or boot.verdict == "pass":
+        verdict = "pass"
+    else:
+        # Nothing to check (no contracts, no boot) → skipped, not pass.
+        verdict = "skipped"
+
+    return ProbeResult(
+        profile=profile.name,
+        runtime_kind=profile.runtime_kind,
+        verdict=verdict,
+        boot=boot,
+        data_wiring=data_wiring,
+        action_wiring=action_wiring,
+        violations=violations,
+    )
+
+
+# -- CLI hook: python -m aise.runtime.integration_probe <project_root> ----
+
+
+def _load_optional_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI wrapper. Reads the project's docs/*.json contracts, runs the
+    probe, writes ``docs/integration_report.json``, and prints the
+    JSON shape on stdout. Exit 0 on verdict in {pass, skipped}; exit 1
+    on verdict=fail.
+    """
+    args = list(argv if argv is not None else sys.argv[1:])
+    enable_boot = True
+    if "--no-boot" in args:
+        enable_boot = False
+        args.remove("--no-boot")
+    if not args:
+        print("usage: integration_probe <project_root> [--no-boot]", file=sys.stderr)
+        return 2
+    project_root = Path(args[0]).resolve()
+    if not project_root.is_dir():
+        print(f"not a directory: {project_root}", file=sys.stderr)
+        return 2
+
+    sc = _load_optional_json(project_root / "docs" / "stack_contract.json")
+    dd = _load_optional_json(project_root / "docs" / "data_dependency_contract.json")
+    ac = _load_optional_json(project_root / "docs" / "action_contract.json")
+
+    result = run_probe(
+        project_root,
+        stack_contract=sc,
+        data_dependency_contract=dd,
+        action_contract=ac,
+        enable_boot=enable_boot,
+    )
+    report = result.to_integration_report()
+    out = project_root / "docs" / "integration_report.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    return 0 if result.verdict in ("pass", "skipped") else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/aise/runtime/phase_executor.py
+++ b/src/aise/runtime/phase_executor.py
@@ -264,6 +264,47 @@ _CONTRACT_EXAMPLES: dict[str, str] = {
     }
   ]
 }""",
+    "data_dependency_contract.json": """{
+  "version": "1",
+  "data_dependencies": [
+    {
+      "name": "level_data",
+      "files_glob": "assets/level_*.json",
+      "consumer_module": "src/level/loader.*",
+      "min_files": 1,
+      "load_invariant": {
+        "kind": "collection_non_empty",
+        "expr": "loader.levels",
+        "after": "boot+init"
+      }
+    }
+  ]
+}""",
+    "action_contract.json": """{
+  "version": "1",
+  "actions": [
+    {
+      "name": "primary_action",
+      "trigger": { "kind": "key", "value": "Enter" },
+      "expected_change": { "kind": "state_field_changes", "field": "currentScreen" },
+      "handler_must_call": ["controller.handlePrimary"]
+    }
+  ]
+}""",
+    "integration_report.json": """{
+  "phase": "main_entry",
+  "completed_at": "<ISO timestamp>",
+  "verdict": "pass",
+  "lifecycle_init_check": { "expected": 0, "reached": 0 },
+  "data_wiring_check": [
+    { "name": "<dep name>", "static_refs": 1, "consumer_module_resolved": "src/<file>", "runtime_invariant_ok": true }
+  ],
+  "action_wiring_check": [
+    { "name": "<action name>", "handler_calls_found": 1, "handler_calls_missing": [] }
+  ],
+  "boot_check": { "ran": false, "verdict": "skipped", "reason": "no headless harness available in sandbox" },
+  "violations": []
+}""",
 }
 
 
@@ -417,6 +458,8 @@ class PhaseExecutor:
     stack_contract: dict[str, Any] | None = None
     behavioral_contract: dict[str, Any] | None = None
     requirement_contract: dict[str, Any] | None = None
+    data_dependency_contract: dict[str, Any] | None = None
+    action_contract: dict[str, Any] | None = None
     # B3 (2026-05-05): per-(path, kind, file_fp, contracts_fp) cache of
     # previously-PASSED DeliverableReports. Skips re-running the predicate
     # sweep on retries when nothing relevant has changed. Reset implicitly
@@ -691,6 +734,8 @@ class PhaseExecutor:
                     stack_contract=self.stack_contract,
                     behavioral_contract=self.behavioral_contract,
                     requirement_contract=self.requirement_contract,
+                    data_dependency_contract=self.data_dependency_contract,
+                    action_contract=self.action_contract,
                 )
                 report = evaluate_deliverable(deliverable, ctx)
                 if report.passed:
@@ -699,13 +744,19 @@ class PhaseExecutor:
         return tuple(reports)
 
     def _contracts_fingerprint(self) -> str:
-        """Cheap content-hash of the 3 loaded contracts. When any
+        """Cheap content-hash of the loaded contracts. When any
         contract changes between producer attempts, every deliverable's
         cache entry is invalidated — even if the deliverable file
         itself is unchanged — because the predicate evaluator reads
         the contracts via PredicateContext."""
         h = hashlib.sha256()
-        for c in (self.stack_contract, self.behavioral_contract, self.requirement_contract):
+        for c in (
+            self.stack_contract,
+            self.behavioral_contract,
+            self.requirement_contract,
+            self.data_dependency_contract,
+            self.action_contract,
+        ):
             h.update(b"\x00")
             if c is not None:
                 # sort_keys to make this deterministic across dict ordering
@@ -713,13 +764,16 @@ class PhaseExecutor:
         return h.hexdigest()
 
     def _refresh_contracts_from_disk(self) -> None:
-        """Re-read docs/{stack,behavioral,requirement}_contract.json so
-        AUTO_GATE sees the just-produced state. Idempotent — silent on
-        missing files (predicates handle that themselves)."""
+        """Re-read docs/*_contract.json so AUTO_GATE sees the just-produced
+        state. Idempotent — silent on missing files (predicates handle
+        that themselves; the integration-assembly predicates vacuous-pass
+        when their driving contract is absent)."""
         for attr, fname in (
             ("stack_contract", "stack_contract.json"),
             ("behavioral_contract", "behavioral_contract.json"),
             ("requirement_contract", "requirement_contract.json"),
+            ("data_dependency_contract", "data_dependency_contract.json"),
+            ("action_contract", "action_contract.json"),
         ):
             path = self.project_root / "docs" / fname
             if not path.is_file():

--- a/src/aise/runtime/predicates.py
+++ b/src/aise/runtime/predicates.py
@@ -94,6 +94,8 @@ class PredicateContext:
     stack_contract: dict[str, Any] | None = None
     behavioral_contract: dict[str, Any] | None = None
     requirement_contract: dict[str, Any] | None = None
+    data_dependency_contract: dict[str, Any] | None = None
+    action_contract: dict[str, Any] | None = None
     extras: dict[str, Any] = field(default_factory=dict)
 
     def read_text(self) -> str:
@@ -188,35 +190,62 @@ def _regex_count(arg: Any, ctx: PredicateContext) -> PredicateResult:
     return PredicateResult("regex_count", False, f"matched {n} < {min_n} for {pattern!r}")
 
 
+def _schema_validate(arg: Any, ctx: PredicateContext, kind: str) -> PredicateResult:
+    """Shared body for the ``schema`` and ``schema_optional`` predicates.
+    Caller decides whether a missing file is FAIL (``schema``) or
+    skipped=True (``schema_optional``)."""
+    if not isinstance(arg, str):
+        return PredicateResult(kind, False, f"invalid arg {arg!r}")
+    path = ctx.deliverable_path
+    # Caller is expected to have handled the missing-file case before
+    # calling us; we re-check defensively for robustness.
+    if not path.is_file():
+        return PredicateResult(kind, False, f"missing: {path}")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return PredicateResult(kind, False, f"invalid JSON: {exc}")
+    schema_path = _resolve_schema_path(arg, ctx)
+    if not schema_path.is_file():
+        return PredicateResult(kind, False, f"schema file missing: {schema_path}")
+    try:
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return PredicateResult(kind, False, f"schema is invalid JSON: {exc}")
+    errors = validate(data, schema)
+    if errors:
+        joined = "; ".join(errors[:5])  # cap to keep error preview readable
+        more = f" (+{len(errors) - 5} more)" if len(errors) > 5 else ""
+        return PredicateResult(kind, False, f"{joined}{more}")
+    return PredicateResult(kind, True, f"valid against {arg}")
+
+
 @register("schema")
 def _schema(arg: Any, ctx: PredicateContext) -> PredicateResult:
     """``schema: schemas/foo.schema.json`` — validate JSON deliverable
     against the named schema. Schema path is relative to ``src/aise/``
     (so ``schemas/foo.schema.json`` resolves to
-    ``src/aise/schemas/foo.schema.json``).
+    ``src/aise/schemas/foo.schema.json``). Fails when the deliverable
+    file is missing.
     """
-    if not isinstance(arg, str):
-        return PredicateResult("schema", False, f"invalid arg {arg!r}")
-    path = ctx.deliverable_path
-    if not path.is_file():
-        return PredicateResult("schema", False, f"missing: {path}")
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        return PredicateResult("schema", False, f"invalid JSON: {exc}")
-    schema_path = _resolve_schema_path(arg, ctx)
-    if not schema_path.is_file():
-        return PredicateResult("schema", False, f"schema file missing: {schema_path}")
-    try:
-        schema = json.loads(schema_path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        return PredicateResult("schema", False, f"schema is invalid JSON: {exc}")
-    errors = validate(data, schema)
-    if errors:
-        joined = "; ".join(errors[:5])  # cap to keep error preview readable
-        more = f" (+{len(errors) - 5} more)" if len(errors) > 5 else ""
-        return PredicateResult("schema", False, f"{joined}{more}")
-    return PredicateResult("schema", True, f"valid against {arg}")
+    return _schema_validate(arg, ctx, "schema")
+
+
+@register("schema_optional")
+def _schema_optional(arg: Any, ctx: PredicateContext) -> PredicateResult:
+    """Same as ``schema`` but vacuous-passes (skipped=True) when the
+    deliverable file is absent. Use for additive contracts that not every
+    project declares (e.g. data_dependency_contract.json,
+    action_contract.json) — when present the schema is enforced; when
+    absent the AUTO_GATE does not trip."""
+    if not ctx.deliverable_path.is_file():
+        return PredicateResult(
+            "schema_optional",
+            True,
+            f"file absent ({ctx.deliverable_path.name}); skipping",
+            skipped=True,
+        )
+    return _schema_validate(arg, ctx, "schema_optional")
 
 
 def _resolve_schema_path(arg: str, ctx: PredicateContext) -> Path:
@@ -679,6 +708,330 @@ def _count_at_most(arg: Any, ctx: PredicateContext) -> PredicateResult:
     if n <= max_n:
         return PredicateResult("count_at_most", True, f"len({field_path})={n} <= {max_n}")
     return PredicateResult("count_at_most", False, f"len({field_path})={n} > {max_n}")
+
+
+# -- Integration-assembly predicates (main_entry phase) -------------------
+#
+# These three predicates (``data_dependency_wiring_static``,
+# ``action_contract_wiring_static``, ``lint_integration_test_imports``)
+# enforce the "main_entry must prove the assembly is wired" responsibility
+# established in the v2 design. They are intentionally pure-static —
+# they read source files and contract JSON; they never spawn subprocesses
+# or browser harnesses. Runtime-side enforcement (boot probes) is a
+# separate optional layer in ``stack_profiles.py``.
+#
+# All three are vacuous-pass when their driving contract is absent, so
+# legacy projects (no data_dependency_contract.json, no action_contract.json)
+# behave exactly as before this commit.
+
+
+def _expand_glob(project_root: Path, glob: str) -> list[Path]:
+    """Expand a project-relative glob to concrete files (directories are
+    filtered out). Empty list when nothing matches; caller decides
+    whether that's an error.
+
+    Two conveniences over raw ``Path.glob``:
+    1. Leading ``/`` on the glob is stripped (project-root-rooted).
+    2. A trailing ``**`` is treated as recursive-files: e.g.
+       ``tests/integration/**`` is rewritten to expand both that
+       directory's plain ``Path.glob`` result and ``**/*`` so that files
+       at any depth are included. This matches the shell-style
+       intuition most callers have when writing globs in process.md.
+    """
+    g = glob.lstrip("/")
+    out: set[Path] = set(project_root.glob(g))
+    # Recursive-file behaviour for trailing ** (and the bare '**' case).
+    if g.endswith("**"):
+        out.update(project_root.glob(g + "/*"))
+        out.update(project_root.glob(g[:-2] + "**/*"))
+    return sorted(p for p in out if p.is_file())
+
+
+def _glob_substring_keys(glob: str) -> list[str]:
+    """Decompose a glob into substring keys used to spot-check whether
+    a source file references it. Two keys are produced:
+    1. The literal glob (less wildcards/braces) — covers the case where
+       the source builds the path with a template like
+       ``f'assets/level_{i:02d}.json'`` (the prefix ``assets/level_``
+       still appears verbatim).
+    2. The full literal — when the consumer hard-codes the glob string.
+    Returns at least one key (the prefix before the first wildcard char).
+    """
+    out: list[str] = []
+    # Stripped form: cut at the first wildcard so we keep the static
+    # prefix. e.g. 'assets/level_*.json' → 'assets/level_'.
+    cut = glob
+    for ch in ("*", "?", "[", "{"):
+        idx = cut.find(ch)
+        if idx >= 0:
+            cut = cut[:idx]
+    cut = cut.rstrip("/")
+    if cut:
+        out.append(cut)
+    if glob and glob not in out:
+        out.append(glob)
+    return out or [glob]
+
+
+@register("data_dependency_wiring_static")
+def _data_dependency_wiring_static(arg: Any, ctx: PredicateContext) -> PredicateResult:
+    """Verify each entry in data_dependency_contract.data_dependencies has
+    its consumer_module file referencing the declared files_glob.
+
+    Pass conditions per entry:
+    - the consumer_module glob resolves to ≥1 file in src/, AND
+    - at least one of those files contains a substring matching either
+      the static prefix of files_glob (e.g. ``assets/level_``) or the
+      literal glob itself, OR the name of any concrete file the
+      files_glob expands to.
+
+    Vacuous-pass (skipped=True) when the contract is absent or has zero
+    entries — projects that don't declare data dependencies are not
+    required to wire them. ``arg`` is currently unused (reserved for
+    future per-call overrides like ``min_files``).
+    """
+    del arg  # reserved
+    contract = ctx.data_dependency_contract
+    if not contract or not isinstance(contract, dict):
+        return PredicateResult(
+            "data_dependency_wiring_static",
+            True,
+            "no data_dependency_contract loaded; skipping",
+            skipped=True,
+        )
+    deps = contract.get("data_dependencies") or []
+    if not deps:
+        return PredicateResult(
+            "data_dependency_wiring_static",
+            True,
+            "data_dependency_contract has zero entries; skipping",
+            skipped=True,
+        )
+    violations: list[str] = []
+    for dep in deps:
+        if not isinstance(dep, dict):
+            continue
+        name = dep.get("name") or "?"
+        files_glob = dep.get("files_glob") or ""
+        consumer_module = dep.get("consumer_module") or ""
+        if not files_glob or not consumer_module:
+            violations.append(f"{name}: missing files_glob or consumer_module")
+            continue
+        consumers = _expand_glob(ctx.project_root, consumer_module)
+        if not consumers:
+            violations.append(f"{name}: consumer_module {consumer_module!r} matched no files")
+            continue
+        # Build the candidate substrings the source must contain at
+        # least one of.
+        keys = list(_glob_substring_keys(files_glob))
+        # Also accept any concrete file the glob expands to (basename
+        # without leading directories is still a useful signal).
+        for f in _expand_glob(ctx.project_root, files_glob):
+            try:
+                rel = str(f.relative_to(ctx.project_root))
+            except ValueError:
+                rel = str(f)
+            keys.append(rel)
+            keys.append(f.name)
+        keys = list(dict.fromkeys(keys))  # de-dup, preserve order
+        found = False
+        for c in consumers:
+            try:
+                body = c.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            if any(k and k in body for k in keys):
+                found = True
+                break
+        if not found:
+            violations.append(
+                f"{name}: consumer {consumer_module!r} contains no reference to "
+                f"files_glob {files_glob!r} (tried keys: {keys[:3]})"
+            )
+    if violations:
+        return PredicateResult(
+            "data_dependency_wiring_static",
+            False,
+            "data dependency wiring gaps: " + "; ".join(violations),
+        )
+    return PredicateResult(
+        "data_dependency_wiring_static",
+        True,
+        f"all {len(deps)} data dependencies wired in source",
+    )
+
+
+@register("action_contract_wiring_static")
+def _action_contract_wiring_static(arg: Any, ctx: PredicateContext) -> PredicateResult:
+    """Verify each action's handler invokes every symbol in handler_must_call.
+
+    Pass conditions per action:
+    - handler file (action.handler_module if set, else stack_contract.entry_point)
+      exists, AND
+    - every symbol in action.handler_must_call appears as a call site
+      (regex ``\\bsymbol\\s*\\(`` — also allows dotted forms like
+      ``combat.calculateBattle`` which match as method calls).
+
+    Actions without handler_must_call entries are not graded by the
+    static gate (they may still be graded by the runtime probe).
+
+    Vacuous-pass when the contract is absent or empty.
+    """
+    del arg
+    contract = ctx.action_contract
+    if not contract or not isinstance(contract, dict):
+        return PredicateResult(
+            "action_contract_wiring_static",
+            True,
+            "no action_contract loaded; skipping",
+            skipped=True,
+        )
+    actions = contract.get("actions") or []
+    if not actions:
+        return PredicateResult(
+            "action_contract_wiring_static",
+            True,
+            "action_contract has zero entries; skipping",
+            skipped=True,
+        )
+
+    default_handler = (ctx.stack_contract or {}).get("entry_point") or ""
+    violations: list[str] = []
+    graded = 0
+    for action in actions:
+        if not isinstance(action, dict):
+            continue
+        name = action.get("name") or "?"
+        must_call = action.get("handler_must_call") or []
+        if not must_call:
+            continue  # not graded by static gate
+        graded += 1
+        handler_rel = action.get("handler_module") or default_handler
+        if not handler_rel:
+            violations.append(f"{name}: no handler_module and no entry_point declared")
+            continue
+        handler_path = ctx.project_root / handler_rel.lstrip("/")
+        if not handler_path.is_file():
+            violations.append(f"{name}: handler file {handler_rel!r} does not exist")
+            continue
+        try:
+            body = handler_path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            violations.append(f"{name}: read failed for {handler_rel!r}: {exc}")
+            continue
+        missing: list[str] = []
+        for sym in must_call:
+            if not isinstance(sym, str) or not sym:
+                continue
+            # Use the symbol's last token for the call-site check; allow
+            # dotted prefix as match (so 'combat.calculateBattle' matches
+            # 'combat.calculateBattle(' or '.calculateBattle(').
+            tail = sym.rsplit(".", 1)[-1]
+            pattern = rf"\b{re.escape(tail)}\s*\("
+            if not re.search(pattern, body):
+                missing.append(sym)
+        if missing:
+            violations.append(f"{name}: handler {handler_rel!r} missing call sites for {missing}")
+    if violations:
+        return PredicateResult(
+            "action_contract_wiring_static",
+            False,
+            "action wiring gaps: " + "; ".join(violations),
+        )
+    if graded == 0:
+        return PredicateResult(
+            "action_contract_wiring_static",
+            True,
+            "no actions declared handler_must_call; skipping",
+            skipped=True,
+        )
+    return PredicateResult(
+        "action_contract_wiring_static",
+        True,
+        f"all {graded} graded actions have wired handlers",
+    )
+
+
+@register("lint_integration_test_imports")
+def _lint_integration_test_imports(arg: Any, ctx: PredicateContext) -> PredicateResult:
+    """Lint-only warning: scan each declared integration-test glob; report
+    files with zero references to project source. Always returns
+    skipped=True (gate-passed regardless) — the goal is to surface a
+    warning in the AUTO_GATE log, not block the phase. The hard gate
+    against fake integration tests is the main_entry assembly check;
+    this lint is a redundant signal in case the assembly check
+    is itself bypassed.
+
+    ``arg`` is ``{"globs": ["tests/integration/**", ...], "source_globs": ["src/**"]}``.
+    Both lists are required. ``source_globs`` is used to compute the set
+    of expected source-prefix substrings.
+    """
+    if not isinstance(arg, dict) or "globs" not in arg or "source_globs" not in arg:
+        # The lint silently passes on misconfiguration — failing here would
+        # block the gate, defeating the lint-only contract.
+        return PredicateResult(
+            "lint_integration_test_imports",
+            True,
+            "no globs configured; skipping",
+            skipped=True,
+        )
+    test_globs = arg["globs"]
+    source_globs = arg["source_globs"]
+    if not isinstance(test_globs, list) or not isinstance(source_globs, list):
+        return PredicateResult(
+            "lint_integration_test_imports",
+            True,
+            "globs must be lists; skipping",
+            skipped=True,
+        )
+    # Source-prefix tokens the test file should contain at least one of.
+    prefix_tokens: list[str] = []
+    for sg in source_globs:
+        if not isinstance(sg, str):
+            continue
+        cut = sg.split("*", 1)[0].rstrip("/")
+        if cut:
+            prefix_tokens.append(cut)
+    prefix_tokens = list(dict.fromkeys(prefix_tokens))
+    test_files: list[Path] = []
+    for tg in test_globs:
+        if not isinstance(tg, str):
+            continue
+        test_files.extend(_expand_glob(ctx.project_root, tg))
+    if not test_files:
+        return PredicateResult(
+            "lint_integration_test_imports",
+            True,
+            "no integration test files found; skipping",
+            skipped=True,
+        )
+    suspect: list[str] = []
+    for tf in test_files:
+        try:
+            body = tf.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if not any(tok in body for tok in prefix_tokens):
+            try:
+                rel = str(tf.relative_to(ctx.project_root))
+            except ValueError:
+                rel = str(tf)
+            suspect.append(rel)
+    detail = (
+        f"checked {len(test_files)} integration test files; {len(suspect)} "
+        f"contain no reference to source globs {prefix_tokens}"
+    )
+    if suspect:
+        # We want this surfaced — appending to detail. Still gate-passed.
+        detail += f"\n  suspect (no source refs): {suspect[:5]}"
+        if len(suspect) > 5:
+            detail += f" (+{len(suspect) - 5} more)"
+    return PredicateResult(
+        "lint_integration_test_imports",
+        True,
+        detail,
+        skipped=True,
+    )
 
 
 # -- Top-level evaluation -------------------------------------------------

--- a/src/aise/runtime/stack_profiles.py
+++ b/src/aise/runtime/stack_profiles.py
@@ -1,0 +1,281 @@
+"""Stack profile registry — language/framework-agnostic abstraction for
+the integration probe.
+
+Each profile declares:
+
+* ``matches`` — heuristics for auto-detecting the profile from a project
+  root (presence of marker files like ``package.json`` + ``vite.config.*``)
+* ``runtime_kind`` — ``cli`` | ``server`` | ``web`` | ``library``
+* ``boot_cmd`` — command template for spawning the runtime, with
+  placeholders ``{entry_point}``, ``{port}`` substituted at probe time
+* ``observe`` — how to capture an observable signal (stdio_capture,
+  http_get, screenshot_via_browser)
+* ``primary_trigger`` — how to fire the architect-declared action's
+  ``trigger.kind`` (only the cli + server runtimes have a real
+  implementation today; ``web`` is a stub that returns ``skipped``)
+
+The profiles are pure data — no executable code lives here. The probe
+runner (``integration_probe.py``) consumes a profile and emits an
+``integration_report.json`` fragment.
+
+Detection precedence:
+1. Explicit ``stack_contract.profile`` field (architect override)
+2. Best-fit auto-detection over all registered profiles
+3. ``unknown`` profile fallback (probe writes verdict=skipped)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# -- Profile dataclass ----------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StackProfile:
+    """Single source of truth for one (language, runtime_kind) profile.
+
+    All command/template strings allow the placeholders:
+      - ``{entry_point}`` — stack_contract.entry_point
+      - ``{run_command}`` — stack_contract.run_command (preferred when set)
+      - ``{port}`` — runtime-allocated free port for the probe
+
+    The probe runner does literal ``str.format`` substitution; missing
+    placeholders raise KeyError with a descriptive message rather than
+    silently producing a malformed command.
+    """
+
+    name: str
+    runtime_kind: str  # cli | server | web | library | unknown
+    detect_required_files: tuple[str, ...] = ()
+    detect_optional_indicators: tuple[str, ...] = ()
+    detect_languages: tuple[str, ...] = ()
+    boot_cmd: tuple[str, ...] = ()
+    observe: str = "none"  # stdio_capture | http_get | screenshot | none
+    observe_arg: str = ""  # e.g. URL path for http_get
+    boot_timeout_s: int = 10
+    primary_trigger: dict[str, Any] = field(default_factory=dict)
+    invariant_emitter: dict[str, str] = field(default_factory=dict)
+    notes: str = ""
+
+    def detection_score(self, project_root: Path, language: str | None) -> int:
+        """Return an integer score; higher = better fit. Zero means the
+        profile cannot apply. The runner picks the highest-scoring
+        profile across the registry; ties broken by registration order.
+        """
+        score = 0
+        for req in self.detect_required_files:
+            if not (project_root / req).is_file():
+                return 0  # required file absent → disqualified
+            score += 5
+        for opt in self.detect_optional_indicators:
+            # Optional indicators may include glob wildcards.
+            if any(project_root.glob(opt)):
+                score += 2
+        if language and self.detect_languages:
+            if language.lower() in tuple(s.lower() for s in self.detect_languages):
+                score += 3
+        return score
+
+
+# -- Registry -------------------------------------------------------------
+
+
+_PROFILES: list[StackProfile] = []
+
+
+def register_profile(profile: StackProfile) -> StackProfile:
+    """Register a profile. Idempotent on re-registration of the same name."""
+    for i, existing in enumerate(_PROFILES):
+        if existing.name == profile.name:
+            _PROFILES[i] = profile
+            return profile
+    _PROFILES.append(profile)
+    return profile
+
+
+def all_profiles() -> tuple[StackProfile, ...]:
+    return tuple(_PROFILES)
+
+
+def profile_by_name(name: str) -> StackProfile | None:
+    for p in _PROFILES:
+        if p.name == name:
+            return p
+    return None
+
+
+# -- Built-in profiles ----------------------------------------------------
+
+
+# Web TS / Vite. Real boot would need a headless browser; we declare the
+# command but mark observe=screenshot so the probe runner knows to
+# delegate to a browser harness (currently a stub returning skipped).
+_WEB_TYPESCRIPT = StackProfile(
+    name="web_typescript",
+    runtime_kind="web",
+    detect_required_files=("package.json",),
+    detect_optional_indicators=(
+        "tsconfig.json",
+        "vite.config.*",
+        "vitest.config.*",
+        "webpack.config.*",
+    ),
+    detect_languages=("typescript", "javascript"),
+    boot_cmd=("npx", "vite", "preview", "--port", "{port}"),
+    observe="screenshot",
+    observe_arg="http://127.0.0.1:{port}/",
+    boot_timeout_s=15,
+    primary_trigger={
+        "key": "key_press",  # browser-key-press emit
+        "click": "browser_click",
+    },
+    invariant_emitter={
+        "collection_non_empty": ("if (!({expr} && {expr}.length > 0)) throw new Error('data invariant: {name}');"),
+        "map_size_at_least": (
+            "if (Object.keys({expr} || {{}}).length < {min}) throw new Error('data invariant: {name}');"
+        ),
+        "string_non_empty": "if (!{expr}) throw new Error('data invariant: {name}');",
+    },
+    notes=(
+        "Real web boot probe requires a headless browser. The probe runner "
+        "currently writes verdict=skipped for runtime_kind=web; static gates "
+        "(data_dependency_wiring_static, action_contract_wiring_static) still "
+        "enforce assembly correctness."
+    ),
+)
+
+
+# Generic CLI. Works for python (`python -m src.main`), go binary, node CLI,
+# any process that accepts stdin, writes stdout, exits cleanly. Truly
+# language-neutral — driven by stack_contract.run_command.
+_GENERIC_CLI = StackProfile(
+    name="cli",
+    runtime_kind="cli",
+    detect_required_files=(),
+    detect_optional_indicators=(
+        "pyproject.toml",
+        "go.mod",
+        "Cargo.toml",
+        "src/main.py",
+        "src/main.go",
+        "src/main.rs",
+    ),
+    detect_languages=("python", "go", "rust", "node", "javascript"),
+    boot_cmd=("sh", "-c", "{run_command}"),
+    observe="stdio_capture",
+    observe_arg="",
+    boot_timeout_s=10,
+    primary_trigger={
+        "stdin": "stdin_write",
+        "key": "stdin_write",  # CLIs treat key→stdin
+    },
+    invariant_emitter={
+        # Language-specific generators are emitted by the stack profile
+        # only when the architect requests runtime invariants; the static
+        # gates do not need them. Strings here are pseudo-code that the
+        # developer prompt expands into the host language.
+        "collection_non_empty": "assert len({expr}) > 0, 'data invariant: {name}'",
+        "map_size_at_least": "assert len({expr}) >= {min}, 'data invariant: {name}'",
+        "string_non_empty": "assert {expr}, 'data invariant: {name}'",
+    },
+    notes="Generic CLI probe: spawn run_command, capture stdout, optional stdin trigger.",
+)
+
+
+# Generic HTTP server. Probe spawns the run_command, polls a known
+# endpoint until it responds 2xx (or boot_timeout_s), then optionally
+# fires primary_trigger as an HTTP request and re-observes.
+_GENERIC_SERVER = StackProfile(
+    name="server",
+    runtime_kind="server",
+    detect_required_files=(),
+    detect_optional_indicators=(
+        "fastapi.toml",
+        "src/main.py",
+        "main.go",
+        "src/server.ts",
+        "src/server.js",
+    ),
+    detect_languages=("python", "go", "node", "javascript", "typescript"),
+    boot_cmd=("sh", "-c", "{run_command}"),
+    observe="http_get",
+    observe_arg="http://127.0.0.1:{port}/",
+    boot_timeout_s=15,
+    primary_trigger={
+        "http": "http_request",
+    },
+    invariant_emitter={
+        "collection_non_empty": "assert len({expr}) > 0, 'data invariant: {name}'",
+        "map_size_at_least": "assert len({expr}) >= {min}, 'data invariant: {name}'",
+        "string_non_empty": "assert {expr}, 'data invariant: {name}'",
+    },
+    notes="Generic server probe: spawn run_command, http_get the root, parse status.",
+)
+
+
+_UNKNOWN = StackProfile(
+    name="unknown",
+    runtime_kind="unknown",
+    detect_required_files=(),
+    detect_optional_indicators=(),
+    detect_languages=(),
+    boot_cmd=(),
+    observe="none",
+    boot_timeout_s=0,
+    primary_trigger={},
+    invariant_emitter={},
+    notes=(
+        "Fallback profile when no other profile matches. The probe runner "
+        "writes integration_report.boot_check.verdict='skipped' with "
+        "reason='no_matching_profile'. Static gates still enforce assembly."
+    ),
+)
+
+
+# Register in priority order. ``select_profile`` picks the highest-scoring
+# match; ``_UNKNOWN`` always scores 0 so it only wins when no other does.
+register_profile(_WEB_TYPESCRIPT)
+register_profile(_GENERIC_CLI)
+register_profile(_GENERIC_SERVER)
+register_profile(_UNKNOWN)
+
+
+# -- Selection -----------------------------------------------------------
+
+
+def select_profile(
+    project_root: Path,
+    stack_contract: dict[str, Any] | None,
+) -> StackProfile:
+    """Pick the best-fitting profile.
+
+    Selection rules:
+    1. ``stack_contract.profile`` (string field) — exact-match override.
+    2. Highest-scoring built-in via ``StackProfile.detection_score``.
+    3. ``unknown`` profile when nothing scores > 0.
+
+    The unknown profile is functionally a no-op; the integration probe
+    short-circuits to ``verdict=skipped`` for it.
+    """
+    sc = stack_contract or {}
+    explicit = sc.get("profile")
+    if isinstance(explicit, str) and explicit:
+        named = profile_by_name(explicit)
+        if named is not None:
+            return named
+    language = sc.get("language") if isinstance(sc.get("language"), str) else None
+    best: tuple[int, StackProfile] | None = None
+    for p in _PROFILES:
+        if p.name == "unknown":
+            continue
+        score = p.detection_score(project_root, language)
+        if score <= 0:
+            continue
+        if best is None or score > best[0]:
+            best = (score, p)
+    if best is not None:
+        return best[1]
+    return profile_by_name("unknown") or _UNKNOWN

--- a/src/aise/schemas/action_contract.schema.json
+++ b/src/aise/schemas/action_contract.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "action_contract",
+  "title": "Action contract (architect output, phase 2)",
+  "description": "Declares the user/external-trigger actions whose handlers MUST be wired to non-trivial behaviour. Drives the main_entry phase's action_contract_wiring_static AUTO_GATE — for each action's handler_must_call entries the gate verifies that the symbol appears as a call site in the entry_point (or in the action's handler_module). Modeled as additive: projects without this file behave exactly as before.",
+  "type": "object",
+  "required": ["actions"],
+  "properties": {
+    "version": { "type": "string" },
+    "actions": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/action" }
+    }
+  },
+  "additionalProperties": true,
+
+  "definitions": {
+    "action": {
+      "type": "object",
+      "required": ["name", "trigger", "expected_change"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable id (e.g. 'primary_attack', 'open_dialogue')."
+        },
+        "trigger": {
+          "$ref": "#/definitions/trigger"
+        },
+        "expected_change": {
+          "$ref": "#/definitions/expected_change"
+        },
+        "handler_module": {
+          "type": "string",
+          "description": "Optional override. When omitted, the static gate searches in stack_contract.entry_point. Use this when the action handler lives in a non-main file (e.g. controller / dispatcher)."
+        },
+        "handler_must_call": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Symbols (function or method names; dotted form like 'combat.calculateBattle' is allowed) that MUST appear as a call site in the handler. Static gate uses regex '<symbol>\\s*\\('. Use this to forbid handler-binds-to-empty-stub assemblies."
+        }
+      },
+      "additionalProperties": true
+    },
+    "trigger": {
+      "type": "object",
+      "required": ["kind"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "key",
+            "click",
+            "interact_npc",
+            "stdin",
+            "http",
+            "timer",
+            "lifecycle"
+          ]
+        },
+        "value": { "type": "string" },
+        "selector": { "type": "string" }
+      },
+      "additionalProperties": true,
+      "description": "How the action is initiated. The stack profile's action_probes table maps each trigger.kind to a concrete probe in the runtime harness (puppeteer key press, stdin write, http request)."
+    },
+    "expected_change": {
+      "type": "object",
+      "required": ["kind"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "state_field_changes",
+            "ui_node_appears",
+            "ui_node_disappears",
+            "stdout_contains",
+            "http_status",
+            "any_observable_change"
+          ]
+        },
+        "field": { "type": "string" },
+        "selector": { "type": "string" },
+        "expected": {}
+      },
+      "additionalProperties": true,
+      "description": "What must observably differ before vs. after the trigger. The runtime probe captures both snapshots and diffs them; the static gate does not enforce expected_change (it only verifies handler symbols exist)."
+    }
+  }
+}

--- a/src/aise/schemas/data_dependency_contract.schema.json
+++ b/src/aise/schemas/data_dependency_contract.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "data_dependency_contract",
+  "title": "Data dependency contract (architect output, phase 2)",
+  "description": "Declares which data files (assets, fixtures, config bundles) MUST be consumed by which source modules at runtime. Drives the main_entry phase's data_dependency_wiring_static AUTO_GATE — when a contract entry's consumer_module file does not contain any reference to the declared files_glob, the gate fails. Modeled as additive: projects without this file behave exactly as before (the predicates vacuous-pass).",
+  "type": "object",
+  "required": ["data_dependencies"],
+  "properties": {
+    "version": { "type": "string" },
+    "data_dependencies": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/data_dependency" }
+    }
+  },
+  "additionalProperties": true,
+
+  "definitions": {
+    "data_dependency": {
+      "type": "object",
+      "required": ["name", "files_glob", "consumer_module"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable id used by reports & cross-references."
+        },
+        "files_glob": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Glob (project-relative) for the data files. Examples: 'assets/level_*.json', 'config/i18n.json', 'data/world.bin'. The static gate accepts any source-file substring match of either the literal glob (with the wildcard part trimmed) or any concrete file the glob expands to."
+        },
+        "consumer_module": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Project-relative glob for the source file(s) that MUST consume the data. Examples: 'src/level/loader.*', 'src/i18n/**/*.ts'. Predicate fails if no matching file references files_glob."
+        },
+        "min_files": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Optional: minimum number of files matching files_glob expected on disk. Used by the runtime probe; ignored by the pure-static gate."
+        },
+        "load_invariant": {
+          "type": "object",
+          "required": ["kind"],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "collection_non_empty",
+                "map_size_at_least",
+                "string_non_empty"
+              ]
+            },
+            "expr": { "type": "string" },
+            "min": { "type": "integer", "minimum": 0 },
+            "after": { "type": "string" }
+          },
+          "additionalProperties": true,
+          "description": "Optional runtime-side invariant for the boot probe. The stack profile's invariant_emitter translates this into the host language."
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/src/aise/schemas/integration_report.schema.json
+++ b/src/aise/schemas/integration_report.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "integration_report",
+  "title": "Integration report (developer output, phase 4 / main_entry)",
+  "description": "Structural report written by the developer at the end of the main_entry phase to attest that the assembly is wired (lifecycle inits reached, data dependencies referenced, action handlers non-trivial). The hard gates are independent predicates re-executing the static checks; this report is the developer's self-disclosure for the delivery report's audit trail. Phase 6 (delivery) reads this verbatim.",
+  "type": "object",
+  "required": ["phase", "verdict"],
+  "properties": {
+    "phase": {
+      "type": "string",
+      "const": "main_entry"
+    },
+    "completed_at": { "type": "string" },
+    "verdict": {
+      "type": "string",
+      "enum": ["pass", "fail", "skipped"]
+    },
+    "lifecycle_init_check": {
+      "type": "object",
+      "properties": {
+        "expected": { "type": "integer", "minimum": 0 },
+        "reached": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": true
+    },
+    "data_wiring_check": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "static_refs"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "static_refs": { "type": "integer", "minimum": 0 },
+          "consumer_module_resolved": { "type": "string" },
+          "runtime_invariant_ok": { "type": "boolean" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "action_wiring_check": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "handler_calls_found"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "handler_calls_found": { "type": "integer", "minimum": 0 },
+          "handler_calls_missing": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "state_changed": { "type": "boolean" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "boot_check": {
+      "type": "object",
+      "properties": {
+        "ran": { "type": "boolean" },
+        "verdict": {
+          "type": "string",
+          "enum": ["pass", "fail", "skipped"]
+        },
+        "exit_code": { "type": "integer" },
+        "duration_s": { "type": "number" },
+        "reason": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "violations": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "additionalProperties": true
+}

--- a/tests/test_runtime/test_action_contract.py
+++ b/tests/test_runtime/test_action_contract.py
@@ -1,0 +1,260 @@
+"""Tests for ``action_contract_wiring_static`` predicate and the
+action_contract.schema.json validation.
+
+Regression: princess_tower TS run had ``input.onAttack(() => { ...
+gameRef._currentScreen = 'battle'; })`` — never called
+``combat.calculateBattle()``. Action contract should declare
+``handler_must_call: ["combat.calculateBattle"]`` and the gate
+must catch the missing call site.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aise.runtime.predicates import (
+    PredicateContext,
+    evaluate_predicate,
+)
+from aise.runtime.waterfall_v2_models import AcceptancePredicate
+
+
+def _ctx(tmp_path: Path, **kwargs) -> PredicateContext:
+    return PredicateContext(
+        project_root=tmp_path,
+        deliverable_path=tmp_path / "src" / "main.ts",  # entry_point file as the deliverable
+        **kwargs,
+    )
+
+
+def _pred(kind: str, arg=None) -> AcceptancePredicate:
+    return AcceptancePredicate(kind=kind, arg=arg)
+
+
+# -- Schema --------------------------------------------------------------
+
+
+class TestSchema:
+    def test_valid_minimal(self, tmp_path: Path):
+        contract = {
+            "actions": [
+                {
+                    "name": "primary_attack",
+                    "trigger": {"kind": "key", "value": "Space"},
+                    "expected_change": {
+                        "kind": "state_field_changes",
+                        "field": "currentScreen",
+                    },
+                    "handler_must_call": ["combat.calculateBattle"],
+                }
+            ]
+        }
+        (tmp_path / "action_contract.json").write_text(json.dumps(contract), encoding="utf-8")
+        ctx = PredicateContext(
+            project_root=tmp_path,
+            deliverable_path=tmp_path / "action_contract.json",
+        )
+        r = evaluate_predicate(_pred("schema", "schemas/action_contract.schema.json"), ctx)
+        assert r.passed, r.detail
+
+    def test_invalid_trigger_kind(self, tmp_path: Path):
+        contract = {
+            "actions": [
+                {
+                    "name": "x",
+                    "trigger": {"kind": "telepathy"},
+                    "expected_change": {"kind": "state_field_changes"},
+                }
+            ]
+        }
+        (tmp_path / "action_contract.json").write_text(json.dumps(contract), encoding="utf-8")
+        ctx = PredicateContext(
+            project_root=tmp_path,
+            deliverable_path=tmp_path / "action_contract.json",
+        )
+        r = evaluate_predicate(_pred("schema", "schemas/action_contract.schema.json"), ctx)
+        assert not r.passed and "telepathy" in r.detail
+
+
+# -- action_contract_wiring_static -- pass cases ------------------------
+
+
+class TestPassCases:
+    def test_handler_calls_all_required(self, tmp_path: Path):
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.ts").write_text(
+            """
+            input.onAttack(() => {
+              const result = combat.calculateBattle(player, monster);
+              player.applyBattleResult(result);
+            });
+            """,
+            encoding="utf-8",
+        )
+        contract = {
+            "actions": [
+                {
+                    "name": "primary_attack",
+                    "trigger": {"kind": "key", "value": "Space"},
+                    "expected_change": {"kind": "state_field_changes", "field": "currentScreen"},
+                    "handler_must_call": [
+                        "combat.calculateBattle",
+                        "player.applyBattleResult",
+                    ],
+                }
+            ]
+        }
+        ctx = _ctx(
+            tmp_path,
+            action_contract=contract,
+            stack_contract={"entry_point": "src/main.ts"},
+        )
+        r = evaluate_predicate(_pred("action_contract_wiring_static"), ctx)
+        assert r.passed, r.detail
+
+    def test_dotted_symbol_matches_method_call(self, tmp_path: Path):
+        # Even when the symbol is written 'a.b.c', we accept a call to
+        # the bare last token 'c(' too.
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.ts").write_text("function go() { calculateBattle(p, m); }\n", encoding="utf-8")
+        contract = {
+            "actions": [
+                {
+                    "name": "x",
+                    "trigger": {"kind": "key", "value": "Space"},
+                    "expected_change": {"kind": "any_observable_change"},
+                    "handler_must_call": ["combat.calculateBattle"],
+                }
+            ]
+        }
+        ctx = _ctx(
+            tmp_path,
+            action_contract=contract,
+            stack_contract={"entry_point": "src/main.ts"},
+        )
+        r = evaluate_predicate(_pred("action_contract_wiring_static"), ctx)
+        assert r.passed, r.detail
+
+
+# -- action_contract_wiring_static -- fail cases ------------------------
+
+
+class TestFailCases:
+    def test_regression_handler_calls_zero_required(self, tmp_path: Path):
+        # Princess_tower regression: handler only changes state field,
+        # never calls combat.calculateBattle.
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.ts").write_text(
+            """
+            input.onAttack(() => {
+              if (this._currentScreen === 'playing') {
+                this._currentScreen = 'battle';   // wired to nothing
+              }
+            });
+            """,
+            encoding="utf-8",
+        )
+        contract = {
+            "actions": [
+                {
+                    "name": "primary_attack",
+                    "trigger": {"kind": "key", "value": "Space"},
+                    "expected_change": {"kind": "state_field_changes"},
+                    "handler_must_call": [
+                        "combat.calculateBattle",
+                        "player.applyBattleResult",
+                    ],
+                }
+            ]
+        }
+        ctx = _ctx(
+            tmp_path,
+            action_contract=contract,
+            stack_contract={"entry_point": "src/main.ts"},
+        )
+        r = evaluate_predicate(_pred("action_contract_wiring_static"), ctx)
+        assert not r.passed
+        assert "primary_attack" in r.detail
+        assert "missing call sites" in r.detail
+        # Both missing symbols must be named in the failure detail.
+        assert "combat.calculateBattle" in r.detail
+        assert "player.applyBattleResult" in r.detail
+
+    def test_handler_module_override(self, tmp_path: Path):
+        # When action.handler_module is set, the gate uses it instead of
+        # stack_contract.entry_point.
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.ts").write_text("// nothing\n", encoding="utf-8")
+        (tmp_path / "src" / "controllers").mkdir()
+        (tmp_path / "src" / "controllers" / "input.ts").write_text(
+            "function onAttack() { combat.calculateBattle(p, m); }\n",
+            encoding="utf-8",
+        )
+        contract = {
+            "actions": [
+                {
+                    "name": "primary_attack",
+                    "trigger": {"kind": "key", "value": "Space"},
+                    "expected_change": {"kind": "state_field_changes"},
+                    "handler_module": "src/controllers/input.ts",
+                    "handler_must_call": ["combat.calculateBattle"],
+                }
+            ]
+        }
+        ctx = _ctx(
+            tmp_path,
+            action_contract=contract,
+            stack_contract={"entry_point": "src/main.ts"},
+        )
+        r = evaluate_predicate(_pred("action_contract_wiring_static"), ctx)
+        assert r.passed, r.detail
+
+    def test_handler_module_missing_file_fails(self, tmp_path: Path):
+        contract = {
+            "actions": [
+                {
+                    "name": "x",
+                    "trigger": {"kind": "key"},
+                    "expected_change": {"kind": "any_observable_change"},
+                    "handler_module": "src/missing.ts",
+                    "handler_must_call": ["foo"],
+                }
+            ]
+        }
+        ctx = _ctx(
+            tmp_path,
+            action_contract=contract,
+            stack_contract={"entry_point": "src/main.ts"},
+        )
+        r = evaluate_predicate(_pred("action_contract_wiring_static"), ctx)
+        assert not r.passed and "does not exist" in r.detail
+
+
+# -- action_contract_wiring_static -- vacuous pass ----------------------
+
+
+class TestVacuousPass:
+    def test_no_contract_loaded_skipped(self, tmp_path: Path):
+        ctx = _ctx(tmp_path)
+        r = evaluate_predicate(_pred("action_contract_wiring_static"), ctx)
+        assert r.passed and r.skipped
+
+    def test_actions_without_handler_must_call_skipped(self, tmp_path: Path):
+        contract = {
+            "actions": [
+                {
+                    "name": "x",
+                    "trigger": {"kind": "key"},
+                    "expected_change": {"kind": "any_observable_change"},
+                }
+            ]
+        }
+        ctx = _ctx(
+            tmp_path,
+            action_contract=contract,
+            stack_contract={"entry_point": "src/main.ts"},
+        )
+        r = evaluate_predicate(_pred("action_contract_wiring_static"), ctx)
+        # No graded actions → skipped.
+        assert r.passed and r.skipped

--- a/tests/test_runtime/test_data_dependency_contract.py
+++ b/tests/test_runtime/test_data_dependency_contract.py
@@ -1,0 +1,209 @@
+"""Tests for ``data_dependency_wiring_static`` predicate and the
+data_dependency_contract.schema.json validation.
+
+These cover the regression case from the princess_tower TS run on
+2026-05-06: ``assets/floor_*.json`` was declared by the architect but
+no source file under ``src/`` referenced it — the gate must catch
+this.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aise.runtime.predicates import (
+    PredicateContext,
+    evaluate_predicate,
+)
+from aise.runtime.waterfall_v2_models import AcceptancePredicate
+
+
+def _ctx(tmp_path: Path, **kwargs) -> PredicateContext:
+    return PredicateContext(
+        project_root=tmp_path,
+        deliverable_path=tmp_path / "docs" / "data_dependency_contract.json",
+        **kwargs,
+    )
+
+
+def _pred(kind: str, arg=None) -> AcceptancePredicate:
+    return AcceptancePredicate(kind=kind, arg=arg)
+
+
+# -- Schema ---------------------------------------------------------------
+
+
+class TestSchema:
+    def test_valid_minimal(self, tmp_path: Path):
+        contract = {
+            "version": "1",
+            "data_dependencies": [
+                {
+                    "name": "level_data",
+                    "files_glob": "assets/level_*.json",
+                    "consumer_module": "src/level/loader.py",
+                }
+            ],
+        }
+        (tmp_path / "data_dependency_contract.json").write_text(json.dumps(contract), encoding="utf-8")
+        ctx = PredicateContext(
+            project_root=tmp_path,
+            deliverable_path=tmp_path / "data_dependency_contract.json",
+        )
+        r = evaluate_predicate(_pred("schema", "schemas/data_dependency_contract.schema.json"), ctx)
+        assert r.passed, r.detail
+
+    def test_missing_required_consumer_module(self, tmp_path: Path):
+        contract = {"data_dependencies": [{"name": "x", "files_glob": "a/*"}]}  # no consumer_module
+        (tmp_path / "data_dependency_contract.json").write_text(json.dumps(contract), encoding="utf-8")
+        ctx = PredicateContext(
+            project_root=tmp_path,
+            deliverable_path=tmp_path / "data_dependency_contract.json",
+        )
+        r = evaluate_predicate(_pred("schema", "schemas/data_dependency_contract.schema.json"), ctx)
+        assert not r.passed and "consumer_module" in r.detail
+
+    def test_optional_skipped_when_absent(self, tmp_path: Path):
+        # When the file isn't present, ``schema_optional`` vacuous-passes.
+        ctx = PredicateContext(
+            project_root=tmp_path,
+            deliverable_path=tmp_path / "data_dependency_contract.json",
+        )
+        r = evaluate_predicate(
+            _pred("schema_optional", "schemas/data_dependency_contract.schema.json"),
+            ctx,
+        )
+        assert r.passed and r.skipped
+
+
+# -- data_dependency_wiring_static ---------------------------------------
+
+
+class TestWiringStaticPasses:
+    def test_consumer_references_glob_prefix(self, tmp_path: Path):
+        # Source file references the glob prefix (typical: dynamic loader
+        # builds path with f-string template like 'assets/level_<i>.json').
+        (tmp_path / "src" / "level").mkdir(parents=True)
+        (tmp_path / "src" / "level" / "loader.py").write_text(
+            "def load(i): return open(f'assets/level_{i:02d}.json')\n",
+            encoding="utf-8",
+        )
+        # Concrete files exist on disk too.
+        (tmp_path / "assets").mkdir()
+        (tmp_path / "assets" / "level_01.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "assets" / "level_02.json").write_text("{}", encoding="utf-8")
+
+        contract = {
+            "data_dependencies": [
+                {
+                    "name": "level_data",
+                    "files_glob": "assets/level_*.json",
+                    "consumer_module": "src/level/loader.py",
+                }
+            ]
+        }
+        ctx = _ctx(tmp_path, data_dependency_contract=contract)
+        r = evaluate_predicate(_pred("data_dependency_wiring_static"), ctx)
+        assert r.passed, r.detail
+
+    def test_concrete_filename_match(self, tmp_path: Path):
+        # Source hard-codes a single concrete file path.
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "i18n.py").write_text(
+            "STRINGS = json.load(open('assets/i18n.json'))\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "assets").mkdir()
+        (tmp_path / "assets" / "i18n.json").write_text("{}", encoding="utf-8")
+
+        contract = {
+            "data_dependencies": [
+                {
+                    "name": "i18n",
+                    "files_glob": "assets/i18n.json",
+                    "consumer_module": "src/i18n.py",
+                }
+            ]
+        }
+        ctx = _ctx(tmp_path, data_dependency_contract=contract)
+        r = evaluate_predicate(_pred("data_dependency_wiring_static"), ctx)
+        assert r.passed, r.detail
+
+
+class TestWiringStaticFails:
+    def test_zero_references_flagged(self, tmp_path: Path):
+        # Regression for princess_tower TS: floor_*.json on disk, but
+        # no source file references it.
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.ts").write_text(
+            "import 'phaser';\nclass Game { boot() {} }\nnew Game().boot();\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "assets").mkdir()
+        for i in range(1, 11):
+            (tmp_path / "assets" / f"floor_{i:02d}.json").write_text("{}", encoding="utf-8")
+
+        contract = {
+            "data_dependencies": [
+                {
+                    "name": "floor_data",
+                    "files_glob": "assets/floor_*.json",
+                    "consumer_module": "src/main.ts",
+                    "min_files": 10,
+                }
+            ]
+        }
+        ctx = _ctx(tmp_path, data_dependency_contract=contract)
+        r = evaluate_predicate(_pred("data_dependency_wiring_static"), ctx)
+        assert not r.passed
+        assert "floor_data" in r.detail
+        assert "no reference" in r.detail
+
+    def test_missing_consumer_module(self, tmp_path: Path):
+        contract = {
+            "data_dependencies": [
+                {
+                    "name": "x",
+                    "files_glob": "data/*.json",
+                    "consumer_module": "src/loader.py",
+                }
+            ]
+        }
+        ctx = _ctx(tmp_path, data_dependency_contract=contract)
+        r = evaluate_predicate(_pred("data_dependency_wiring_static"), ctx)
+        assert not r.passed and "matched no files" in r.detail
+
+
+class TestWiringStaticVacuousPass:
+    def test_no_contract_loaded_skipped(self, tmp_path: Path):
+        ctx = _ctx(tmp_path)  # no data_dependency_contract
+        r = evaluate_predicate(_pred("data_dependency_wiring_static"), ctx)
+        assert r.passed and r.skipped
+
+    def test_empty_array_skipped(self, tmp_path: Path):
+        ctx = _ctx(tmp_path, data_dependency_contract={"data_dependencies": []})
+        r = evaluate_predicate(_pred("data_dependency_wiring_static"), ctx)
+        assert r.passed and r.skipped
+
+    def test_glob_consumer_matches_multiple(self, tmp_path: Path):
+        # Consumer glob matches several files; only one needs to contain
+        # the reference for the gate to pass.
+        (tmp_path / "src" / "level").mkdir(parents=True)
+        (tmp_path / "src" / "level" / "loader_a.py").write_text("# nothing here\n", encoding="utf-8")
+        (tmp_path / "src" / "level" / "loader_b.py").write_text("open('assets/level_01.json')\n", encoding="utf-8")
+        (tmp_path / "assets").mkdir()
+        (tmp_path / "assets" / "level_01.json").write_text("{}", encoding="utf-8")
+
+        contract = {
+            "data_dependencies": [
+                {
+                    "name": "level_data",
+                    "files_glob": "assets/level_*.json",
+                    "consumer_module": "src/level/loader_*.py",
+                }
+            ]
+        }
+        ctx = _ctx(tmp_path, data_dependency_contract=contract)
+        r = evaluate_predicate(_pred("data_dependency_wiring_static"), ctx)
+        assert r.passed, r.detail

--- a/tests/test_runtime/test_integration_probe.py
+++ b/tests/test_runtime/test_integration_probe.py
@@ -1,0 +1,261 @@
+"""Tests for ``integration_probe.run_probe`` end-to-end.
+
+Covers:
+- Static analysis branch with passing data + action contracts
+- Static analysis branch with failing wiring
+- web profile → boot=skipped (no headless browser)
+- cli profile → real subprocess call (uses /bin/echo with run_command)
+- unknown profile → boot=skipped with reason
+- to_integration_report shape validates against the schema
+- main() CLI hook returns exit 1 on verdict=fail
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aise.runtime.integration_probe import (
+    main,
+    run_probe,
+)
+from aise.runtime.predicates import PredicateContext, evaluate_predicate
+from aise.runtime.waterfall_v2_models import AcceptancePredicate
+
+# -- Static-side checks ---------------------------------------------------
+
+
+class TestStaticChecks:
+    def test_pass_when_wired(self, tmp_path: Path):
+        # Source references the data files; entry_point calls handler symbols.
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.py").write_text(
+            """
+def boot():
+    levels = open('assets/level_01.json').read()
+    on_attack()
+
+def on_attack():
+    combat_calculate_battle()
+""",
+            encoding="utf-8",
+        )
+        (tmp_path / "assets").mkdir()
+        (tmp_path / "assets" / "level_01.json").write_text("{}", encoding="utf-8")
+
+        sc = {"entry_point": "src/main.py", "language": "python"}
+        dd = {
+            "data_dependencies": [
+                {
+                    "name": "level_data",
+                    "files_glob": "assets/level_*.json",
+                    "consumer_module": "src/main.py",
+                }
+            ]
+        }
+        ac = {
+            "actions": [
+                {
+                    "name": "primary_attack",
+                    "trigger": {"kind": "key"},
+                    "expected_change": {"kind": "any_observable_change"},
+                    "handler_must_call": ["combat_calculate_battle"],
+                }
+            ]
+        }
+        result = run_probe(
+            tmp_path,
+            stack_contract=sc,
+            data_dependency_contract=dd,
+            action_contract=ac,
+            enable_boot=False,
+        )
+        assert result.verdict == "pass", result.violations
+        assert result.violations == []
+        assert result.data_wiring[0].static_refs >= 1
+        assert result.action_wiring[0].handler_calls_found == 1
+        assert result.action_wiring[0].handler_calls_missing == []
+
+    def test_fail_collects_violations(self, tmp_path: Path):
+        # Source references nothing — both contracts trip violations.
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.py").write_text("def boot(): pass\n", encoding="utf-8")
+        (tmp_path / "assets").mkdir()
+        (tmp_path / "assets" / "level_01.json").write_text("{}", encoding="utf-8")
+
+        sc = {"entry_point": "src/main.py", "language": "python"}
+        dd = {
+            "data_dependencies": [
+                {
+                    "name": "level_data",
+                    "files_glob": "assets/level_*.json",
+                    "consumer_module": "src/main.py",
+                }
+            ]
+        }
+        ac = {
+            "actions": [
+                {
+                    "name": "primary_attack",
+                    "trigger": {"kind": "key"},
+                    "expected_change": {"kind": "any_observable_change"},
+                    "handler_must_call": ["combat_calculate_battle"],
+                }
+            ]
+        }
+        result = run_probe(
+            tmp_path,
+            stack_contract=sc,
+            data_dependency_contract=dd,
+            action_contract=ac,
+            enable_boot=False,
+        )
+        assert result.verdict == "fail"
+        assert any("data_wiring.level_data" in v for v in result.violations)
+        assert any("action_wiring.primary_attack" in v for v in result.violations)
+
+
+# -- Boot-side branches --------------------------------------------------
+
+
+class TestBootBranches:
+    def test_web_profile_skipped(self, tmp_path: Path):
+        (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "tsconfig.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "vite.config.ts").write_text("\n", encoding="utf-8")
+        sc = {"language": "typescript", "entry_point": "src/index.ts"}
+        result = run_probe(
+            tmp_path,
+            stack_contract=sc,
+            enable_boot=True,
+        )
+        # Web profile auto-detected; boot returns skipped.
+        assert result.profile == "web_typescript"
+        assert result.runtime_kind == "web"
+        assert result.boot.verdict == "skipped"
+        assert "headless browser" in result.boot.reason
+
+    def test_unknown_profile_skipped(self, tmp_path: Path):
+        result = run_probe(tmp_path, stack_contract=None, enable_boot=True)
+        assert result.profile == "unknown"
+        assert result.boot.verdict == "skipped"
+
+    def test_disabled_boot(self, tmp_path: Path):
+        # enable_boot=False short-circuits regardless of profile.
+        (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+        sc = {"language": "typescript"}
+        result = run_probe(tmp_path, stack_contract=sc, enable_boot=False)
+        assert result.boot.verdict == "skipped"
+        assert "disabled by caller" in result.boot.reason
+
+    def test_cli_profile_runs_subprocess(self, tmp_path: Path):
+        # Use ``echo`` as the run_command — exits 0, prints something.
+        # This is the actual cli boot harness path, exercised end-to-end.
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.py").write_text("print('hi')\n", encoding="utf-8")
+        sc = {
+            "language": "python",
+            "entry_point": "src/main.py",
+            "run_command": "echo HELLO_WORLD",
+            "profile": "cli",  # explicit override to avoid web detection
+        }
+        result = run_probe(tmp_path, stack_contract=sc, enable_boot=True)
+        assert result.profile == "cli"
+        # Should pass — echo exits 0 with non-empty stdout.
+        assert result.boot.verdict == "pass", result.boot.reason
+        assert result.boot.exit_code == 0
+
+    def test_cli_profile_failed_command(self, tmp_path: Path):
+        # ``false`` exits 1 — boot verdict must be fail.
+        sc = {
+            "language": "python",
+            "entry_point": "src/main.py",
+            "run_command": "false",
+            "profile": "cli",
+        }
+        result = run_probe(tmp_path, stack_contract=sc, enable_boot=True)
+        assert result.profile == "cli"
+        assert result.boot.verdict == "fail"
+        assert result.boot.exit_code == 1
+
+
+# -- Report shape (validates against schema) ------------------------------
+
+
+class TestReportShape:
+    def test_to_integration_report_matches_schema(self, tmp_path: Path):
+        result = run_probe(tmp_path, stack_contract=None, enable_boot=False)
+        report = result.to_integration_report()
+        out = tmp_path / "integration_report.json"
+        out.write_text(json.dumps(report), encoding="utf-8")
+        ctx = PredicateContext(project_root=tmp_path, deliverable_path=out)
+        r = evaluate_predicate(
+            AcceptancePredicate("schema", "schemas/integration_report.schema.json"),
+            ctx,
+        )
+        assert r.passed, r.detail
+
+
+# -- CLI hook ------------------------------------------------------------
+
+
+class TestCliHook:
+    def test_main_writes_report_and_exits_zero_on_pass(self, tmp_path: Path, capsys):
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "stack_contract.json").write_text(
+            json.dumps({"language": "python", "entry_point": "src/main.py"}),
+            encoding="utf-8",
+        )
+        rc = main([str(tmp_path), "--no-boot"])
+        # Captured stdout should be valid JSON
+        out = capsys.readouterr().out
+        report = json.loads(out)
+        assert report["phase"] == "main_entry"
+        # No contracts → verdict=skipped (still rc=0).
+        assert report["verdict"] == "skipped"
+        assert rc == 0
+        # File on disk too.
+        on_disk = (tmp_path / "docs" / "integration_report.json").read_text("utf-8")
+        assert json.loads(on_disk)["phase"] == "main_entry"
+
+    def test_main_exits_one_on_fail(self, tmp_path: Path, capsys):
+        # Construct a project where action wiring fails → verdict=fail
+        # → main() returns 1.
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.py").write_text("# nothing wired\n", encoding="utf-8")
+        (tmp_path / "docs" / "stack_contract.json").write_text(
+            json.dumps({"language": "python", "entry_point": "src/main.py"}),
+            encoding="utf-8",
+        )
+        (tmp_path / "docs" / "action_contract.json").write_text(
+            json.dumps(
+                {
+                    "actions": [
+                        {
+                            "name": "primary",
+                            "trigger": {"kind": "key"},
+                            "expected_change": {"kind": "any_observable_change"},
+                            "handler_must_call": ["do_thing"],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        rc = main([str(tmp_path), "--no-boot"])
+        capsys.readouterr()
+        assert rc == 1
+
+    def test_main_rejects_missing_arg(self, capsys):
+        rc = main([])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "usage" in err
+
+    def test_main_rejects_non_directory(self, tmp_path: Path):
+        # Pointing at a file should fail fast.
+        f = tmp_path / "not-a-dir"
+        f.write_text("", encoding="utf-8")
+        rc = main([str(f), "--no-boot"])
+        assert rc == 2

--- a/tests/test_runtime/test_lint_integration_test_imports.py
+++ b/tests/test_runtime/test_lint_integration_test_imports.py
@@ -1,0 +1,91 @@
+"""Tests for the lint-only ``lint_integration_test_imports`` predicate.
+
+Predicate is intentionally non-blocking — always returns gate_passed
+(skipped=True) regardless of whether suspect files were found. The
+detail string carries the warning so AUTO_GATE logs surface it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aise.runtime.predicates import (
+    PredicateContext,
+    evaluate_predicate,
+)
+from aise.runtime.waterfall_v2_models import AcceptancePredicate
+
+
+def _ctx(tmp_path: Path) -> PredicateContext:
+    return PredicateContext(
+        project_root=tmp_path,
+        deliverable_path=tmp_path / "docs" / "qa_report.json",
+    )
+
+
+def _pred(arg) -> AcceptancePredicate:
+    return AcceptancePredicate(kind="lint_integration_test_imports", arg=arg)
+
+
+class TestLintIntegrationTestImports:
+    def test_clean_when_tests_reference_source(self, tmp_path: Path):
+        (tmp_path / "tests" / "integration").mkdir(parents=True)
+        (tmp_path / "tests" / "integration" / "happy.ts").write_text(
+            "import { x } from '../../src/core';\nx();\n", encoding="utf-8"
+        )
+        (tmp_path / "src").mkdir()
+        r = evaluate_predicate(
+            _pred({"globs": ["tests/integration/**"], "source_globs": ["src/"]}),
+            _ctx(tmp_path),
+        )
+        assert r.gate_passed and r.skipped
+        assert "0 contain no reference" in r.detail
+
+    def test_warn_surfaces_suspect_file(self, tmp_path: Path):
+        # Princess_tower regression: tests/integration/mainline.test.ts
+        # has zero src/ refs.
+        (tmp_path / "tests" / "integration").mkdir(parents=True)
+        (tmp_path / "tests" / "integration" / "mainline.test.ts").write_text(
+            "let x = 1;\nexpect(x).toBe(1);\n", encoding="utf-8"
+        )
+        (tmp_path / "src").mkdir()
+        r = evaluate_predicate(
+            _pred({"globs": ["tests/integration/**"], "source_globs": ["src/"]}),
+            _ctx(tmp_path),
+        )
+        # Always gate-passed — lint, not a hard gate.
+        assert r.gate_passed and r.skipped
+        # But detail must surface the suspect filename.
+        assert "mainline.test.ts" in r.detail
+        assert "1 contain no reference" in r.detail
+
+    def test_skipped_when_no_test_files(self, tmp_path: Path):
+        r = evaluate_predicate(
+            _pred({"globs": ["tests/integration/**"], "source_globs": ["src/"]}),
+            _ctx(tmp_path),
+        )
+        assert r.gate_passed and r.skipped
+        assert "no integration test files" in r.detail
+
+    def test_invalid_arg_silently_passes(self, tmp_path: Path):
+        # Lint must never block a phase — even on misconfiguration.
+        r = evaluate_predicate(_pred("not-a-dict"), _ctx(tmp_path))
+        assert r.gate_passed and r.skipped
+
+    def test_lib_directory_detected(self, tmp_path: Path):
+        # Flutter / dart layouts use lib/ — the lint accepts a list of
+        # source-prefix globs.
+        (tmp_path / "tests" / "scenarios").mkdir(parents=True)
+        (tmp_path / "tests" / "scenarios" / "boot.dart").write_text("import '../../lib/main.dart';\n", encoding="utf-8")
+        (tmp_path / "lib").mkdir()
+        r = evaluate_predicate(
+            _pred(
+                {
+                    "globs": ["tests/scenarios/**"],
+                    "source_globs": ["src/", "lib/"],
+                }
+            ),
+            _ctx(tmp_path),
+        )
+        assert r.gate_passed and r.skipped
+        assert "0 contain no reference" in r.detail

--- a/tests/test_runtime/test_main_entry_assembly_gate.py
+++ b/tests/test_runtime/test_main_entry_assembly_gate.py
@@ -1,0 +1,331 @@
+"""End-to-end regression for the main_entry assembly gate.
+
+Replays the princess_tower TS run failure mode in miniature:
+
+* architect produces stack_contract.json + data_dependency_contract.json
+  + action_contract.json declaring assets/floor_*.json must be loaded
+  by src/level/loader.py and that primary_attack must invoke
+  combat.calculateBattle.
+* developer (mocked) writes a "broken" main where neither the
+  loader nor the attack handler does the required work.
+* We invoke PhaseExecutor against the main_entry phase and assert
+  the AUTO_GATE rejects (PhaseStatus.FAILED) with the right
+  violations.
+
+Then we replay with a "fixed" main and assert the gate passes.
+
+The test exercises the production process.md (no inline phase spec)
+so any drift between docs/process.md and the predicate registry
+trips the test.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aise.runtime.phase_executor import PhaseExecutor, PhaseStatus
+from aise.runtime.waterfall_v2_loader import (
+    default_waterfall_v2_path,
+    load_waterfall_v2,
+)
+
+# -- Fixtures ------------------------------------------------------------
+
+
+def _seed_contracts(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir(parents=True, exist_ok=True)
+    stack = {
+        "language": "typescript",
+        "framework_backend": "phaser",
+        "package_manager": "npm",
+        "test_runner": "vitest",
+        "entry_point": "src/main.ts",
+        "run_command": "npx vite preview",
+        "ui_required": True,
+        "subsystems": [
+            {
+                "name": "level",
+                "src_dir": "src/level",
+                "components": [{"name": "loader", "file": "src/level/loader.ts"}],
+            }
+        ],
+        "lifecycle_inits": [
+            {
+                "attr": "level",
+                "method": "initialize",
+                "class": "LevelLoader",
+                "module": "src/level/loader.ts",
+            }
+        ],
+    }
+    (docs / "stack_contract.json").write_text(json.dumps(stack), encoding="utf-8")
+
+    data_dep = {
+        "version": "1",
+        "data_dependencies": [
+            {
+                "name": "floor_data",
+                "files_glob": "assets/floor_*.json",
+                "consumer_module": "src/level/loader.ts",
+                "min_files": 10,
+            }
+        ],
+    }
+    (docs / "data_dependency_contract.json").write_text(json.dumps(data_dep), encoding="utf-8")
+
+    action = {
+        "version": "1",
+        "actions": [
+            {
+                "name": "primary_attack",
+                "trigger": {"kind": "key", "value": "Space"},
+                "expected_change": {
+                    "kind": "state_field_changes",
+                    "field": "currentScreen",
+                },
+                "handler_must_call": [
+                    "combat.calculateBattle",
+                    "player.applyBattleResult",
+                ],
+            }
+        ],
+    }
+    (docs / "action_contract.json").write_text(json.dumps(action), encoding="utf-8")
+
+    # 10 floor data files on disk.
+    assets = tmp_path / "assets"
+    assets.mkdir(exist_ok=True)
+    for i in range(1, 11):
+        (assets / f"floor_{i:02d}.json").write_text("{}", encoding="utf-8")
+
+
+def _write_broken_main(tmp_path: Path) -> None:
+    # Mirrors the princess_tower TS regression:
+    # - main.ts has lifecycle init (level.initialize)
+    # - but no reference to assets/floor_*.json (loader is a no-op)
+    # - and onAttack just sets state, never calls combat methods
+    src = tmp_path / "src"
+    (src / "level").mkdir(parents=True, exist_ok=True)
+    (src / "level" / "loader.ts").write_text(
+        "// stub loader\nexport class LevelLoader { initialize() {} }\n",
+        encoding="utf-8",
+    )
+    (src / "main.ts").write_text(
+        """
+import { LevelLoader } from './level/loader';
+class Game {
+  level = new LevelLoader();
+  currentScreen = 'menu';
+  boot() {
+    this.level.initialize();
+    onAttack(() => {
+      this.currentScreen = 'battle';
+    });
+  }
+}
+new Game().boot();
+""",
+        encoding="utf-8",
+    )
+    # integration_report.json with verdict=fail to make AUTO_GATE
+    # reject regardless (we want the static gates to be the actual
+    # blocker, not the verdict field — the broken case must fail on
+    # the predicates above).
+    (tmp_path / "docs" / "integration_report.json").write_text(
+        json.dumps(
+            {
+                "phase": "main_entry",
+                "verdict": "pass",
+                "data_wiring_check": [
+                    {
+                        "name": "floor_data",
+                        "static_refs": 0,
+                    }
+                ],
+                "action_wiring_check": [
+                    {
+                        "name": "primary_attack",
+                        "handler_calls_found": 0,
+                        "handler_calls_missing": [
+                            "combat.calculateBattle",
+                            "player.applyBattleResult",
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_fixed_main(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    (src / "level").mkdir(parents=True, exist_ok=True)
+    (src / "level" / "loader.ts").write_text(
+        """
+export class LevelLoader {
+  levels: any[] = [];
+  initialize() {
+    for (let i = 1; i <= 10; i++) {
+      // Source string contains 'assets/floor_' so the static gate detects
+      // the dependency reference.
+      const path = `assets/floor_${i.toString().padStart(2, '0')}.json`;
+      this.levels.push({ path });
+    }
+  }
+}
+""",
+        encoding="utf-8",
+    )
+    (src / "main.ts").write_text(
+        """
+import { LevelLoader } from './level/loader';
+class Combat { calculateBattle(p, m) { return { won: true }; } }
+class Player { applyBattleResult(r) {} }
+class Game {
+  level = new LevelLoader();
+  combat = new Combat();
+  player = new Player();
+  currentScreen = 'menu';
+  boot() {
+    this.level.initialize();
+    onAttack(() => {
+      const result = this.combat.calculateBattle(null, null);
+      this.player.applyBattleResult(result);
+      this.currentScreen = 'battle';
+    });
+  }
+}
+new Game().boot();
+""",
+        encoding="utf-8",
+    )
+    (tmp_path / "docs" / "integration_report.json").write_text(
+        json.dumps(
+            {
+                "phase": "main_entry",
+                "verdict": "pass",
+                "data_wiring_check": [{"name": "floor_data", "static_refs": 1}],
+                "action_wiring_check": [
+                    {
+                        "name": "primary_attack",
+                        "handler_calls_found": 2,
+                        "handler_calls_missing": [],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _make_executor(tmp_path: Path, produce_fn) -> PhaseExecutor:
+    spec = load_waterfall_v2(default_waterfall_v2_path())
+    return PhaseExecutor(
+        spec=spec,
+        project_root=tmp_path,
+        produce_fn=produce_fn,
+        dispatch_reviewer=lambda role, prompt: "PASS",
+    )
+
+
+# -- Tests ---------------------------------------------------------------
+
+
+class TestRegression:
+    def test_broken_main_entry_fails_auto_gate(self, tmp_path: Path):
+        _seed_contracts(tmp_path)
+
+        # produce_fn writes the broken main on every attempt.
+        def produce(role, prompt, expected):
+            _write_broken_main(tmp_path)
+            return f"produced ({role})"
+
+        executor = _make_executor(tmp_path, produce)
+        spec = executor.spec
+        main_entry = spec.phase_by_id("main_entry")
+        assert main_entry is not None
+        result = executor.execute_phase(main_entry, "Build the magic-tower TS game")
+        assert result.status == PhaseStatus.FAILED
+        # Producer was retried 3× (the AUTO_GATE retry budget).
+        assert result.producer_attempts == 3
+        # The summary names both regressions.
+        summary = result.failure_summary
+        assert "data_dependency_wiring_static" in summary or "floor_data" in summary
+        assert "action_contract_wiring_static" in summary or "primary_attack" in summary
+
+    def test_fixed_main_entry_passes(self, tmp_path: Path):
+        _seed_contracts(tmp_path)
+
+        def produce(role, prompt, expected):
+            _write_fixed_main(tmp_path)
+            return f"produced ({role})"
+
+        executor = _make_executor(tmp_path, produce)
+        spec = executor.spec
+        main_entry = spec.phase_by_id("main_entry")
+        assert main_entry is not None
+        result = executor.execute_phase(main_entry, "Build the magic-tower TS game")
+        # Reviewer mock always PASSes.
+        assert result.status in (
+            PhaseStatus.PASSED,
+            PhaseStatus.PASSED_WITH_UNRESOLVED_REVIEW,
+        ), result.failure_summary
+        assert all(r.passed for r in result.deliverable_reports)
+
+    def test_legacy_project_without_optional_contracts_passes(self, tmp_path: Path):
+        # No data_dependency_contract.json + no action_contract.json on
+        # disk — the new gates must vacuous-pass and the phase executes
+        # the same way as before this commit.
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        stack = {
+            "language": "python",
+            "framework_backend": "none",
+            "package_manager": "pip",
+            "test_runner": "pytest",
+            "entry_point": "src/main.py",
+            "run_command": "python -m src.main",
+            "ui_required": False,
+            "subsystems": [
+                {
+                    "name": "core",
+                    "src_dir": "src/core",
+                    "components": [{"name": "x", "file": "src/core/x.py"}],
+                }
+            ],
+            "lifecycle_inits": [],
+        }
+        (docs / "stack_contract.json").write_text(json.dumps(stack), encoding="utf-8")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.py").write_text("def main(): pass\n", encoding="utf-8")
+
+        # Developer writes the integration_report.json verdict=skipped
+        # (legacy projects with no contracts hit that path naturally).
+        def produce(role, prompt, expected):
+            (docs / "integration_report.json").write_text(
+                json.dumps(
+                    {
+                        "phase": "main_entry",
+                        "verdict": "skipped",
+                        "boot_check": {
+                            "ran": False,
+                            "verdict": "skipped",
+                            "reason": "no contracts to enforce",
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            return "ok"
+
+        executor = _make_executor(tmp_path, produce)
+        main_entry = executor.spec.phase_by_id("main_entry")
+        assert main_entry is not None
+        result = executor.execute_phase(main_entry, "build a small python cli")
+        assert result.status in (
+            PhaseStatus.PASSED,
+            PhaseStatus.PASSED_WITH_UNRESOLVED_REVIEW,
+        ), result.failure_summary

--- a/tests/test_runtime/test_predicates.py
+++ b/tests/test_runtime/test_predicates.py
@@ -31,12 +31,16 @@ class TestRegistry:
             "contains_sections",
             "regex_count",
             "schema",
+            "schema_optional",
             "language_supported",
             "min_scenarios",
             "contains_all_lifecycle_inits",
             "prior_phases_summarized",
             "mermaid_validates_via_skill",
             "language_idiomatic_check",
+            "data_dependency_wiring_static",
+            "action_contract_wiring_static",
+            "lint_integration_test_imports",
         ]:
             assert is_registered(kind), f"{kind} should be registered"
 
@@ -239,6 +243,36 @@ class TestSchemaPredicate:
             _ctx(tmp_path, "stack_contract.json"),
         )
         assert r.passed, r.detail
+
+    def test_schema_optional_passes_when_file_absent(self, tmp_path: Path):
+        # Additive contracts (data_dependency_contract.json, action_contract.json)
+        # use schema_optional so legacy projects that don't declare them
+        # still pass the architecture phase AUTO_GATE.
+        ctx = _ctx(tmp_path, "data_dependency_contract.json")
+        r = evaluate_predicate(
+            _pred("schema_optional", "schemas/data_dependency_contract.schema.json"),
+            ctx,
+        )
+        assert r.passed and r.skipped
+
+    def test_schema_optional_validates_when_file_present(self, tmp_path: Path):
+        # When the file exists, schema_optional behaves identically to schema.
+        good = {"data_dependencies": [{"name": "x", "files_glob": "a/*", "consumer_module": "src/loader.py"}]}
+        (tmp_path / "data_dependency_contract.json").write_text(json.dumps(good), encoding="utf-8")
+        r = evaluate_predicate(
+            _pred("schema_optional", "schemas/data_dependency_contract.schema.json"),
+            _ctx(tmp_path, "data_dependency_contract.json"),
+        )
+        assert r.passed, r.detail
+
+    def test_schema_optional_rejects_invalid_when_present(self, tmp_path: Path):
+        bad = {"data_dependencies": [{"name": "x"}]}  # missing required fields
+        (tmp_path / "data_dependency_contract.json").write_text(json.dumps(bad), encoding="utf-8")
+        r = evaluate_predicate(
+            _pred("schema_optional", "schemas/data_dependency_contract.schema.json"),
+            _ctx(tmp_path, "data_dependency_contract.json"),
+        )
+        assert not r.passed and "files_glob" in r.detail
 
     def test_event_loop_owner_object_still_valid(self, tmp_path: Path):
         # Pygame / Qt-with-custom-loop projects fill in a real lifecycle_init

--- a/tests/test_runtime/test_stack_profiles.py
+++ b/tests/test_runtime/test_stack_profiles.py
@@ -1,0 +1,130 @@
+"""Tests for stack profile registry + selection logic.
+
+The profile registry is the language-decoupling layer: each profile
+declares matchers (file presence + language hint) and the integration
+probe runner picks the highest-scoring fit. We verify:
+- web_typescript wins for vite/typescript projects
+- generic cli wins for python with src/main.py
+- generic server wins when an explicit ``profile`` field is set
+- unknown profile is the fallback when nothing matches
+- explicit stack_contract.profile overrides auto-detection
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aise.runtime.stack_profiles import (
+    StackProfile,
+    all_profiles,
+    profile_by_name,
+    register_profile,
+    select_profile,
+)
+
+# -- Selection -----------------------------------------------------------
+
+
+class TestSelect:
+    def test_web_typescript_wins_for_vite(self, tmp_path: Path):
+        (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "tsconfig.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "vite.config.ts").write_text("// vite config\n", encoding="utf-8")
+        sc = {"language": "typescript"}
+        p = select_profile(tmp_path, sc)
+        assert p.name == "web_typescript"
+        assert p.runtime_kind == "web"
+
+    def test_generic_cli_wins_for_python_main(self, tmp_path: Path):
+        # No package.json → web_typescript disqualified (required file
+        # absent). Python markers present → cli profile wins.
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.py").write_text("def main(): pass\n", encoding="utf-8")
+        sc = {"language": "python", "entry_point": "src/main.py"}
+        p = select_profile(tmp_path, sc)
+        assert p.name == "cli"
+        assert p.runtime_kind == "cli"
+
+    def test_unknown_when_nothing_matches(self, tmp_path: Path):
+        # Bare directory, no language hint → falls back to unknown.
+        p = select_profile(tmp_path, None)
+        assert p.name == "unknown"
+        assert p.runtime_kind == "unknown"
+
+    def test_explicit_profile_override(self, tmp_path: Path):
+        # An architect can pin a profile via stack_contract.profile.
+        # Even if the marker files match a different profile, the
+        # override wins.
+        (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "tsconfig.json").write_text("{}", encoding="utf-8")
+        sc = {"language": "typescript", "profile": "server"}
+        p = select_profile(tmp_path, sc)
+        assert p.name == "server"
+
+    def test_unknown_override_falls_through(self, tmp_path: Path):
+        # If the override names a missing profile, we don't crash —
+        # we proceed to auto-detection.
+        (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "tsconfig.json").write_text("{}", encoding="utf-8")
+        sc = {"language": "typescript", "profile": "totally-fictional"}
+        p = select_profile(tmp_path, sc)
+        # Auto-detection picks web_typescript.
+        assert p.name == "web_typescript"
+
+
+# -- Registry housekeeping -----------------------------------------------
+
+
+class TestRegistry:
+    def test_built_in_profiles_present(self):
+        names = [p.name for p in all_profiles()]
+        for required in ("web_typescript", "cli", "server", "unknown"):
+            assert required in names, names
+
+    def test_lookup_by_name(self):
+        for name in ("web_typescript", "cli", "server", "unknown"):
+            assert profile_by_name(name) is not None
+
+    def test_register_idempotent(self):
+        # Re-register a profile by the same name → updates in-place.
+        original = profile_by_name("cli")
+        assert original is not None
+        replacement = StackProfile(
+            name="cli",
+            runtime_kind="cli",
+            boot_cmd=("echo", "replaced"),
+        )
+        register_profile(replacement)
+        try:
+            after = profile_by_name("cli")
+            assert after is not None and after.boot_cmd == ("echo", "replaced")
+        finally:
+            register_profile(original)
+        # And restoration sticks.
+        assert profile_by_name("cli") == original
+
+
+# -- Detection scoring ---------------------------------------------------
+
+
+class TestDetectionScore:
+    def test_required_file_missing_scores_zero(self, tmp_path: Path):
+        wt = profile_by_name("web_typescript")
+        assert wt is not None
+        # No package.json on disk → score = 0 even with all optional
+        # indicators and a typescript language hint.
+        (tmp_path / "tsconfig.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "vite.config.ts").write_text("\n", encoding="utf-8")
+        assert wt.detection_score(tmp_path, "typescript") == 0
+
+    def test_optional_indicators_add_score(self, tmp_path: Path):
+        wt = profile_by_name("web_typescript")
+        assert wt is not None
+        (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+        bare_score = wt.detection_score(tmp_path, None)
+        # Add optional indicators, score should rise.
+        (tmp_path / "tsconfig.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "vite.config.ts").write_text("\n", encoding="utf-8")
+        better_score = wt.detection_score(tmp_path, "typescript")
+        assert better_score > bare_score

--- a/tests/test_runtime/test_waterfall_v2_driver.py
+++ b/tests/test_runtime/test_waterfall_v2_driver.py
@@ -72,6 +72,27 @@ def _passing_produce(tmp_path: Path):
         (tmp_path / "src" / "core" / "__init__.py").write_text("# barrel\n" + "x" * 200, encoding="utf-8")
         (tmp_path / "src" / "main.py").write_text("# entry\n" + "x" * 200, encoding="utf-8")
 
+        # Phase 4 (main_entry) requires integration_report.json (added
+        # 2026-05-06 to harden assembly). Project has no
+        # data_dependency_contract / action_contract on disk, so the
+        # static gates vacuous-pass and a verdict=skipped is the
+        # natural value.
+        (docs / "integration_report.json").write_text(
+            json.dumps(
+                {
+                    "phase": "main_entry",
+                    "completed_at": "2026-05-06T00:00:00Z",
+                    "verdict": "skipped",
+                    "boot_check": {
+                        "ran": False,
+                        "verdict": "skipped",
+                        "reason": "no contracts to enforce; legacy project shape",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
         # Phase 5 fanout: write scenario tests
         (tmp_path / "tests" / "scenarios").mkdir(parents=True, exist_ok=True)
         for sid in (f"s{i}" for i in range(5)):

--- a/tests/test_runtime/test_waterfall_v2_e2e.py
+++ b/tests/test_runtime/test_waterfall_v2_e2e.py
@@ -50,7 +50,25 @@ class MockLLM:
             for path in expected:
                 p = self.project_root / path.lstrip("/")
                 p.parent.mkdir(parents=True, exist_ok=True)
-                if not p.exists():
+                # Special-case integration_report.json — the schema
+                # check + verdict gate require valid JSON, so a generic
+                # text stub would fail AUTO_GATE.
+                if p.name == "integration_report.json":
+                    p.write_text(
+                        json.dumps(
+                            {
+                                "phase": "main_entry",
+                                "verdict": "skipped",
+                                "boot_check": {
+                                    "ran": False,
+                                    "verdict": "skipped",
+                                    "reason": "mock dev: no contracts to enforce",
+                                },
+                            }
+                        ),
+                        encoding="utf-8",
+                    )
+                elif not p.exists():
                     p.write_text(f"# stub for {path}\n" + "x" * 250, encoding="utf-8")
         elif role == "qa_engineer":
             for path in expected:


### PR DESCRIPTION
## Summary

- Redefines main_entry from \"write the entry file\" to \"prove the assembly is wired\"; adds two optional architect contracts (data_dependency, action) and a developer-side integration_report
- Adds 4 new acceptance predicates and a 4-profile stack registry + best-effort runtime probe (cli/server real, web intentionally skipped)
- Catches the princess_tower regression (assets/floor_*.json never loaded; attack handler set state but never called combat) at the main_entry AUTO_GATE — verified by an e2e regression test that replays it in miniature

## Why now

Two recent e2e runs (Flutter and TypeScript princess_tower) shipped projects that compiled, passed every unit test, and produced an honest qa_report — yet the runtime game was a stub. The existing gates checked module-level correctness, not whether the modules were assembled into a working program. PR #143 fixed toolchain-honesty; this PR fills the orthogonal gap: \"modules pass + tests green ≠ assembly works\".

## What changed

**Schemas (additive; legacy projects unaffected):**
- \`data_dependency_contract.json\` — which data files MUST be consumed by which source modules
- \`action_contract.json\` — user/external triggers + \`handler_must_call\` symbols that MUST appear as call sites
- \`integration_report.json\` — main_entry self-disclosure artefact

**Predicates** (\`src/aise/runtime/predicates.py\`):
- \`data_dependency_wiring_static\` — fails when consumer_module has zero references to files_glob
- \`action_contract_wiring_static\` — fails when handler is missing any handler_must_call call site
- \`schema_optional\` — \`schema\` variant that vacuous-passes on missing file
- \`lint_integration_test_imports\` — non-blocking warn for integration tests with no source refs

**Process spec changes** (\`waterfall_v2.process.md\`):
- architecture phase: 2 new optional contract deliverables
- main_entry phase: entry_point now graded by lifecycle + data + action wiring; new \`docs/integration_report.json\` deliverable
- verification phase: lint-only fake-test warning

**Stack profile registry** (\`stack_profiles.py\`) + **runtime probe** (\`integration_probe.py\`):
- 4 built-in profiles: web_typescript / cli / server / unknown
- cli/server probes actually spawn the run_command; web=skipped (no headless browser in sandbox); static gates always run regardless

**Agent prompts:** architect.md + developer.md updated with the new responsibilities.

## Backwards compatibility

Projects without \`data_dependency_contract.json\` / \`action_contract.json\` see no behaviour change — the new predicates vacuous-pass when their driving contract is absent. The \`integration_report.json\` deliverable is new but its predicates accept \`verdict=skipped\` for legacy/CLI projects with nothing to prove. Existing test fixtures (test_waterfall_v2_driver, test_waterfall_v2_e2e) updated to write the report; regression coverage in \`test_main_entry_assembly_gate.py\` includes a \`legacy_project_without_optional_contracts\` case.

## Test plan

- [x] \`ruff check\` — passes
- [x] \`ruff format --check\` — passes (246 files)
- [x] \`pytest tests/test_runtime/\` — 772 pass / 2 skip
- [x] \`pytest tests/test_agents tests/test_core tests/test_skills tests/test_system tests/test_testing\` — 487 pass / 42 skip
- [x] Schema validation: 8 schemas parse + the 3 new ones validate against synthetic samples
- [x] **Regression test** in \`test_main_entry_assembly_gate.py\`:
  - \`test_broken_main_entry_fails_auto_gate\` — replays princess_tower TS failure: data files declared, never loaded; action handler missing must-call symbols → AUTO_GATE rejects after 3 producer retries with both violations named
  - \`test_fixed_main_entry_passes\` — same fixture, fixed main → phase passes
  - \`test_legacy_project_without_optional_contracts_passes\` — no data/action contracts → vacuous-pass

## Files changed

19 files; 2978 insertions, 22 deletions. New files:
- 3 schemas under \`src/aise/schemas/\`
- 2 runtime modules: \`stack_profiles.py\`, \`integration_probe.py\`
- 6 test files under \`tests/test_runtime/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)