### PR TITLE
fix(web): add missing CSS for the project file browser

### DIFF
--- a/src/aise/web/static/main.css
+++ b/src/aise/web/static/main.css
@@ -3563,3 +3563,104 @@ button.flow-composite-card:hover,
   color: var(--muted);
   font-size: 0.78rem;
 }
+
+/* ── Project file browser ── */
+.file-browser {
+  padding: 0;
+  overflow: hidden;
+}
+.file-browser-grid {
+  display: grid;
+  grid-template-columns: minmax(220px, 320px) 1fr;
+  min-height: 320px;
+  max-height: 70vh;
+}
+.file-tree-pane {
+  border-right: 1px solid var(--line);
+  background: var(--surface-soft);
+  overflow: auto;
+  padding: 8px 0;
+}
+.file-tree-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 12px;
+  font-size: 13px;
+  color: var(--text);
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+.file-tree-row:hover {
+  background: var(--surface-hover);
+}
+.file-tree-row.active {
+  background: var(--primary-light);
+  color: var(--primary-hover);
+}
+.file-tree-icon {
+  flex: 0 0 auto;
+}
+.file-tree-name {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+/* margin-left:auto pushes the size to the right edge so it never abuts the
+   file name (the unstyled markup rendered them as "formatter.py2.2 KB"). */
+.file-tree-size {
+  flex: 0 0 auto;
+  margin-left: auto;
+  padding-left: 12px;
+  font-size: 11px;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+.file-preview-pane {
+  overflow: auto;
+  max-height: 70vh;
+}
+.file-preview-inner {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+.file-preview-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
+  position: sticky;
+  top: 0;
+}
+.file-preview-head code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+  word-break: break-all;
+}
+.file-preview-content {
+  margin: 0;
+  padding: 16px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--text);
+  white-space: pre;
+  overflow-x: auto;
+}
+@media (max-width: 720px) {
+  .file-browser-grid {
+    grid-template-columns: 1fr;
+    max-height: none;
+  }
+  .file-tree-pane {
+    border-right: none;
+    border-bottom: 1px solid var(--line);
+    max-height: 280px;
+  }
+}


### PR DESCRIPTION
## Problem

The project file browser renders the file **name and size with no separation** — `formatter.py2.2 KB`, `reader.py1.5 KB`, and in the preview header `src/cli/formatter.py2.2 KB`.

## Cause

PR #150 shipped the file browser's markup, JS, backend route, and i18n — but **never added the stylesheet**. `grep file-tree|file-browser|file-preview src/aise/web/static/main.css` → **0 matches**. So every class (`.file-tree-row`, `.file-tree-name`, `.file-tree-size`, `.file-browser-grid`, `.file-preview-*`) fell back to unstyled inline `<span>`s: name and size concatenated, and the two-pane tree/preview layout never applied.

## Fix

Add the rules, built on the existing CSS design tokens (`--surface`, `--line`, `--muted`, `--font-mono`, …) so light/dark themes both work:

- `.file-browser-grid` — two-column `tree | preview` grid; stacks vertically under 720px.
- `.file-tree-row` — flex row with `gap`; **`.file-tree-size { margin-left: auto }`** pushes the size to the right edge so it never abuts the name (the reported bug).
- `.file-preview-head` — `justify-content: space-between` (path ↔ size), sticky header.
- `.file-preview-content` — monospace, preserved whitespace, horizontal scroll.

## Verification

- All 12 classes used by the `FileBrowser` markup are now present in `main.css` (cross-checked against `app.js`).
- CSS braces balanced; no duplicate/conflicting selectors (the names were previously absent).

CSS-only change; no JS/Python touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)