### PR TITLE
feat(runtime): size max_tokens from input length to stop context overflow

### DIFF
--- a/src/aise/runtime/dynamic_llm.py
+++ b/src/aise/runtime/dynamic_llm.py
@@ -1,0 +1,156 @@
+"""Input-aware dynamic ``max_tokens`` for OpenAI-compatible chat models.
+
+AI tasks are lopsided: a short prompt often wants a long completion
+("write the whole file"), while a long prompt usually wants a short one
+("review this and reply REVISE"). Binding a single fixed ``max_tokens``
+on the client — the historical behaviour, a flat 64K floor — is wrong at
+both ends:
+
+* On long-input dispatches it **overflows the context window**. Observed
+  on project_21-calculator (2026-06-10): a developer fanout accumulated
+  ~65,537 input tokens across its ReAct loop, the client still requested
+  65,536 output tokens, and the server rejected the call —
+  ``131073 > 131072`` — with a 400. Six dispatches died this way.
+* On short-input dispatches a fixed small ceiling silently truncates.
+
+The fix is to size ``max_tokens`` from the *actual* input length on every
+call, leaving the rest of the window for output, capped at 64K.
+
+Sizing rule (``compute_dynamic_max_tokens``):
+
+    room        = context_window - input_tokens - safety_margin
+    max_tokens  = min( cap , largest power of two <= room )
+
+so ``max_tokens`` is always a power of two and ``input + max_tokens``
+never exceeds the window. ``cap`` defaults to 64K (2**16); the power-of-two
+flooring is what guarantees headroom — at worst it hands back just under
+half of ``room``, which absorbs any drift between the client tokenizer and
+the server's count.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from langchain_core.messages import BaseMessage
+from langchain_openai import ChatOpenAI
+
+# 64K — the ceiling. A reasoning model (qwen3.x) spends part of this on a
+# hidden <think> block, so the ceiling stays generous for short-input,
+# large-artifact dispatches (see runtime_config.DEFAULT_MIN_MAX_TOKENS).
+DEFAULT_MAX_TOKENS_CAP = 65536
+# Smallest budget we will ever request. A power of two so the result of
+# ``compute_dynamic_max_tokens`` is always 2**n, even on the degenerate
+# "input already fills the window" path.
+DEFAULT_MIN_FLOOR = 256
+# Reserved headroom subtracted before sizing, to cover the gap between the
+# client-side token count and the server's stricter count (the original
+# overflow was an exact off-by-one). Scales with input so it stays
+# meaningful at large prompts; see ``_safety_margin_for``.
+MIN_SAFETY_MARGIN = 1024
+
+
+def _largest_power_of_two_at_most(value: int) -> int:
+    """Largest ``2**n`` with ``2**n <= value`` (value >= 1)."""
+    return 1 << (value.bit_length() - 1)
+
+
+def compute_dynamic_max_tokens(
+    input_tokens: int,
+    context_window: int,
+    cap: int = DEFAULT_MAX_TOKENS_CAP,
+    *,
+    safety_margin: int = 0,
+    min_floor: int = DEFAULT_MIN_FLOOR,
+) -> int:
+    """Size ``max_tokens`` from the input length.
+
+    Returns ``min(cap, 2**floor(log2(room)))`` where
+    ``room = context_window - input_tokens - safety_margin``. The result is
+    always a power of two, and whenever ``room >= 1`` it satisfies
+    ``input_tokens + safety_margin + result <= context_window`` — i.e. it
+    never overflows the window. When the input alone (plus margin) already
+    fills the window there is no non-overflowing budget; we return
+    ``min_floor`` so the request carries a truthful tiny budget and the
+    server rejects it with a clear error instead of us guessing.
+    """
+    room = context_window - input_tokens - safety_margin
+    if room < 1:
+        return min_floor
+    return min(cap, _largest_power_of_two_at_most(room))
+
+
+def _safety_margin_for(input_tokens: int) -> int:
+    """Headroom reserve: at least ``MIN_SAFETY_MARGIN``, ~3% of input.
+
+    A flat reserve is too thin once the prompt is tens of thousands of
+    tokens (where the client/server tokenizer gap is largest), so it grows
+    with the input."""
+    return max(MIN_SAFETY_MARGIN, input_tokens // 32)
+
+
+class DynamicMaxTokensChatOpenAI(ChatOpenAI):
+    """``ChatOpenAI`` that recomputes ``max_tokens`` per request.
+
+    Every chat call in ``langchain_openai`` (sync/async, streaming or not)
+    funnels through ``_get_request_payload``; overriding it once covers all
+    four entry points. We measure the outgoing messages, size the budget
+    with :func:`compute_dynamic_max_tokens`, and overwrite whatever fixed
+    ceiling the payload carried (``max_completion_tokens`` after the SDK's
+    own rename of ``max_tokens``).
+    """
+
+    # Declared as pydantic fields so they survive model construction.
+    aise_context_window: int = 131072
+    aise_max_tokens_cap: int = DEFAULT_MAX_TOKENS_CAP
+
+    def _count_input_tokens(self, messages: Sequence[BaseMessage]) -> int:
+        """Token count of the outgoing messages, with a char heuristic
+        fallback if the tokenizer is unavailable for this model."""
+        try:
+            return self.get_num_tokens_from_messages(list(messages))
+        except Exception:
+            # ~4 chars/token over textual content; deliberately rough — the
+            # power-of-two flooring absorbs the imprecision.
+            chars = 0
+            for m in messages:
+                content = getattr(m, "content", "")
+                if isinstance(content, str):
+                    chars += len(content)
+                elif isinstance(content, list):
+                    for part in content:
+                        if isinstance(part, dict):
+                            chars += len(str(part.get("text", "")))
+            return chars // 4
+
+    def _resolve_dynamic_max_tokens(self, input_: Any) -> int | None:
+        """Dynamic budget for this input, or ``None`` if messages can't be
+        recovered (then the static payload value is left untouched)."""
+        try:
+            messages = self._convert_input(input_).to_messages()
+        except Exception:
+            return None
+        input_tokens = self._count_input_tokens(messages)
+        return compute_dynamic_max_tokens(
+            input_tokens,
+            self.aise_context_window,
+            self.aise_max_tokens_cap,
+            safety_margin=_safety_margin_for(input_tokens),
+        )
+
+    def _get_request_payload(
+        self,
+        input_: Any,
+        *,
+        stop: list[str] | None = None,
+        **kwargs: Any,
+    ) -> dict:
+        payload = super()._get_request_payload(input_, stop=stop, **kwargs)
+        dynamic = self._resolve_dynamic_max_tokens(input_)
+        if dynamic is not None:
+            # ChatOpenAI renamed max_tokens -> max_completion_tokens upstream;
+            # drop any stale key and set the one the API actually reads.
+            payload.pop("max_tokens", None)
+            payload["max_completion_tokens"] = dynamic
+        return payload

--- a/src/aise/runtime/llm_factory.py
+++ b/src/aise/runtime/llm_factory.py
@@ -67,15 +67,31 @@ def _is_local_base_url(base_url: str) -> bool:
 # -- Built-in providers ----------------------------------------------------
 
 
-def _build_openai(config: ModelConfig, defaults: LLMDefaults) -> BaseChatModel:
-    from langchain_openai import ChatOpenAI
+def _context_window(config: ModelConfig, defaults: LLMDefaults) -> int:
+    """Per-model context window, falling back to the provider-agnostic
+    default. Overridable via ``ModelConfig.extra["context_window"]``."""
+    raw = config.extra.get("context_window")
+    try:
+        if raw is not None:
+            return int(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        pass
+    return defaults.context_window
 
+
+def _build_openai(config: ModelConfig, defaults: LLMDefaults) -> BaseChatModel:
+    from .dynamic_llm import DynamicMaxTokensChatOpenAI
+
+    # ``effective_max_tokens`` is now the CEILING; the actual per-call budget
+    # is sized down from the input length (see dynamic_llm).
     effective_max_tokens = max(config.max_tokens, defaults.min_max_tokens)
     kwargs: dict[str, Any] = {
         "model": config.model,
         "temperature": config.temperature,
         "max_tokens": effective_max_tokens,
         "max_retries": defaults.max_retries,
+        "aise_context_window": _context_window(config, defaults),
+        "aise_max_tokens_cap": effective_max_tokens,
     }
 
     api_key = config.api_key or os.environ.get("OPENAI_API_KEY", "")
@@ -84,12 +100,12 @@ def _build_openai(config: ModelConfig, defaults: LLMDefaults) -> BaseChatModel:
     if config.base_url:
         kwargs["base_url"] = config.base_url
 
-    return ChatOpenAI(**kwargs)
+    return DynamicMaxTokensChatOpenAI(**kwargs)
 
 
 def _build_local(config: ModelConfig, defaults: LLMDefaults) -> BaseChatModel:
     """Local OpenAI-compatible endpoint (vLLM/Ollama/LM Studio/etc.)."""
-    from langchain_openai import ChatOpenAI
+    from .dynamic_llm import DynamicMaxTokensChatOpenAI
 
     effective_max_tokens = max(config.max_tokens, defaults.min_max_tokens)
     kwargs: dict[str, Any] = {
@@ -97,6 +113,8 @@ def _build_local(config: ModelConfig, defaults: LLMDefaults) -> BaseChatModel:
         "temperature": config.temperature,
         "max_tokens": effective_max_tokens,
         "max_retries": defaults.max_retries,
+        "aise_context_window": _context_window(config, defaults),
+        "aise_max_tokens_cap": effective_max_tokens,
     }
 
     api_key = config.api_key or os.environ.get("AISE_LOCAL_OPENAI_API_KEY") or "local-no-key-required"
@@ -104,7 +122,7 @@ def _build_local(config: ModelConfig, defaults: LLMDefaults) -> BaseChatModel:
     if config.base_url:
         kwargs["base_url"] = config.base_url
 
-    return ChatOpenAI(**kwargs)
+    return DynamicMaxTokensChatOpenAI(**kwargs)
 
 
 register_provider("openai", _build_openai)

--- a/src/aise/runtime/project_session.py
+++ b/src/aise/runtime/project_session.py
@@ -516,7 +516,13 @@ class ProjectSession:
             model_cfg.base_url = global_cfg.base_url
             model_cfg.extra = global_cfg.extra
 
-        llm = _factory_build_llm(model_cfg, LLMDefaults(min_max_tokens=self._config.llm.min_max_tokens))
+        llm = _factory_build_llm(
+            model_cfg,
+            LLMDefaults(
+                min_max_tokens=self._config.llm.min_max_tokens,
+                context_window=self._config.llm.context_window,
+            ),
+        )
 
         skills_dir = orchestrator_md.parent / "_runtime_skills"
         skills_dir.mkdir(exist_ok=True)
@@ -905,7 +911,13 @@ class ProjectSession:
                 model_cfg.base_url = gc.base_url
                 model_cfg.extra = gc.extra
 
-            llm = _factory_build_llm(model_cfg, LLMDefaults(min_max_tokens=self._config.llm.min_max_tokens))
+            llm = _factory_build_llm(
+                model_cfg,
+                LLMDefaults(
+                    min_max_tokens=self._config.llm.min_max_tokens,
+                    context_window=self._config.llm.context_window,
+                ),
+            )
             backend = make_policy_backend(
                 self._project_root,
                 layout=global_rt.definition.output_layout,

--- a/src/aise/runtime/runtime_config.py
+++ b/src/aise/runtime/runtime_config.py
@@ -205,6 +205,12 @@ class LLMDefaults:
 
     min_max_tokens: int = DEFAULT_MIN_MAX_TOKENS
     max_retries: int = 1
+    # Model context window (input + output). Used to size ``max_tokens``
+    # per request from the actual input length so a long prompt no longer
+    # overflows the window. Per-model overrides go through
+    # ``ModelConfig.extra["context_window"]``. Default matches the 128K
+    # window of the qwen3.x-class models this project runs.
+    context_window: int = 131072
 
 
 # -- RuntimeConfig ---------------------------------------------------------

--- a/tests/test_runtime/test_dynamic_max_tokens.py
+++ b/tests/test_runtime/test_dynamic_max_tokens.py
@@ -1,0 +1,119 @@
+"""Tests for input-aware dynamic ``max_tokens`` sizing."""
+
+from unittest.mock import patch
+
+from langchain_core.messages import HumanMessage
+
+from aise.runtime.dynamic_llm import (
+    DEFAULT_MIN_FLOOR,
+    DynamicMaxTokensChatOpenAI,
+    compute_dynamic_max_tokens,
+)
+
+
+def _is_power_of_two(n: int) -> bool:
+    return n > 0 and (n & (n - 1)) == 0
+
+
+class TestComputeDynamicMaxTokens:
+    """The sizing rule: min(cap, largest 2**n <= context - input - margin)."""
+
+    def test_long_input_short_output(self):
+        # The exact dispatch that 400'd on project_21: input 65537 in a 128K
+        # window previously paired with a fixed 65536 -> 131073 > 131072.
+        out = compute_dynamic_max_tokens(65537, 131072, 65536, safety_margin=0)
+        assert out == 32768
+        assert 65537 + out <= 131072
+
+    def test_short_input_long_output_hits_cap(self):
+        # Typical small dispatch keeps the full 64K ceiling.
+        out = compute_dynamic_max_tokens(16828, 131072, 65536, safety_margin=0)
+        assert out == 65536
+
+    def test_zero_input_capped(self):
+        # Room for 2**17 but the 64K cap binds.
+        assert compute_dynamic_max_tokens(0, 131072, 65536, safety_margin=0) == 65536
+
+    def test_result_is_always_power_of_two(self):
+        for inp in range(0, 131072, 257):
+            out = compute_dynamic_max_tokens(inp, 131072, 65536, safety_margin=0)
+            assert _is_power_of_two(out), f"{out} not a power of two (input={inp})"
+
+    def test_never_overflows_window(self):
+        # The core guarantee: input + budget never exceeds the window.
+        for inp in range(0, 131072, 137):
+            out = compute_dynamic_max_tokens(inp, 131072, 65536, safety_margin=0)
+            assert inp + out <= 131072, f"overflow at input={inp}: {inp}+{out}"
+
+    def test_rule_picks_largest_fitting_power(self):
+        # 2**n <= room < 2**(n+1) — verify the boundary picks 2**n exactly.
+        # room = 40000 -> 32768 (2**15), since 2**16=65536 > 40000.
+        out = compute_dynamic_max_tokens(131072 - 40000, 131072, 65536, safety_margin=0)
+        assert out == 32768
+
+    def test_safety_margin_reserves_headroom(self):
+        # Same input, but a margin pushes the result down a power when it
+        # straddles a boundary.
+        no_margin = compute_dynamic_max_tokens(65535, 131072, 65536, safety_margin=0)
+        with_margin = compute_dynamic_max_tokens(65535, 131072, 65536, safety_margin=2048)
+        assert no_margin == 65536
+        assert with_margin == 32768
+        assert 65535 + with_margin <= 131072
+
+    def test_input_fills_window_falls_back_to_floor(self):
+        assert compute_dynamic_max_tokens(131072, 131072, 65536) == DEFAULT_MIN_FLOOR
+        assert compute_dynamic_max_tokens(200000, 131072, 65536) == DEFAULT_MIN_FLOOR
+        assert _is_power_of_two(DEFAULT_MIN_FLOOR)
+
+    def test_custom_cap_respected(self):
+        # A smaller ceiling caps even when there is ample room.
+        assert compute_dynamic_max_tokens(1000, 131072, 8192, safety_margin=0) == 8192
+
+
+class TestDynamicMaxTokensChatOpenAI:
+    """The ChatOpenAI subclass rewrites the per-request budget."""
+
+    def _model(self, **over):
+        kwargs = dict(
+            model="qwen3.6-35b",
+            api_key="test-key",
+            max_tokens=65536,
+            aise_context_window=131072,
+            aise_max_tokens_cap=65536,
+        )
+        kwargs.update(over)
+        return DynamicMaxTokensChatOpenAI(**kwargs)
+
+    def test_payload_uses_dynamic_budget_for_long_input(self):
+        model = self._model()
+        with patch.object(DynamicMaxTokensChatOpenAI, "_count_input_tokens", return_value=65537):
+            payload = model._get_request_payload([HumanMessage(content="hi")])
+        # SDK renames max_tokens -> max_completion_tokens; the stale key is gone.
+        assert "max_tokens" not in payload
+        assert payload["max_completion_tokens"] == 32768
+
+    def test_payload_keeps_cap_for_short_input(self):
+        model = self._model()
+        with patch.object(DynamicMaxTokensChatOpenAI, "_count_input_tokens", return_value=2000):
+            payload = model._get_request_payload([HumanMessage(content="hi")])
+        assert payload["max_completion_tokens"] == 65536
+
+    def test_char_heuristic_fallback_when_tokenizer_fails(self):
+        model = self._model()
+        with patch.object(
+            DynamicMaxTokensChatOpenAI,
+            "get_num_tokens_from_messages",
+            side_effect=RuntimeError("no tokenizer"),
+        ):
+            # 4000 chars -> ~1000 tokens via the len/4 heuristic; well under
+            # the cap so the budget stays at 64K.
+            n = model._count_input_tokens([HumanMessage(content="x" * 4000)])
+        assert n == 1000
+
+    def test_respects_smaller_context_window(self):
+        model = self._model(aise_context_window=32768)
+        with patch.object(DynamicMaxTokensChatOpenAI, "_count_input_tokens", return_value=20000):
+            payload = model._get_request_payload([HumanMessage(content="hi")])
+        # room ~12768 -> 2**13 = 8192, and input + budget fits the 32K window.
+        assert payload["max_completion_tokens"] == 8192
+        assert 20000 + payload["max_completion_tokens"] <= 32768

--- a/tests/test_runtime/test_llm_factory.py
+++ b/tests/test_runtime/test_llm_factory.py
@@ -1,6 +1,6 @@
 """Tests for the provider-pluggable LLM factory."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -110,12 +110,36 @@ class TestIsLocalBaseUrl:
 
 
 class TestDefaults:
