### PR TITLE
fix(runtime): honor start_phase_idx on waterfall_v2 retry resume

### DIFF
--- a/src/aise/runtime/project_session.py
+++ b/src/aise/runtime/project_session.py
@@ -390,6 +390,12 @@ class ProjectSession:
             project_root=self._project_root,
             produce_fn=produce_fn,
             dispatch_reviewer=reviewer_dispatch,
+            # Resume point for web retries: when the prior run failed
+            # without writing a HALTED.json (crash, non-gate failure,
+            # manual stop), the driver falls back to this index instead
+            # of restarting from phase 0. A halt file, if present, still
+            # wins inside the driver.
+            start_phase_idx=self._start_phase_idx,
             # Forward phase_plan / phase_start / phase_complete events
             # through the project's ToolContext so the web UI's phase
             # stepper renders correctly. The wrapper also captures the

--- a/src/aise/runtime/waterfall_v2_driver.py
+++ b/src/aise/runtime/waterfall_v2_driver.py
@@ -107,6 +107,15 @@ class WaterfallV2Driver:
     contracts_loader: Callable[[Path], dict[str, Any]] | None = None
     spec_path: Path | None = None
     spec: WaterfallV2Spec | None = None  # injectable for tests
+    # Zero-based phase index to resume at when no ``HALTED.json`` is
+    # present. The orchestrator (web retry) computes this from the prior
+    # run's ``failed_phase_idx`` and passes it through ProjectSession.
+    # A persisted halt file always takes priority (it also carries
+    # producer-attempt bookkeeping); this is the fallback for failures
+    # that never wrote a halt file (crashes, non-gate failures, manual
+    # stops). Earlier phases are treated as already completed — their
+    # on-disk artifacts (contracts, code) survive from the prior run.
+    start_phase_idx: int = 0
     # Optional event sink so the web UI / monitor can render the phase
     # stepper. The legacy v1 ``ProjectSession.run()`` emits ``phase_plan``
     # at start and ``phase_start`` / ``phase_complete`` per phase; the
@@ -143,6 +152,20 @@ class WaterfallV2Driver:
                 completed = existing.completed_phases
                 start_phase_idx = self.spec.phase_index(existing.halted_at_phase) or 0
                 clear_halt_state(self.project_root)
+        elif self.start_phase_idx > 0:
+            # No halt file, but the orchestrator asked to resume at a
+            # specific phase (web retry from ``failed_phase_idx``). Honor
+            # it so retries don't silently restart from phase 0 when the
+            # prior failure never wrote a HALTED.json.
+            start_phase_idx = min(self.start_phase_idx, len(self.spec.phases))
+            phases_to_run = self.spec.phases[start_phase_idx:]
+            completed = tuple(p.id for p in self.spec.phases[:start_phase_idx])
+            logger.info(
+                "Resuming at phase index %d (%d already completed) via "
+                "orchestrator start_phase_idx; no halt file present",
+                start_phase_idx,
+                len(completed),
+            )
         else:
             phases_to_run = self.spec.phases
             completed = ()

--- a/src/aise/web/app.py
+++ b/src/aise/web/app.py
@@ -1006,11 +1006,19 @@ class WebProjectService:
                         run.failed_phase_idx = -1
                     run.failed_phase_name = str(event.get("phase_name", ""))
                 elif event_type == "phase_complete":
-                    # Phase cleared — if the next phase_start arrives we'll
-                    # overwrite these; if the session ends cleanly, the
-                    # final status=completed branch resets them anyway.
-                    run.failed_phase_idx = -1
-                    run.failed_phase_name = ""
+                    # Only a *successful* phase clears the failure marker.
+                    # waterfall_v2 emits ``phase_status: "failed"`` when a
+                    # phase halts; preserve failed_phase_idx in that case so
+                    # a retry resumes here instead of restarting from phase 0.
+                    # (Phases with no status are treated as success — the v1
+                    # waterfall loop only emits phase_complete after a phase
+                    # runs to the end.) A following phase_start overwrites
+                    # this; a clean session-end resets it in the completed
+                    # branch.
+                    phase_status = str(event.get("phase_status", "") or "")
+                    if phase_status not in ("failed", "halted"):
+                        run.failed_phase_idx = -1
+                        run.failed_phase_name = ""
                 elif event_type == "token_usage":
                     try:
                         run.total_input_tokens += int(event.get("input_tokens") or 0)

--- a/tests/test_runtime/test_waterfall_v2_driver.py
+++ b/tests/test_runtime/test_waterfall_v2_driver.py
@@ -224,6 +224,95 @@ class TestHaltAndResume:
         assert "requirements" not in called_phases
         assert "architecture" not in called_phases
 
