### PR TITLE
fix(runtime): calibrate client token count to the server tokenizer

### DIFF
--- a/src/aise/runtime/dynamic_llm.py
+++ b/src/aise/runtime/dynamic_llm.py
@@ -49,6 +49,11 @@ DEFAULT_MIN_FLOOR = 256
 # overflow was an exact off-by-one). Scales with input so it stays
 # meaningful at large prompts; see ``_safety_margin_for``.
 MIN_SAFETY_MARGIN = 1024
+# Multiplier applied to the client token estimate to match the server's
+# tokenizer, which counts more tokens for the same text (measured ~1.6x for
+# qwen3.x vs tiktoken cl100k near the overflow boundary). See the field doc
+# on ``DynamicMaxTokensChatOpenAI.aise_token_estimate_factor``.
+DEFAULT_TOKEN_ESTIMATE_FACTOR = 2.0
 
 
 def _largest_power_of_two_at_most(value: int) -> int:
@@ -104,6 +109,17 @@ class DynamicMaxTokensChatOpenAI(ChatOpenAI):
     # Declared as pydantic fields so they survive model construction.
     aise_context_window: int = 131072
     aise_max_tokens_cap: int = DEFAULT_MAX_TOKENS_CAP
+    # Calibration: the client tokenizer (tiktoken cl100k) systematically
+    # UNDER-counts relative to the server's tokenizer. Measured on a qwen3.6
+    # dispatch (project_21, 2026-06-10): the server reported 1.39–2.8x the
+    # tiktoken count, ~1.56–1.61x in the boundary region (input 50–65K) where
+    # overflow actually happens. Without correction the sizing thinks there
+    # is ample room and keeps handing out the full 64K cap, so a long prompt
+    # still 400s. We inflate the counted input by this factor before sizing;
+    # 2.0 covers the boundary drift with headroom. Over-inflation only costs
+    # output budget on large inputs (where a smaller completion is fine),
+    # never correctness.
+    aise_token_estimate_factor: float = DEFAULT_TOKEN_ESTIMATE_FACTOR
 
     def _count_input_tokens(self, messages: Sequence[BaseMessage]) -> int:
         """Token count of the outgoing messages, with a char heuristic
@@ -131,12 +147,15 @@ class DynamicMaxTokensChatOpenAI(ChatOpenAI):
             messages = self._convert_input(input_).to_messages()
         except Exception:
             return None
-        input_tokens = self._count_input_tokens(messages)
+        # Inflate the (under-counted) client estimate to the server's scale
+        # before sizing — see ``aise_token_estimate_factor``.
+        counted = self._count_input_tokens(messages)
+        effective = int(counted * max(1.0, self.aise_token_estimate_factor))
         return compute_dynamic_max_tokens(
-            input_tokens,
+            effective,
             self.aise_context_window,
             self.aise_max_tokens_cap,
-            safety_margin=_safety_margin_for(input_tokens),
+            safety_margin=_safety_margin_for(effective),
         )
 
     def _get_request_payload(

--- a/src/aise/runtime/llm_factory.py
+++ b/src/aise/runtime/llm_factory.py
@@ -79,6 +79,18 @@ def _context_window(config: ModelConfig, defaults: LLMDefaults) -> int:
     return defaults.context_window
 
 
+def _token_estimate_factor(config: ModelConfig, defaults: LLMDefaults) -> float:
+    """Per-model client→server tokenizer calibration factor, falling back to
+    the default. Overridable via ``ModelConfig.extra["token_estimate_factor"]``."""
+    raw = config.extra.get("token_estimate_factor")
+    try:
+        if raw is not None:
+            return float(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        pass
+    return defaults.token_estimate_factor
+
+
 def _build_openai(config: ModelConfig, defaults: LLMDefaults) -> BaseChatModel:
     from .dynamic_llm import DynamicMaxTokensChatOpenAI
 
@@ -92,6 +104,7 @@ def _build_openai(config: ModelConfig, defaults: LLMDefaults) -> BaseChatModel:
         "max_retries": defaults.max_retries,
         "aise_context_window": _context_window(config, defaults),
         "aise_max_tokens_cap": effective_max_tokens,
+        "aise_token_estimate_factor": _token_estimate_factor(config, defaults),
     }
 
     api_key = config.api_key or os.environ.get("OPENAI_API_KEY", "")
@@ -115,6 +128,7 @@ def _build_local(config: ModelConfig, defaults: LLMDefaults) -> BaseChatModel:
         "max_retries": defaults.max_retries,
         "aise_context_window": _context_window(config, defaults),
         "aise_max_tokens_cap": effective_max_tokens,
+        "aise_token_estimate_factor": _token_estimate_factor(config, defaults),
     }
 
     api_key = config.api_key or os.environ.get("AISE_LOCAL_OPENAI_API_KEY") or "local-no-key-required"

--- a/src/aise/runtime/project_session.py
+++ b/src/aise/runtime/project_session.py
@@ -521,6 +521,7 @@ class ProjectSession:
             LLMDefaults(
                 min_max_tokens=self._config.llm.min_max_tokens,
                 context_window=self._config.llm.context_window,
+                token_estimate_factor=self._config.llm.token_estimate_factor,
             ),
         )
 

--- a/src/aise/runtime/runtime_config.py
+++ b/src/aise/runtime/runtime_config.py
@@ -211,6 +211,11 @@ class LLMDefaults:
     # ``ModelConfig.extra["context_window"]``. Default matches the 128K
     # window of the qwen3.x-class models this project runs.
     context_window: int = 131072
+    # Multiplier applied to the client-side token estimate to match the
+    # server tokenizer (which counts more tokens for the same text). Without
+    # it, dynamic max_tokens under-counts the input and still overflows.
+    # Per-model overrides go through ``ModelConfig.extra["token_estimate_factor"]``.
+    token_estimate_factor: float = 2.0
 
 
 # -- RuntimeConfig ---------------------------------------------------------

--- a/tests/test_runtime/test_dynamic_max_tokens.py
+++ b/tests/test_runtime/test_dynamic_max_tokens.py
@@ -80,6 +80,9 @@ class TestDynamicMaxTokensChatOpenAI:
             max_tokens=65536,
             aise_context_window=131072,
             aise_max_tokens_cap=65536,
+            # factor 1.0 so these tests exercise the sizing math directly on
+            # the patched count; the calibration factor has its own tests.
+            aise_token_estimate_factor=1.0,
         )
         kwargs.update(over)
         return DynamicMaxTokensChatOpenAI(**kwargs)
@@ -117,3 +120,52 @@ class TestDynamicMaxTokensChatOpenAI:
         # room ~12768 -> 2**13 = 8192, and input + budget fits the 32K window.
         assert payload["max_completion_tokens"] == 8192
         assert 20000 + payload["max_completion_tokens"] <= 32768
+
+
+class TestTokenEstimateFactor:
+    """The calibration factor inflates the under-counted client estimate so a
+    long prompt no longer overflows the server's stricter tokenizer."""
+
+    def _model(self, factor, **over):
+        kwargs = dict(
+            model="qwen3.6-35b",
+            api_key="test-key",
+            max_tokens=65536,
+            aise_context_window=131072,
+            aise_max_tokens_cap=65536,
+            aise_token_estimate_factor=factor,
+        )
+        kwargs.update(over)
+        return DynamicMaxTokensChatOpenAI(**kwargs)
+
+    def test_regression_factor_prevents_overflow(self):
+        # The exact project_21 regression: the client (tiktoken) counted
+        # ~41.5K for an input the server saw as ~65.5K. With factor 1.0 the
+        # sizing wrongly hands out the full cap; with the 2.0 default it
+        # scales the budget down so input + budget fits the real window.
+        client_count = 41500
+        real_server_input = 65537
+        with patch.object(DynamicMaxTokensChatOpenAI, "_count_input_tokens", return_value=client_count):
+            naive = self._model(1.0)._get_request_payload([HumanMessage(content="hi")])
+            calibrated = self._model(2.0)._get_request_payload([HumanMessage(content="hi")])
+        assert naive["max_completion_tokens"] == 65536  # the bug: overflows
+        assert real_server_input + naive["max_completion_tokens"] > 131072
+        assert calibrated["max_completion_tokens"] == 32768  # fixed
+        assert real_server_input + calibrated["max_completion_tokens"] <= 131072
+
+    def test_factor_leaves_short_inputs_at_cap(self):
+        # Even inflated, a small input has ample room -> still the full cap.
+        with patch.object(DynamicMaxTokensChatOpenAI, "_count_input_tokens", return_value=5000):
+            payload = self._model(2.0)._get_request_payload([HumanMessage(content="hi")])
+        assert payload["max_completion_tokens"] == 65536
+
+    def test_factor_below_one_is_ignored(self):
+        # A misconfigured factor < 1 must not shrink the input below reality.
+        with patch.object(DynamicMaxTokensChatOpenAI, "_count_input_tokens", return_value=40000):
+            payload = self._model(0.5)._get_request_payload([HumanMessage(content="hi")])
+        # Clamped to 1.0: effective 40000 -> room ~89.7K -> capped at 64K.
+        assert payload["max_completion_tokens"] == 65536
+
+    def test_default_factor_is_two(self):
+        model = DynamicMaxTokensChatOpenAI(model="qwen3.6-35b", api_key="test-key")
+        assert model.aise_token_estimate_factor == 2.0