-    def test_min_max_tokens_applied_via_openai_builder(self):
+    def test_min_max_tokens_becomes_the_cap(self):
+        # ``min_max_tokens`` is the floor on the ceiling; the builder now
+        # carries it as ``aise_max_tokens_cap`` (the per-call budget is sized
+        # down from there). max(config.max_tokens=1024, floor=8000) -> 8000.
+        from aise.runtime.dynamic_llm import DynamicMaxTokensChatOpenAI
         from aise.runtime.llm_factory import _build_openai
 
         cfg = ModelConfig(provider="openai", model="gpt-4o", api_key="x", max_tokens=1024)
         defaults = LLMDefaults(min_max_tokens=8000)
-        with patch("langchain_openai.ChatOpenAI") as mock_cls:
-            _build_openai(cfg, defaults)
-            kwargs = mock_cls.call_args.kwargs
-            assert kwargs["max_tokens"] == 8000
+        llm = _build_openai(cfg, defaults)
+        assert isinstance(llm, DynamicMaxTokensChatOpenAI)
+        assert llm.aise_max_tokens_cap == 8000
+
+    def test_context_window_from_defaults(self):
+        from aise.runtime.llm_factory import _build_openai
+
+        cfg = ModelConfig(provider="openai", model="gpt-4o", api_key="x")
+        defaults = LLMDefaults(context_window=200000)
+        llm = _build_openai(cfg, defaults)
+        assert llm.aise_context_window == 200000
+
+    def test_context_window_per_model_override(self):
+        from aise.runtime.llm_factory import _build_local
+
+        cfg = ModelConfig(
+            provider="local",
+            model="qwen",
+            base_url="http://localhost:8000/v1",
+            extra={"context_window": 32768},
+        )
+        defaults = LLMDefaults(context_window=131072)
+        llm = _build_local(cfg, defaults)
+        assert llm.aise_context_window == 32768