+    def test_resume_via_start_phase_idx_without_halt_file(self, tmp_path: Path):
+        """Web-retry path: the prior run failed WITHOUT writing a
+        HALTED.json (crash / non-gate failure / manual stop), so resume
+        relies on ``start_phase_idx`` (computed from failed_phase_idx).
+        Earlier phases must be skipped, not re-run from phase 0.
+
+        Regression for project_21: retrying a run that halted at
+        verification restarted the whole pipeline from requirements.
+        """
+        assert not is_halted(tmp_path)  # no halt file — the whole point
+
+        # Stage the artifacts the earlier phases produced last time.
+        prod = _passing_produce(tmp_path)
+        prod("dev", "", ())
+
+        called_phases: list[str] = []
+
+        def tracking_produce(role, prompt, expected):
+            for e in expected:
+                if "main.py" in e:
+                    called_phases.append("main_entry")
+                elif "tests/scenarios" in e:
+                    called_phases.append("verification")
+                elif "delivery_report" in e:
+                    called_phases.append("delivery")
+                break
+            return "ok"
+
+        # verification is phase index 4 (requirements, architecture,
+        # implementation, main_entry, verification, delivery).
+        driver = WaterfallV2Driver(
+            project_root=tmp_path,
+            produce_fn=tracking_produce,
+            dispatch_reviewer=lambda role, prompt: "PASS",
+            start_phase_idx=4,
+        )
+        result = driver.run("x")
+
+        # Phases before the resume point were skipped, not re-executed.
+        assert "requirements" not in called_phases
+        assert "architecture" not in called_phases
+        assert "main_entry" not in called_phases  # phase 3 < 4
+        # The resumed phase actually ran.
+        assert "verification" in called_phases
+        # Skipped phases are reported as already completed.
+        assert result.completed_phases[:4] == (
+            "requirements",
+            "architecture",
+            "implementation",
+            "main_entry",
+        )
+
+    def test_halt_file_takes_priority_over_start_phase_idx(self, tmp_path: Path):
+        """When both a HALTED.json and ``start_phase_idx`` are present,
+        the halt file wins (it carries producer-attempt bookkeeping)."""
+        from aise.runtime.halt_resume import HaltState
+
+        save_halt_state(
+            tmp_path,
+            HaltState(
+                halted_at_phase="main_entry",  # index 3
+                halt_reason="prior_failure",
+                completed_phases=("requirements", "architecture", "implementation"),
+            ),
+        )
+        prod = _passing_produce(tmp_path)
+        prod("dev", "", ())
+
+        called_phases: list[str] = []
+
+        def tracking_produce(role, prompt, expected):
+            for e in expected:
+                if "main.py" in e:
+                    called_phases.append("main_entry")
+                break
+            return "ok"
+
+        driver = WaterfallV2Driver(
+            project_root=tmp_path,
+            produce_fn=tracking_produce,
+            dispatch_reviewer=lambda role, prompt: "PASS",
+            start_phase_idx=5,  # would skip main_entry — but halt wins
+        )
+        driver.run("x")
+        assert not is_halted(tmp_path)
+        # Halt file resumed at main_entry (3), so it ran despite
+        # start_phase_idx=5 asking to skip it.
+        assert "main_entry" in called_phases
+
     def test_failed_resume_leaves_new_halt(self, tmp_path: Path):
         """If a resumed phase fails, halt state is re-saved (NOT
         regressing back to phase 1). This test exercises the path:


### PR DESCRIPTION
## Problem

Retrying a failed **waterfall_v2** run restarts the pipeline from phase 0 instead of resuming at the failed phase. Observed on `project_21` (failed at `verification`/phase 4; retry re-ran from `requirements`).

## Root cause

Two independent resume mechanisms that aren't wired together:

- **Web layer** correctly computes `start_phase_idx` from the failed run's `failed_phase_idx` and passes it to `ProjectSession`.
- **v2 driver** resumes *only* from the `runs/HALTED.json` side-channel, which is written **only** on a producer acceptance-gate exhaustion (`PhaseStatus.FAILED`).

For any other failure (crash, non-gate failure, manual stop) no `HALTED.json` is written. And `_run_waterfall_v2` never forwarded `start_phase_idx` to the driver (`driver.run()` ignored it), so the driver fell back to phase 0.

## Fix

- `WaterfallV2Driver` gains a `start_phase_idx` field; `run()` falls back to it when no halt file is present, skipping already-completed phases (their on-disk artifacts persist from the prior run). A halt file still takes priority.
- `ProjectSession._run_waterfall_v2` forwards `self._start_phase_idx` to the driver.
- The web `phase_complete` handler no longer clears `failed_phase_idx` when the phase reports `phase_status` `"failed"`/`"halted"`, so the retry pointer survives a clean gate failure too.

## Tests

- New: `test_resume_via_start_phase_idx_without_halt_file`, `test_halt_file_takes_priority_over_start_phase_idx`.
- `test_waterfall_v2_driver.py` 8 passed; related runtime suites (project_session / integration / e2e / halt_resume) 80 passed.
- The 6 failing `tests/test_web/test_app.py` tests are pre-existing (identical on `main`) and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)