--- a/tests/test_runtime/test_llm_factory.py
+++ b/tests/test_runtime/test_llm_factory.py
@@ -143,3 +143,19 @@ class TestDefaults:
         defaults = LLMDefaults(context_window=131072)
         llm = _build_local(cfg, defaults)
         assert llm.aise_context_window == 32768
+
+    def test_token_estimate_factor_from_defaults(self):
+        from aise.runtime.llm_factory import _build_openai
+
+        cfg = ModelConfig(provider="openai", model="gpt-4o", api_key="x")
+        defaults = LLMDefaults(token_estimate_factor=1.7)
+        llm = _build_openai(cfg, defaults)
+        assert llm.aise_token_estimate_factor == 1.7
+
+    def test_token_estimate_factor_per_model_override(self):
+        from aise.runtime.llm_factory import _build_openai
+
+        cfg = ModelConfig(provider="openai", model="x", api_key="x", extra={"token_estimate_factor": 2.5})
+        defaults = LLMDefaults(token_estimate_factor=2.0)
+        llm = _build_openai(cfg, defaults)
+        assert llm.aise_token_estimate_factor == 2.5


### PR DESCRIPTION
## The regression

After #151 (dynamic max_tokens) + #152 (read dedup) shipped and the server was restarted on the new code, `project_21` overflowed **again** — same signature:

```
Error 400 — maximum context length is 131072.
requested 65536 output + 65537 input = 131073 > 131072
```

So the dynamic sizer **still requested the full 65536 cap** on a near-full prompt.

## Root cause

The client tokenizer (**tiktoken cl100k**) systematically **under-counts** vs the server's **qwen** tokenizer. Measured on the actual failing trace:

| call | server `prompt_tokens` | tiktoken | ratio |
|------|------|------|------|
| #20 | 51,503 | 32,239 | 1.60 |
| #30 | 59,616 | 37,060 | 1.61 |
| #40 | 64,538 | 41,297 | **1.56** |

Across the run: ratio **1.39–2.8×**, ~**1.6×** in the boundary region where overflow happens. #151 sized `max_tokens` from the tiktoken count, so it thought only ~41K of the 128K window was used, saw plenty of room, and kept handing out the 64K cap — which the server then rejected. The fix was real but **neutralized by the count gap**; the 2K safety margin couldn't cover a ~56% under-count.

`#152` compaction *was* running (40 stub markers in the trace) — this run just had few duplicate reads, so unique content still accumulated to ~64K. Compaction is a mitigation, not a hard cap; the real guarantee has to come from sizing.

## Fix

Inflate the counted input by a calibration factor before sizing — `aise_token_estimate_factor`, **default 2.0** (covers the ~1.6× boundary drift with headroom). Over-inflation only trims the completion budget on large inputs (where a short completion is fine); it never risks overflow.

```
effective_input = client_count × factor      # clamped to ≥1.0
max_tokens      = min(64K, largest 2^n ≤ window − effective_input − margin)
```

## Validation on the real failing trace

Replaying **all 41 calls** of the dispatch that crashed, through the sizer with factor 2.0:

```
worst-case (server_input + computed_budget) = 110,879  ≤ 131,072   ✅ no call overflows
```

vs the `131,073` that actually crashed.

## Changes

| File | Change |
|------|--------|
| `runtime/dynamic_llm.py` | `aise_token_estimate_factor` field + `DEFAULT_TOKEN_ESTIMATE_FACTOR=2.0`; multiply the count (clamped ≥1.0) before `compute_dynamic_max_tokens` (the pure rule is unchanged). |
| `runtime/runtime_config.py` | `LLMDefaults.token_estimate_factor` (default 2.0). |
| `runtime/llm_factory.py` | Wire it in; overridable via `ModelConfig.extra["token_estimate_factor"]`. |
| `runtime/project_session.py` | Thread through both LLM build sites. |
| tests | Regression case (naive overflows / calibrated fits), short-input cap, factor<1 clamp, default 2.0, factory wiring + per-model override. |

## Tests

```
tests/test_runtime/  ->  813 passed, 2 skipped, 1 pre-existing unrelated failure
```

(`test_write_rejects_absolute_non_project_path` fails on `main` too — unrelated.) `ruff check` + `format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)