### PR DESCRIPTION
## Problem

The LLM client bound a **single fixed `max_tokens`** (a flat 64K floor, `max(config.max_tokens, 65536)`) on every call. AI dispatches are lopsided — short prompt → long completion, or long prompt → short completion — so a fixed budget is wrong at both ends.

On long-input dispatches it **overflows the model's 128K context window**. On `project_21-calculator` (2026-06-10) a developer fanout accumulated **~65,537 input tokens** across its ReAct loop, the client still requested **65,536 output tokens**, and the server rejected the call:

```
Error 400 — maximum context length is 131072 tokens.
You requested 65536 output + 65537 input = 131073 > 131072
```

**Six dispatches died this way** (`impl:ui`, `impl:logic`, `impl:storage`, and fanout retries), stalling the run.

## Fix

Size the per-request budget from the **actual input length**:

```
room       = context_window - input_tokens - safety_margin
max_tokens = min( 64K , largest power of two <= room )
```

- `max_tokens` is always a power of two, and `input + budget` never exceeds the window.
- Short inputs keep the full 64K ceiling; long inputs scale down (e.g. **65,537 in → 32,768 out**, which fits at 98,305 ≤ 131,072).
- Power-of-two flooring leaves generous headroom that absorbs client/server tokenizer drift; a small input-scaled `safety_margin` guards the boundary.

## Changes

| File | Change |
|------|--------|
| `runtime/dynamic_llm.py` *(new)* | `compute_dynamic_max_tokens()` (pure, tested against the rule) + `DynamicMaxTokensChatOpenAI`, which recomputes the budget in `_get_request_payload` — the single chokepoint all of sync/async/streaming funnel through. Char-heuristic fallback if the tokenizer is unavailable. |
| `runtime/llm_factory.py` | Build the dynamic subclass; `effective_max_tokens` is now the **ceiling** (`aise_max_tokens_cap`). `context_window` resolved per-model (`ModelConfig.extra["context_window"]`) or from defaults. |
| `runtime/runtime_config.py` | `LLMDefaults.context_window` (default `131072`). |
| `runtime/project_session.py` | Thread `context_window` through both LLM build sites (the deep-agent path). |
| `tests/test_runtime/test_dynamic_max_tokens.py` *(new)* | Rule correctness, power-of-two + no-overflow invariants, the exact project_21 overflow case, payload injection, tokenizer fallback, per-model window override. |
| `tests/test_runtime/test_llm_factory.py` | Updated for the cap/window wiring. |

## Tests

```
tests/test_runtime/  ->  796 passed, 2 skipped, 1 pre-existing failure
```

The one failure (`test_write_rejects_absolute_non_project_path`) is **pre-existing on `main`** and unrelated — it depends on where `aise` is installed vs the tmp project root, and touches none of the files in this PR. `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)